### PR TITLE
Update pipeline interface: prepare() should accept any params

### DIFF
--- a/lib/frame_processor.py
+++ b/lib/frame_processor.py
@@ -232,10 +232,10 @@ class FrameProcessor:
         # Get the current pipeline using sync wrapper
         pipeline = self.pipeline_manager.get_pipeline()
 
-        prompts = self.parameters.get("prompts", None)
-
         # prepare() will handle any required preparation based on parameters internally
-        requirements = pipeline.prepare(prompts, should_prepare=not self.is_prepared)
+        requirements = pipeline.prepare(
+            should_prepare=not self.is_prepared, **self.parameters
+        )
         self.is_prepared = True
         input = None
 

--- a/pipelines/interface.py
+++ b/pipelines/interface.py
@@ -16,9 +16,7 @@ class Pipeline(ABC):
     """Abstract base class for all pipelines."""
 
     @abstractmethod
-    def prepare(
-        self, prompts: list[str] | None = None, should_prepare: bool = False
-    ) -> Requirements | None:
+    def prepare(self, should_prepare: bool = False, **kwargs) -> Requirements | None:
         """Prepare the pipeline and get requirements for the next processing chunk."""
         pass
 

--- a/pipelines/longlive/pipeline.py
+++ b/pipelines/longlive/pipeline.py
@@ -65,13 +65,12 @@ class LongLivePipeline(Pipeline):
 
         self.prompts = None
 
-    def prepare(
-        self, prompts: list[str] = None, should_prepare: bool = False
-    ) -> Requirements | None:
+    def prepare(self, should_prepare: bool = False, **kwargs) -> Requirements | None:
         # If caller requested prepare assume cache init
         # Otherwise no cache init
         init_cache = should_prepare
 
+        prompts = kwargs.get("prompts", None)
         if prompts is not None and prompts != self.prompts:
             self.prompts = prompts
             should_prepare = True

--- a/pipelines/longlive/test.py
+++ b/pipelines/longlive/test.py
@@ -42,7 +42,7 @@ outputs = []
 for i, prompt in enumerate(prompts):
     should_prepare = i == 0
 
-    pipeline.prepare([prompt], should_prepare=should_prepare)
+    pipeline.prepare(prompts=[prompt], should_prepare=should_prepare)
 
     num_frames = 0
     max_output_frames = 81

--- a/pipelines/passthrough/pipeline.py
+++ b/pipelines/passthrough/pipeline.py
@@ -21,9 +21,7 @@ class PassthroughPipeline(Pipeline):
         self.dtype = dtype
         self.prompts = None
 
-    def prepare(
-        self, prompts: list[str] = None, should_prepare: bool = False
-    ) -> Requirements:
+    def prepare(self, should_prepare: bool = False, **kwargs) -> Requirements:
         return Requirements(input_size=4)
 
     def __call__(

--- a/pipelines/streamdiffusionv2/pipeline.py
+++ b/pipelines/streamdiffusionv2/pipeline.py
@@ -69,12 +69,11 @@ class StreamDiffusionV2Pipeline(Pipeline):
         self.current_start = 0
         self.current_end = self.stream.frame_seq_length * 2
 
-    def prepare(
-        self, prompts: list[str] = None, should_prepare: bool = False
-    ) -> Requirements:
+    def prepare(self, should_prepare: bool = False, **kwargs) -> Requirements:
         if should_prepare:
             logger.info("Initiating pipeline prepare for request")
 
+        prompts = kwargs.get("prompts", None)
         if prompts is not None and prompts != self.prompts:
             logger.info("Initiating pipeline prepare for prompt update")
             should_prepare = True

--- a/pipelines/streamdiffusionv2/test.py
+++ b/pipelines/streamdiffusionv2/test.py
@@ -32,7 +32,7 @@ pipeline = StreamDiffusionV2Pipeline(
     device=torch.device("cuda"),
     dtype=torch.bfloat16,
 )
-pipeline.prepare(["a bear is walking on the grass"])
+pipeline.prepare(prompts=["a bear is walking on the grass"])
 
 # input_video is a 1CTHW tensor
 input_video = (

--- a/pipelines/vod/pipeline.py
+++ b/pipelines/vod/pipeline.py
@@ -56,9 +56,7 @@ class VodPipeline(Pipeline):
                 f"Error loading video {self.video_path}: {e}. Using gray frames as fallback."
             )
 
-    def prepare(
-        self, prompts: list[str] = None, should_prepare: bool = False
-    ) -> Requirements | None:
+    def prepare(self, should_prepare: bool = False, **kwargs) -> Requirements | None:
         return None
 
     def __call__(


### PR DESCRIPTION
Make `pipeline.prepare()` interface more flexible to accept any parameters.