### PR TITLE
Add tooltips for all params in SettingsPanel

### DIFF
--- a/frontend/src/components/DenoisingStepsSlider.tsx
+++ b/frontend/src/components/DenoisingStepsSlider.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "./ui/button";
 import { SliderWithInput } from "./ui/slider-with-input";
+import { LabelWithTooltip } from "./ui/label-with-tooltip";
 import { Plus, Minus } from "lucide-react";
 
 interface DenoisingStepsSliderProps {
@@ -9,6 +10,7 @@ interface DenoisingStepsSliderProps {
   onChange: (value: number[]) => void;
   disabled?: boolean;
   defaultValues?: number[];
+  tooltip?: string;
 }
 
 const MIN_SLIDERS = 1;
@@ -23,6 +25,7 @@ export function DenoisingStepsSlider({
   onChange,
   disabled = false,
   defaultValues = DEFAULT_VALUES,
+  tooltip,
 }: DenoisingStepsSliderProps) {
   const [localValue, setLocalValue] = useState<number[]>(
     value.length > 0 ? value : defaultValues
@@ -130,7 +133,11 @@ export function DenoisingStepsSlider({
   return (
     <div className={`space-y-2 ${className}`}>
       <div className="flex items-center justify-between">
-        <label className="text-sm text-foreground">Denoising Step List</label>
+        <LabelWithTooltip
+          label="Denoising Step List"
+          tooltip={tooltip}
+          className="text-sm text-foreground"
+        />
         <div className="flex items-center gap-2">
           <Button
             variant="outline"

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -14,12 +14,14 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "./ui/tooltip";
+import { LabelWithTooltip } from "./ui/label-with-tooltip";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
 import { Toggle } from "./ui/toggle";
 import { SliderWithInput } from "./ui/slider-with-input";
 import { Hammer, Info, Minus, Plus, RotateCcw } from "lucide-react";
 import { PIPELINES } from "../data/pipelines";
+import { PARAMETER_METADATA } from "../data/parameterMetadata";
 import { DenoisingStepsSlider } from "./DenoisingStepsSlider";
 import { getDefaultDenoisingSteps } from "../lib/utils";
 import type { PipelineId } from "../types";
@@ -246,9 +248,11 @@ export function SettingsPanel({
 
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-foreground w-14">
-                    Height:
-                  </label>
+                  <LabelWithTooltip
+                    label={PARAMETER_METADATA.height.label}
+                    tooltip={PARAMETER_METADATA.height.tooltip}
+                    className="text-sm text-foreground w-14"
+                  />
                   <div className="flex-1 flex items-center border rounded-full overflow-hidden h-8">
                     <Button
                       variant="ghost"
@@ -291,7 +295,11 @@ export function SettingsPanel({
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-foreground w-14">Width:</label>
+                  <LabelWithTooltip
+                    label={PARAMETER_METADATA.width.label}
+                    tooltip={PARAMETER_METADATA.width.tooltip}
+                    className="text-sm text-foreground w-14"
+                  />
                   <div className="flex-1 flex items-center border rounded-full overflow-hidden h-8">
                     <Button
                       variant="ghost"
@@ -334,7 +342,11 @@ export function SettingsPanel({
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-foreground w-14">Seed:</label>
+                  <LabelWithTooltip
+                    label={PARAMETER_METADATA.seed.label}
+                    tooltip={PARAMETER_METADATA.seed.tooltip}
+                    className="text-sm text-foreground w-14"
+                  />
                   <div className="flex-1 flex items-center border rounded-full overflow-hidden h-8">
                     <Button
                       variant="ghost"
@@ -379,7 +391,11 @@ export function SettingsPanel({
 
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-foreground w-14">Seed:</label>
+                  <LabelWithTooltip
+                    label={PARAMETER_METADATA.seed.label}
+                    tooltip={PARAMETER_METADATA.seed.tooltip}
+                    className="text-sm text-foreground w-14"
+                  />
                   <div className="flex-1 flex items-center border rounded-full overflow-hidden h-8">
                     <Button
                       variant="ghost"
@@ -422,11 +438,11 @@ export function SettingsPanel({
             <div className="space-y-2">
               <div className="space-y-2 pt-2">
                 <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    <label className="text-sm text-foreground">
-                      Manage Cache:
-                    </label>
-                  </div>
+                  <LabelWithTooltip
+                    label={PARAMETER_METADATA.manageCache.label}
+                    tooltip={PARAMETER_METADATA.manageCache.tooltip}
+                    className="text-sm text-foreground"
+                  />
                   <Toggle
                     pressed={manageCache}
                     onPressedChange={onManageCacheChange || (() => {})}
@@ -439,11 +455,11 @@ export function SettingsPanel({
                 </div>
 
                 <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    <label className="text-sm text-foreground">
-                      Reset Cache:
-                    </label>
-                  </div>
+                  <LabelWithTooltip
+                    label={PARAMETER_METADATA.resetCache.label}
+                    tooltip={PARAMETER_METADATA.resetCache.tooltip}
+                    className="text-sm text-foreground"
+                  />
                   <Button
                     type="button"
                     onClick={onResetCache || (() => {})}
@@ -465,6 +481,7 @@ export function SettingsPanel({
             value={denoisingSteps}
             onChange={onDenoisingStepsChange || (() => {})}
             defaultValues={getDefaultDenoisingSteps(pipelineId)}
+            tooltip={PARAMETER_METADATA.denoisingSteps.tooltip}
           />
         )}
 
@@ -473,11 +490,11 @@ export function SettingsPanel({
             <div className="space-y-2">
               <div className="space-y-2 pt-2">
                 <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    <label className="text-sm text-foreground">
-                      Noise Controller:
-                    </label>
-                  </div>
+                  <LabelWithTooltip
+                    label={PARAMETER_METADATA.noiseController.label}
+                    tooltip={PARAMETER_METADATA.noiseController.tooltip}
+                    className="text-sm text-foreground"
+                  />
                   <Toggle
                     pressed={noiseController}
                     onPressedChange={onNoiseControllerChange || (() => {})}
@@ -492,7 +509,8 @@ export function SettingsPanel({
               </div>
 
               <SliderWithInput
-                label="Noise Scale:"
+                label={PARAMETER_METADATA.noiseScale.label}
+                tooltip={PARAMETER_METADATA.noiseScale.tooltip}
                 value={localNoiseScale}
                 onValueChange={handleNoiseScaleValueChange}
                 onValueCommit={handleNoiseScaleCommit}

--- a/frontend/src/components/ui/label-with-tooltip.tsx
+++ b/frontend/src/components/ui/label-with-tooltip.tsx
@@ -1,0 +1,48 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
+import { cn } from "../../lib/utils";
+
+interface LabelWithTooltipProps {
+  label: string;
+  tooltip?: string;
+  className?: string;
+  htmlFor?: string;
+}
+
+/**
+ * A reusable label component with optional tooltip.
+ * When a tooltip is provided, it shows on hover over the label.
+ */
+export function LabelWithTooltip({
+  label,
+  tooltip,
+  className,
+  htmlFor,
+}: LabelWithTooltipProps) {
+  if (!tooltip) {
+    return (
+      <label htmlFor={htmlFor} className={className}>
+        {label}
+      </label>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <label htmlFor={htmlFor} className={cn("cursor-help", className)}>
+            {label}
+          </label>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs">
+          <p className="text-xs">{tooltip}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/ui/slider-with-input.tsx
+++ b/frontend/src/components/ui/slider-with-input.tsx
@@ -1,10 +1,12 @@
 import { Button } from "./button";
 import { Input } from "./input";
 import { DebouncedSlider } from "./debounced-slider";
+import { LabelWithTooltip } from "./label-with-tooltip";
 import { Plus, Minus } from "lucide-react";
 
 interface SliderWithInputProps {
   label?: string;
+  tooltip?: string;
   value: number;
   onValueChange: (value: number) => void;
   onValueCommit?: (value: number) => void;
@@ -33,6 +35,7 @@ interface SliderWithInputProps {
  */
 export function SliderWithInput({
   label,
+  tooltip,
   value,
   onValueChange,
   onValueCommit,
@@ -83,7 +86,13 @@ export function SliderWithInput({
   return (
     <div className={`space-y-2 ${className}`}>
       <div className="flex items-center gap-2">
-        {label && <label className={labelClassName}>{label}</label>}
+        {label && (
+          <LabelWithTooltip
+            label={label}
+            tooltip={tooltip}
+            className={labelClassName}
+          />
+        )}
         <div className="flex-1 flex items-center border rounded-full overflow-hidden h-8 min-w-0">
           <Button
             variant="ghost"

--- a/frontend/src/data/parameterMetadata.ts
+++ b/frontend/src/data/parameterMetadata.ts
@@ -1,0 +1,55 @@
+/**
+ * Parameter metadata including labels and tooltip descriptions
+ * for the SettingsPanel and related components.
+ *
+ * This centralized configuration makes it easy to maintain
+ * parameter descriptions across the application.
+ */
+
+export interface ParameterMetadata {
+  label: string;
+  tooltip: string;
+}
+
+export const PARAMETER_METADATA: Record<string, ParameterMetadata> = {
+  height: {
+    label: "Height:",
+    tooltip:
+      "Output video height in pixels. Higher values produce more detailed vertical resolution but reduces speed.",
+  },
+  width: {
+    label: "Width:",
+    tooltip:
+      "Output video width in pixels. Higher values produce more detailed horizontal resolution but reduces speed.",
+  },
+  seed: {
+    label: "Seed:",
+    tooltip:
+      "Random seed for reproducible generation. Using the same seed with the same settings will produce similar results.",
+  },
+  manageCache: {
+    label: "Manage Cache:",
+    tooltip:
+      "Enables pipeline to automatically manage the cache which influences newly generated frames. Disable for manual control via Reset Cache.",
+  },
+  resetCache: {
+    label: "Reset Cache:",
+    tooltip:
+      "Clears previous frames from cache allowing new frames to be generated with fresh history. Only available when Manage Cache is disabled.",
+  },
+  denoisingSteps: {
+    label: "Denoising Step List",
+    tooltip:
+      "List of denoising timesteps used in diffusion. Values must be in descending order. Lower values mean less noise to remove. More steps can improve quality but reduce speed.",
+  },
+  noiseController: {
+    label: "Noise Controller:",
+    tooltip:
+      "Enables automatic noise scale adjustment based on detected motion. Disable for manual control via Noise Scale.",
+  },
+  noiseScale: {
+    label: "Noise Scale:",
+    tooltip:
+      "Controls the amount of noise added during generation. Higher values add more variation and creativity and lower values produce more stable results.",
+  },
+};


### PR DESCRIPTION
The tooltip is displayed when you hover over the label for the param in the SettingsPanel.

The `parameterMetadata.ts` file contains the tooltip descriptions in a single place for now.