### PR TITLE
Updates docs link to the Scope tutorial page

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -35,7 +35,7 @@ export function Header({ className = "" }: HeaderProps) {
             />
           </a>
           <a
-            href="https://docs.daydream.live/knowledge-hub/research-references/about-video-and-world-models"
+            href="https://docs.daydream.live/knowledge-hub/tutorials/scope"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:opacity-80 transition-opacity"


### PR DESCRIPTION
Changed the documentation link in the header from the general video/world models page to the specific Scope tutorial page for better user guidance.