### PR TITLE
Align UI style for temporal controls in append vs editing mode

### DIFF
--- a/frontend/src/components/TimelinePromptEditor.tsx
+++ b/frontend/src/components/TimelinePromptEditor.tsx
@@ -175,21 +175,19 @@ export function TimelinePromptEditor({
       prompt?.temporalInterpolationMethod ?? "slerp";
 
     return (
-      <div className="pt-3 border-t border-border">
-        <TemporalTransitionControls
-          transitionSteps={effectiveTransitionSteps}
-          onTransitionStepsChange={handleTransitionStepsChange}
-          temporalInterpolationMethod={effectiveTemporalMethod}
-          onTemporalInterpolationMethodChange={
-            handleTemporalInterpolationMethodChange
-          }
-          disabled={disabled || isFirstBlock}
-          showHeader={true}
-          showDisabledMessage={true}
-          maxSteps={10}
-          className="space-y-3"
-        />
-      </div>
+      <TemporalTransitionControls
+        transitionSteps={effectiveTransitionSteps}
+        onTransitionStepsChange={handleTransitionStepsChange}
+        temporalInterpolationMethod={effectiveTemporalMethod}
+        onTemporalInterpolationMethodChange={
+          handleTemporalInterpolationMethodChange
+        }
+        disabled={disabled || isFirstBlock}
+        showHeader={false}
+        showDisabledMessage={false}
+        maxSteps={16}
+        className="space-y-2"
+      />
     );
   };
   // Render single prompt mode
@@ -211,24 +209,26 @@ export function TimelinePromptEditor({
           />
         </div>
 
-        {prompts.length < 4 && (
-          <div className="flex items-center justify-end gap-2">
-            <Button
-              onMouseDown={e => {
-                e.preventDefault();
-                handleAddPrompt();
-              }}
-              disabled={disabled}
-              size="sm"
-              variant="ghost"
-              className="rounded-full w-8 h-8 p-0"
-            >
-              <Plus className="h-4 w-4" />
-            </Button>
-          </div>
-        )}
+        <div className="space-y-2">
+          {renderTransitionSettings()}
 
-        {renderTransitionSettings()}
+          {prompts.length < 4 && (
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                onMouseDown={e => {
+                  e.preventDefault();
+                  handleAddPrompt();
+                }}
+                disabled={disabled}
+                size="sm"
+                variant="ghost"
+                className="rounded-full w-8 h-8 p-0"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </div>
       </div>
     );
   };
@@ -264,9 +264,10 @@ export function TimelinePromptEditor({
           );
         })}
 
-        <div className="flex items-center justify-between gap-2">
-          {prompts.length >= 2 ? (
-            <div className="flex items-center gap-2">
+        <div className="space-y-2">
+          {/* Spatial Blend - only for multiple prompts */}
+          {prompts.length >= 2 && (
+            <div className="flex items-center justify-between gap-2">
               <span className="text-xs text-muted-foreground">
                 Spatial Blend:
               </span>
@@ -277,7 +278,7 @@ export function TimelinePromptEditor({
                 }
                 disabled={disabled}
               >
-                <SelectTrigger className="w-24 h-7 text-xs">
+                <SelectTrigger className="w-24 h-6 text-xs">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -288,12 +289,13 @@ export function TimelinePromptEditor({
                 </SelectContent>
               </Select>
             </div>
-          ) : (
-            <div />
           )}
 
+          {renderTransitionSettings()}
+
+          {/* Add button - Bottom row */}
           {prompts.length < 4 && (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center justify-end gap-2">
               <Button
                 onMouseDown={e => {
                   e.preventDefault();
@@ -309,8 +311,6 @@ export function TimelinePromptEditor({
             </div>
           )}
         </div>
-
-        {renderTransitionSettings()}
       </div>
     );
   };


### PR DESCRIPTION
At the moment, the Prompts box looks like this when in Editing mode:

<img width="386" height="278" alt="Screenshot 2025-11-04 at 4 42 53 PM" src="https://github.com/user-attachments/assets/8fcca721-07f7-49fa-a282-f7479742ff09" />

IMO this looks a bit strange as the UI style doesn't align with what the Prompts box looks like when in Append mode eg the add/submit buttons in bottom row with Spatial/Temporal controls in rows above it.

This PR aligns the UI style of the Prompts box when in Append and Edit mode so that temporal controls are always above the add/submit buttons and also removes the header for the temporal controls since that is not present in Append mode.

A few screenshots:

Single prompt append mode:

<img width="380" height="233" alt="Screenshot 2025-11-04 at 4 33 50 PM" src="https://github.com/user-attachments/assets/bee29e6b-d7b7-490c-ab98-e37daf049cf2" />

Multiple prompts append mode:

<img width="380" height="393" alt="Screenshot 2025-11-04 at 4 33 46 PM" src="https://github.com/user-attachments/assets/d989614d-7cf2-4e1a-abd3-675edff35c90" />

Single prompt edit mode:

<img width="368" height="225" alt="Screenshot 2025-11-04 at 4 34 10 PM" src="https://github.com/user-attachments/assets/d84bcc33-4b68-4433-a16e-ee69b141909c" />

Multiple prompts edit mode:

<img width="370" height="370" alt="Screenshot 2025-11-04 at 4 34 17 PM" src="https://github.com/user-attachments/assets/c6ce3176-ae18-4f71-a1b4-ae83e55c1e51" />

I'm open to other layouts but in the interest of keeping the two modes stylistically consistent for now I'm making these changes.

FYI @ryanontheinside 