### PR TITLE
fix: prevent zero-sized tensor in flex_attention padding removal

### DIFF
--- a/pipelines/base/wan2_1/modules/causal_model.py
+++ b/pipelines/base/wan2_1/modules/causal_model.py
@@ -185,12 +185,15 @@ class CausalWanSelfAttention(nn.Module):
                     dim=1,
                 )
 
-                x = flex_attention(
+                attn_out = flex_attention(
                     query=padded_roped_query.transpose(2, 1),
                     key=padded_roped_key.transpose(2, 1),
                     value=padded_v.transpose(2, 1),
                     block_mask=block_mask,
-                )[:, :, :-padded_length].transpose(2, 1)
+                )
+                if padded_length > 0:
+                    attn_out = attn_out[:, :, :-padded_length]
+                x = attn_out.transpose(2, 1)
 
             else:
                 roped_query = rope_apply(q, grid_sizes, freqs).type_as(v)
@@ -233,12 +236,15 @@ class CausalWanSelfAttention(nn.Module):
                     dim=1,
                 )
 
-                x = flex_attention(
+                attn_out = flex_attention(
                     query=padded_roped_query.transpose(2, 1),
                     key=padded_roped_key.transpose(2, 1),
                     value=padded_v.transpose(2, 1),
                     block_mask=block_mask,
-                )[:, :, :-padded_length].transpose(2, 1)
+                )
+                if padded_length > 0:
+                    attn_out = attn_out[:, :, :-padded_length]
+                x = attn_out.transpose(2, 1)
         else:
             frame_seqlen = math.prod(grid_sizes[0][1:]).item()
             current_start_frame = current_start // frame_seqlen

--- a/pipelines/streamdiffusionv2/vendor/causvid/models/wan/causal_model.py
+++ b/pipelines/streamdiffusionv2/vendor/causvid/models/wan/causal_model.py
@@ -150,12 +150,15 @@ class CausalWanSelfAttention(nn.Module):
                 dim=1,
             )
 
-            x = flex_attention(
+            attn_out = flex_attention(
                 query=padded_roped_query.transpose(2, 1),
                 key=padded_roped_key.transpose(2, 1),
                 value=padded_v.transpose(2, 1),
                 block_mask=block_mask,
-            )[:, :, :-padded_length].transpose(2, 1)
+            )
+            if padded_length > 0:
+                attn_out = attn_out[:, :, :-padded_length]
+            x = attn_out.transpose(2, 1)
         else:
             frame_seqlen = math.prod(grid_sizes[0][1:]).item()
             sink_tokens = self.sink_size * frame_seqlen


### PR DESCRIPTION
When padded_length is 0, slicing with [:, :, :-0] creates a zero-sized tensor which causes 'amax(): Expected reduction dim 1 to have non-zero size' errors in subsequent operations.