### PR TITLE
Make pipeline status checks async

### DIFF
--- a/frontend/src/hooks/usePipeline.ts
+++ b/frontend/src/hooks/usePipeline.ts
@@ -9,7 +9,7 @@ interface UsePipelineOptions {
 }
 
 export function usePipeline(options: UsePipelineOptions = {}) {
-  const { pollInterval = 2000, maxTimeout = 45000 } = options;
+  const { pollInterval = 2000, maxTimeout = 600000 } = options;
 
   const [status, setStatus] =
     useState<PipelineStatusResponse["status"]>("not_loaded");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -114,6 +114,7 @@ export const getPipelineStatus = async (): Promise<PipelineStatusResponse> => {
   const response = await fetch("/api/v1/pipeline/status", {
     method: "GET",
     headers: { "Content-Type": "application/json" },
+    signal: AbortSignal.timeout(30000), // 30 second timeout per request
   });
 
   if (!response.ok) {


### PR DESCRIPTION
Fixes https://github.com/daydreamlive/scope/issues/163

This is based off of https://github.com/daydreamlive/scope/pull/164 but simplifies things.

**1. Prefer async function calls in async route handlers**

There was a general problem where we called sync functions in async route handlers which means that the sync functions would block the event loop until they completed. We generally should avoid this by making sure we call async functions in the async route handlers instead.

**2. Avoid locking during slow pipeline load operation**

The `_load_pipeline_sync_wrapper()` function in PipelineManager held a lock for the entirety of the pipeline load operation which means that another function that requests the lock would have to wait for the entire load operation to finish. This PR updates the function so it holds the lock when updating shared state and then releases immediately afterwords and it also does not hold the lock during the pipeline load operation.

**3. Increase max timeout for polling for pipeline status and add timeout for individual status requests**

A pipeline load could take 100s+ on a 5090 when using a LoRA with a 14B model so we need to have a higher overall max timeout when polling for pipeline status. In order to make sure we can handle the scenario where the backend becomes unresponsive we also make sure there is an abort timeout for individual status requests.

The polling pattern here is not the right design and a better design would be to use something SSE/WebSocket based. But, this PR just fixes the current issue without touching the design.

The result of these changes is that the frontend will hit `/api/v1/pipeline/load` which returns immediately and then properly poll `/api/v1/pipeline/status` until the pipeline is loaded. Since no request blocks for a long time we won't have problems with the Cloudflare timeout with Runpod proxies.