### PR TITLE
Centralize Pipeline Defaults via Abstract Interface

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,6 +70,17 @@ export interface PipelineStatusResponse {
   error?: string;
 }
 
+export interface PipelineDefaultsResponse {
+  pipeline_id: string;
+  denoising_steps: number[] | null;
+  resolution: { height: number; width: number };
+  manage_cache: boolean;
+  base_seed: number;
+  noise_scale: number | null;
+  noise_controller: boolean | null;
+  kv_cache_attention_bias: number | null;
+}
+
 export const sendWebRTCOffer = async (
   data: WebRTCOfferRequest
 ): Promise<RTCSessionDescriptionInit> => {
@@ -121,6 +132,28 @@ export const getPipelineStatus = async (): Promise<PipelineStatusResponse> => {
     const errorText = await response.text();
     throw new Error(
       `Pipeline status failed: ${response.status} ${response.statusText}: ${errorText}`
+    );
+  }
+
+  const result = await response.json();
+  return result;
+};
+
+export const getPipelineDefaults = async (
+  pipelineId: string
+): Promise<PipelineDefaultsResponse> => {
+  const response = await fetch(
+    `/api/v1/pipeline/defaults?pipeline_id=${pipelineId}`,
+    {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Pipeline defaults failed: ${response.status} ${response.statusText}: ${errorText}`
     );
   }
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,32 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
-import type { PipelineId } from "../types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
-}
-
-export function getDefaultDenoisingSteps(pipelineId: PipelineId): number[] {
-  if (pipelineId === "longlive") {
-    return [1000, 750, 500, 250];
-  } else if (pipelineId === "krea-realtime-video") {
-    return [1000, 750, 500, 250];
-  } else if (pipelineId === "streamdiffusionv2") {
-    return [700, 500];
-  }
-  return [700, 500]; // Default fallback
-}
-
-export function getDefaultResolution(pipelineId: PipelineId): {
-  height: number;
-  width: number;
-} {
-  if (pipelineId === "longlive") {
-    return { height: 320, width: 576 };
-  } else if (pipelineId === "krea-realtime-video") {
-    return { height: 320, width: 576 };
-  } else if (pipelineId === "streamdiffusionv2") {
-    return { height: 512, width: 512 };
-  }
-  return { height: 320, width: 576 }; // Default fallback
 }

--- a/src/scope/core/pipelines/defaults.py
+++ b/src/scope/core/pipelines/defaults.py
@@ -1,0 +1,43 @@
+"""Centralized default extraction for pipelines."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .interface import Pipeline, PipelineDefaults
+
+
+def get_pipeline_defaults(pipeline_class: type["Pipeline"]) -> "PipelineDefaults":
+    """Extract defaults from a pipeline class.
+
+    Args:
+        pipeline_class: The pipeline class (not instance)
+
+    Returns:
+        Typed PipelineDefaults object with pipeline configuration.
+    """
+    return pipeline_class.get_defaults()
+
+
+def extract_load_params(
+    pipeline_class: type["Pipeline"], load_params: dict | None = None
+) -> tuple[int, int, int]:
+    """Extract height, width, and seed from load_params with pipeline defaults as fallback.
+
+    Args:
+        pipeline_class: The pipeline class to get defaults from
+        load_params: Optional dictionary with height, width, seed overrides
+
+    Returns:
+        Tuple of (height, width, seed)
+    """
+    defaults = get_pipeline_defaults(pipeline_class)
+    default_height = defaults.resolution["height"]
+    default_width = defaults.resolution["width"]
+    default_seed = defaults.base_seed
+
+    params = load_params or {}
+    height = params.get("height", default_height)
+    width = params.get("width", default_width)
+    seed = params.get("seed", default_seed)
+
+    return height, width, seed

--- a/src/scope/core/pipelines/interface.py
+++ b/src/scope/core/pipelines/interface.py
@@ -1,9 +1,11 @@
 """Base interface for all pipelines."""
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import torch
-from pydantic import BaseModel
+from diffusers.modular_pipelines import PipelineState
+from pydantic import BaseModel, Field, field_validator
 
 
 class Requirements(BaseModel):
@@ -12,8 +14,117 @@ class Requirements(BaseModel):
     input_size: int
 
 
+class PipelineDefaults(BaseModel):
+    """Typed defaults for pipeline configuration.
+
+    Each pipeline must provide these core defaults. Pipeline-specific parameters
+    can be added via the model_config extra="allow" setting.
+    """
+
+    denoising_steps: list[int] | None = Field(
+        default=None, description="Default denoising steps for the pipeline"
+    )
+    resolution: dict[str, int] = Field(
+        ..., description="Default resolution with height and width keys"
+    )
+    manage_cache: bool = Field(
+        default=True, description="Default cache management setting"
+    )
+    base_seed: int = Field(default=42, description="Default random seed")
+    noise_scale: float | None = Field(
+        default=None, description="Default noise scale (None if not applicable)"
+    )
+    noise_controller: bool | None = Field(
+        default=None,
+        description="Default noise controller setting (None if not applicable)",
+    )
+    kv_cache_attention_bias: float | None = Field(
+        default=None,
+        description="Default KV cache attention bias (None if not applicable)",
+    )
+
+    @field_validator("resolution")
+    @classmethod
+    def validate_resolution(cls, v: dict[str, int]) -> dict[str, int]:
+        """Validate resolution has required height and width keys."""
+        if "height" not in v or "width" not in v:
+            raise ValueError("resolution must contain both 'height' and 'width' keys")
+        if not isinstance(v["height"], int) or not isinstance(v["width"], int):
+            raise ValueError("resolution height and width must be integers")
+        if v["height"] <= 0 or v["width"] <= 0:
+            raise ValueError("resolution height and width must be positive")
+        return v
+
+    model_config = {"extra": "allow"}
+
+
 class Pipeline(ABC):
     """Abstract base class for all pipelines."""
+
+    @classmethod
+    @abstractmethod
+    def get_defaults(cls) -> PipelineDefaults:
+        """Return typed default parameters for this pipeline.
+
+        Returns:
+            PipelineDefaults object with pipeline-specific configuration.
+
+        Example:
+            return PipelineDefaults(
+                denoising_steps=[700, 500],
+                resolution={"height": 512, "width": 512},
+                manage_cache=True,
+                base_seed=42,
+                noise_scale=0.7,
+                noise_controller=True,
+                kv_cache_attention_bias=0.3
+            )
+        """
+        pass
+
+    @classmethod
+    def _initialize_state_with_defaults(
+        cls, state: PipelineState, config: Any, defaults: PipelineDefaults
+    ) -> None:
+        """Initialize pipeline state with default values from config and pipeline defaults.
+
+        This helper consolidates the common pattern of initializing state parameters
+        with values from config (if present) or falling back to pipeline defaults.
+
+        Args:
+            state: PipelineState object to initialize
+            config: Configuration object with optional overrides
+            defaults: PipelineDefaults object with default values
+        """
+        # Common state initialization
+        state.set("current_start_frame", 0)
+
+        # Resolution from config or defaults (resolution is required in PipelineDefaults)
+        state.set(
+            "height",
+            getattr(config, "height", defaults.resolution["height"]),
+        )
+        state.set(
+            "width",
+            getattr(config, "width", defaults.resolution["width"]),
+        )
+
+        # Seed from config or defaults
+        state.set("base_seed", getattr(config, "seed", defaults.base_seed))
+
+        # Cache management from defaults
+        state.set("manage_cache", defaults.manage_cache)
+
+        # Noise controls from defaults
+        if defaults.noise_scale is not None:
+            state.set("noise_scale", defaults.noise_scale)
+
+        if defaults.noise_controller is not None:
+            state.set("noise_controller", defaults.noise_controller)
+
+        # Pipeline-specific parameters (optional, may not exist in all defaults)
+        if defaults.kv_cache_attention_bias is not None:
+            state.set("kv_cache_attention_bias", defaults.kv_cache_attention_bias)
 
     @abstractmethod
     def __call__(

--- a/src/scope/core/pipelines/passthrough/pipeline.py
+++ b/src/scope/core/pipelines/passthrough/pipeline.py
@@ -1,12 +1,24 @@
 import torch
 from einops import rearrange
 
-from ..interface import Pipeline, Requirements
+from ..interface import Pipeline, PipelineDefaults, Requirements
 from ..process import postprocess_chunk, preprocess_chunk
 
 
 class PassthroughPipeline(Pipeline):
     """Passthrough pipeline for testing"""
+
+    @classmethod
+    def get_defaults(cls) -> PipelineDefaults:
+        """Return default parameters for Passthrough pipeline."""
+        return PipelineDefaults(
+            denoising_steps=None,
+            resolution={"height": 512, "width": 512},
+            manage_cache=False,
+            base_seed=42,
+            noise_scale=None,
+            noise_controller=None,
+        )
 
     def __init__(
         self,

--- a/src/scope/server/schema.py
+++ b/src/scope/server/schema.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from scope.core.pipelines.interface import PipelineDefaults
 from scope.core.pipelines.utils import Quantization
 
 
@@ -260,3 +261,12 @@ class PipelineStatusResponse(BaseModel):
     error: str | None = Field(
         default=None, description="Error message if status is error"
     )
+
+
+class PipelineDefaultsResponse(PipelineDefaults):
+    """Pipeline defaults response schema.
+
+    Inherits all fields and validation from PipelineDefaults.
+    """
+
+    pipeline_id: str = Field(..., description="ID of the pipeline")


### PR DESCRIPTION
# Centralize Pipeline Defaults via Abstract Interface

First step toward universal input methods: establish a single source of truth for pipeline configuration defaults.

## Changes

### Backend
- Add `PipelineDefaults` Pydantic model to `interface.py` defining typed default configuration
- Add abstract `get_defaults()` classmethod to `Pipeline` base class
- Implement `get_defaults()` in all pipeline classes (StreamDiffusionV2, LongLive, KreaRealtimeVideo, Passthrough)
- Add `defaults.py` module with utilities for extracting and applying defaults
- Add helper method `_initialize_state_with_defaults()` to reduce boilerplate in pipeline constructors
- Add `/api/v1/pipeline/defaults` endpoint to expose pipeline defaults to frontend
- Refactor `pipeline_manager.py` to use pipeline defaults instead of hardcoded values

### Frontend
- Add `getPipelineDefaults()` API client function
- Update `useStreamState` to fetch and apply pipeline defaults when pipeline changes
- Remove hardcoded defaults from `StreamPage.tsx` pipeline switching logic
- Remove unused `getDefaultDenoisingSteps()` utility (now backend-driven)

## Benefits

- **DRY**: Eliminated duplicate default values across frontend and backend
- **Type Safety**: Pydantic validation ensures consistent configuration
- **Maintainability**: Each pipeline owns its defaults in one place
- **Flexibility**: Frontend automatically adapts to backend default changes
- **Extensibility**: Useful in imminent work on universal input methods, could pave the way for user-defined defaults

## Next Steps

- Pipeline registry pattern to remove if/elif chains in API endpoint
- Additional universal input mode features building on this foundation

## Testing

- [x] Verify pipeline switching updates all settings correctly
- [x] Confirm each pipeline loads with appropriate defaults
- [x] Check API endpoint returns correct defaults for all pipeline IDs