### PR TITLE
Fix: Warmup changes for krea to maximize startup performance.

### DIFF
--- a/src/scope/core/pipelines/krea_realtime_video/modules/causal_model.py
+++ b/src/scope/core/pipelines/krea_realtime_video/modules/causal_model.py
@@ -512,11 +512,7 @@ class CausalWanSelfAttention(nn.Module):
             if kv_cache_attention_bias != KV_CACHE_ATTENTION_BIAS_DISABLED:
                 # Use flex_attention with bias to mitigate error accumulation in past frames
                 # log_scale in (0, 1]: smaller values = less attention to past frame tokens
-                log_scale = torch.tensor(
-                    math.log(kv_cache_attention_bias),
-                    device=roped_query.device,
-                    dtype=torch.float32,
-                )
+                log_scale = math.log(kv_cache_attention_bias)
 
                 # Exclude first frame and current block from bias
                 cache_len = local_end_index - kv_start_idx


### PR DESCRIPTION
# Fix Krea Realtime Video Startup Stuttering

### Problem

When starting a stream with `krea-realtime-video`, users experience ~5 seconds of severe stuttering (2 FPS) before the frame rate stabilizes. This is caused by `torch.compile` recompilation and autotuning happening at runtime instead of during initialization.

### Root Cause

Two issues prevented the warm-up from being effective:

1. **Wrong code path**: Warm-up ran with `kv_cache_attention_bias=1.0` (default), which uses the standard attention path. At runtime, the UI may send a different value (e.g., `0.99`), triggering the `flex_attention` path for the first time.

2. **Incomplete cache state**: Warm-up only ran 3 iterations but reset the cache each time, never reaching the steady-state "full cache" shape that `torch.compile` needs to pre-compile.

### Solution

1. **Trigger the correct code path**: Use `kv_cache_attention_bias=0.99` during warm-up to compile the `flex_attention` kernel.

2. **Fill the cache completely**: Calculate the number of warm-up runs needed to fill the KV cache based on config values, then run with `init_cache=False` after the first iteration to simulate cache accumulation.

3. **Prevent scalar specialization**: Convert scalar values used in `score_mod` to tensors so `torch.compile` treats them as dynamic inputs rather than compile-time constants.

### Changes

**`pipeline.py`**
- Added `WARMUP_KV_CACHE_ATTENTION_BIAS = 0.99` constant
- Calculate warm-up runs dynamically: `(local_attn_size // num_frame_per_block) + 1`
- Pass `init_cache=(i == 0)` to accumulate cache across warm-up iterations

**`causal_model.py`**
- Convert `cache_current_block_start` to tensor before use in `score_mod`

### Testing

1. Start server with `krea-realtime-video` pipeline
2. Observe warm-up logs (should show 3 runs for default config)
3. Start a stream - frame rate should be stable from the first frame
4. No `AUTOTUNE` logs should appear during stream start