### PR TITLE
Fix to AttributeError: 'ShapeAsConstantBuffer' dtype error with compiling

### DIFF
--- a/src/scope/core/pipelines/krea_realtime_video/modules/causal_model.py
+++ b/src/scope/core/pipelines/krea_realtime_video/modules/causal_model.py
@@ -540,21 +540,13 @@ class CausalWanSelfAttention(nn.Module):
 
                 # Convert scalars to tensors to avoid ShapeAsConstantBuffer dtype issues during compilation
                 # This is critical when using torch.compile with flex_attention
-                frame_seqlen_tensor = torch.tensor(
+                frame_seqlen_tensor = torch.as_tensor(
                     frame_seqlen, dtype=torch.int32, device=roped_query.device
                 )
-                # Always convert cache_current_block_start to a tensor to avoid ShapeAsConstantBuffer issues
-                if isinstance(cache_current_block_start, torch.Tensor):
-                    if cache_current_block_start.ndim > 0:
-                        cache_current_block_start_tensor = cache_current_block_start.squeeze()
-                    else:
-                        cache_current_block_start_tensor = cache_current_block_start
-                else:
-                    cache_current_block_start_tensor = torch.tensor(
-                        cache_current_block_start, dtype=torch.int32, device=roped_query.device
-                    )
-                # Convert log_scale to a tensor to avoid ShapeAsConstantBuffer dtype issues
-                log_scale_tensor = torch.tensor(
+                cache_current_block_start_tensor = torch.as_tensor(
+                    cache_current_block_start, dtype=torch.int32, device=roped_query.device
+                ).squeeze()
+                log_scale_tensor = torch.as_tensor(
                     log_scale, dtype=roped_query.dtype, device=roped_query.device
                 )
 


### PR DESCRIPTION
## Fix: Resolve `ShapeAsConstantBuffer` dtype error when compiling flex_attention with score_mod

Reference issue:
- https://github.com/daydreamlive/scope/issues/184

> Note: This was tested on a RunPod 5090 by forcing `compile=True` in the KreaRealtimeVideoPipeline and has not been tested on an H100 Hopper as of yet.

### Problem
When `compile=True` is used with `KreaRealtimeVideoPipeline`, compilation fails with:
```
LoweringException: AttributeError: 'ShapeAsConstantBuffer' object has no attribute 'dtype'
  target: flex_attention
```

This occurs in the denoise block when `flex_attention` is called with a `score_mod` function.

### Root Cause
In `score_mod` (used for KV cache attention bias), Python scalars (`cache_current_block_start` as int, `log_scale` as float) were used directly. With `torch.compile`, these become `ShapeAsConstantBuffer` objects that lack a `dtype`, causing the error.

Related issues:
- https://github.com/pytorch/pytorch/issues/157833
- https://github.com/pytorch/pytorch/issues/129550
- https://github.com/pytorch/pytorch/issues/150056

### Solution
Convert all scalars used in `score_mod` to tensors before compilation:
1. Always convert `cache_current_block_start` to a tensor (handles both tensor and int cases)
2. Convert `log_scale` to a tensor (`log_scale_tensor`) with the correct dtype and device
3. Use tensor versions in `score_mod` instead of Python scalars

This ensures all values in `score_mod` are tensors with `dtype`, preventing the `ShapeAsConstantBuffer` error.

### Changes
- Modified `causal_model.py` lines 541-568 to convert scalars to tensors before use in `score_mod`

### Testing
- Verified compilation succeeds with `compile=True`
- No functional changes; only fixes the compilation path