### PR TITLE
01 feat: add shared VAE infrastructure 

### DIFF
--- a/src/scope/core/pipelines/base/__init__.py
+++ b/src/scope/core/pipelines/base/__init__.py
@@ -1,0 +1,1 @@
+"""Base pipeline components and utilities."""

--- a/src/scope/core/pipelines/krea_realtime_video/components/vae.py
+++ b/src/scope/core/pipelines/krea_realtime_video/components/vae.py
@@ -34,10 +34,6 @@ class WanVAEWrapper(torch.nn.Module):
 
         self.decoder = VAEDecoderWrapper()
         state_dict = torch.load(vae_path, map_location="cpu")
-        decoder_state_dict = {}
-        for key, value in state_dict.items():
-            if "decoder." in key or "conv2" in key:
-                decoder_state_dict[key] = value
         self.decoder.load_state_dict(state_dict, strict=False)
         self.decoder.eval()
         self.decoder.requires_grad_(False)

--- a/src/scope/core/pipelines/wan2_1/vae/__init__.py
+++ b/src/scope/core/pipelines/wan2_1/vae/__init__.py
@@ -1,0 +1,76 @@
+"""Wan2.1 VAE implementations.
+
+This module provides a registry-based factory for VAE instantiation,
+supporting multiple VAE types (currently WanVAEWrapper, with LightVAE planned).
+
+Usage:
+    from scope.core.pipelines.wan2_1.vae import create_vae
+
+    # Default (WanVAEWrapper)
+    vae = create_vae(model_dir="wan_models")
+
+    # Explicit type (for UI dropdown)
+    vae = create_vae(model_dir="wan_models", vae_type="wan")
+
+    # With explicit path override
+    vae = create_vae(model_dir="wan_models", vae_path="/path/to/custom_vae.pth")
+"""
+
+from .wan import WanVAEWrapper
+
+# Registry mapping type names to VAE classes
+# UI dropdowns will use these keys
+VAE_REGISTRY: dict[str, type] = {
+    "wan": WanVAEWrapper,
+    # "lightvae": LightVAE,  # Future: add when LightVAE is implemented
+}
+
+DEFAULT_VAE_TYPE = "wan"
+
+
+def create_vae(
+    model_dir: str = "wan_models",
+    model_name: str = "Wan2.1-T2V-1.3B",
+    vae_type: str | None = None,
+    vae_path: str | None = None,
+) -> WanVAEWrapper:
+    """Create VAE instance by type.
+
+    Args:
+        model_dir: Base model directory
+        model_name: Model subdirectory name (e.g., "Wan2.1-T2V-1.3B")
+        vae_type: VAE type from registry. Defaults to "wan".
+                  This will be selectable via UI dropdown.
+        vae_path: Optional explicit path override. If provided, takes
+                  precedence over model_dir/model_name path construction.
+
+    Returns:
+        Initialized VAE instance
+
+    Raises:
+        ValueError: If vae_type is not in registry
+    """
+    vae_type = vae_type or DEFAULT_VAE_TYPE
+
+    vae_cls = VAE_REGISTRY.get(vae_type)
+    if vae_cls is None:
+        available = list(VAE_REGISTRY.keys())
+        raise ValueError(
+            f"create_vae: Unknown VAE type '{vae_type}'. Available types: {available}"
+        )
+
+    return vae_cls(model_dir=model_dir, model_name=model_name, vae_path=vae_path)
+
+
+def list_vae_types() -> list[str]:
+    """Return list of available VAE types for UI dropdowns."""
+    return list(VAE_REGISTRY.keys())
+
+
+__all__ = [
+    "WanVAEWrapper",
+    "create_vae",
+    "list_vae_types",
+    "VAE_REGISTRY",
+    "DEFAULT_VAE_TYPE",
+]

--- a/src/scope/core/pipelines/wan2_1/vae/constants.py
+++ b/src/scope/core/pipelines/wan2_1/vae/constants.py
@@ -1,0 +1,46 @@
+"""Shared VAE normalization constants for Wan2.1 models.
+
+These constants define the latent space normalization parameters used across
+all Wan2.1-based VAE wrappers to ensure consistent encoding/decoding behavior.
+"""
+
+# Wan2.1 VAE latent space normalization parameters
+# Mean values for each of the 16 latent channels
+WAN_VAE_LATENT_MEAN = [
+    -0.7571,
+    -0.7089,
+    -0.9113,
+    0.1075,
+    -0.1745,
+    0.9653,
+    -0.1517,
+    1.5508,
+    0.4134,
+    -0.0715,
+    0.5517,
+    -0.3632,
+    -0.1922,
+    -0.9497,
+    0.2503,
+    -0.2921,
+]
+
+# Standard deviation values for each of the 16 latent channels
+WAN_VAE_LATENT_STD = [
+    2.8184,
+    1.4541,
+    2.3275,
+    2.6558,
+    1.2196,
+    1.7708,
+    2.6052,
+    2.0743,
+    3.2687,
+    2.1526,
+    2.8652,
+    1.5579,
+    1.6382,
+    1.1253,
+    2.8251,
+    1.9160,
+]

--- a/src/scope/core/pipelines/wan2_1/vae/modules/__init__.py
+++ b/src/scope/core/pipelines/wan2_1/vae/modules/__init__.py
@@ -1,0 +1,5 @@
+"""VAE modules for Wan2.1 pipelines."""
+
+from .vae import _video_vae
+
+__all__ = ["_video_vae"]

--- a/src/scope/core/pipelines/wan2_1/vae/modules/vae.py
+++ b/src/scope/core/pipelines/wan2_1/vae/modules/vae.py
@@ -1,0 +1,860 @@
+# Modified from https://github.com/chenfengxu714/StreamdiffusionV2
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import logging
+
+import torch
+import torch.cuda.amp as amp
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+
+__all__ = [
+    "WanVAE",
+    "_video_vae",
+]
+
+CACHE_T = 2
+
+
+class CausalConv3d(nn.Conv3d):
+    """
+    Causal 3d convolusion.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._padding = (
+            self.padding[2],
+            self.padding[2],
+            self.padding[1],
+            self.padding[1],
+            2 * self.padding[0],
+            0,
+        )
+        self.padding = (0, 0, 0)
+
+    def forward(self, x, cache_x=None):
+        padding = list(self._padding)
+        if cache_x is not None and self._padding[4] > 0:
+            cache_x = cache_x.to(x.device)
+            x = torch.cat([cache_x, x], dim=2)
+            padding[4] -= cache_x.shape[2]
+        x = F.pad(x, padding)
+
+        return super().forward(x)
+
+
+class RMS_norm(nn.Module):
+    def __init__(self, dim, channel_first=True, images=True, bias=False):
+        super().__init__()
+        broadcastable_dims = (1, 1, 1) if not images else (1, 1)
+        shape = (dim, *broadcastable_dims) if channel_first else (dim,)
+
+        self.channel_first = channel_first
+        self.scale = dim**0.5
+        self.gamma = nn.Parameter(torch.ones(shape))
+        self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.0
+
+    def forward(self, x):
+        return (
+            F.normalize(x, dim=(1 if self.channel_first else -1))
+            * self.scale
+            * self.gamma
+            + self.bias
+        )
+
+
+class Upsample(nn.Upsample):
+    def forward(self, x):
+        """
+        Fix bfloat16 support for nearest neighbor interpolation.
+        """
+        return super().forward(x.float()).type_as(x)
+
+
+class Resample(nn.Module):
+    def __init__(self, dim, mode):
+        assert mode in (
+            "none",
+            "upsample2d",
+            "upsample3d",
+            "downsample2d",
+            "downsample3d",
+        )
+        super().__init__()
+        self.dim = dim
+        self.mode = mode
+
+        # layers
+        if mode == "upsample2d":
+            self.resample = nn.Sequential(
+                Upsample(scale_factor=(2.0, 2.0), mode="nearest-exact"),
+                nn.Conv2d(dim, dim // 2, 3, padding=1),
+            )
+        elif mode == "upsample3d":
+            self.resample = nn.Sequential(
+                Upsample(scale_factor=(2.0, 2.0), mode="nearest-exact"),
+                nn.Conv2d(dim, dim // 2, 3, padding=1),
+            )
+            self.time_conv = CausalConv3d(dim, dim * 2, (3, 1, 1), padding=(1, 0, 0))
+
+        elif mode == "downsample2d":
+            self.resample = nn.Sequential(
+                nn.ZeroPad2d((0, 1, 0, 1)), nn.Conv2d(dim, dim, 3, stride=(2, 2))
+            )
+        elif mode == "downsample3d":
+            self.resample = nn.Sequential(
+                nn.ZeroPad2d((0, 1, 0, 1)), nn.Conv2d(dim, dim, 3, stride=(2, 2))
+            )
+            self.time_conv = CausalConv3d(
+                dim, dim, (3, 1, 1), stride=(2, 1, 1), padding=(0, 0, 0)
+            )
+
+        else:
+            self.resample = nn.Identity()
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        b, c, t, h, w = x.size()
+        if self.mode == "upsample3d":
+            if feat_cache is not None:
+                idx = feat_idx[0]
+                if feat_cache[idx] is None:
+                    feat_cache[idx] = "Rep"
+                    feat_idx[0] += 1
+                else:
+                    cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                    if (
+                        cache_x.shape[2] < 2
+                        and feat_cache[idx] is not None
+                        and feat_cache[idx] != "Rep"
+                    ):
+                        # cache last frame of last two chunk
+                        cache_x = torch.cat(
+                            [
+                                feat_cache[idx][:, :, -1, :, :]
+                                .unsqueeze(2)
+                                .to(cache_x.device),
+                                cache_x,
+                            ],
+                            dim=2,
+                        )
+                    if (
+                        cache_x.shape[2] < 2
+                        and feat_cache[idx] is not None
+                        and feat_cache[idx] == "Rep"
+                    ):
+                        cache_x = torch.cat(
+                            [torch.zeros_like(cache_x).to(cache_x.device), cache_x],
+                            dim=2,
+                        )
+                    if feat_cache[idx] == "Rep":
+                        x = self.time_conv(x)
+                    else:
+                        x = self.time_conv(x, feat_cache[idx])
+                    feat_cache[idx] = cache_x
+                    feat_idx[0] += 1
+
+                    x = x.reshape(b, 2, c, t, h, w)
+                    x = torch.stack((x[:, 0, :, :, :, :], x[:, 1, :, :, :, :]), 3)
+                    x = x.reshape(b, c, t * 2, h, w)
+        t = x.shape[2]
+        x = rearrange(x, "b c t h w -> (b t) c h w")
+        x = self.resample(x)
+        x = rearrange(x, "(b t) c h w -> b c t h w", t=t)
+
+        if self.mode == "downsample3d":
+            if feat_cache is not None:
+                idx = feat_idx[0]
+                if feat_cache[idx] is None:
+                    feat_cache[idx] = x.clone()
+                    feat_idx[0] += 1
+                else:
+                    cache_x = x[:, :, -1:, :, :].clone()
+                    # if cache_x.shape[2] < 2 and feat_cache[idx] is not None and feat_cache[idx]!='Rep':
+                    #     # cache last frame of last two chunk
+                    #     cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+
+                    x = self.time_conv(
+                        torch.cat([feat_cache[idx][:, :, -1:, :, :], x], 2)
+                    )
+                    feat_cache[idx] = cache_x
+                    feat_idx[0] += 1
+        return x
+
+    def init_weight(self, conv):
+        conv_weight = conv.weight
+        nn.init.zeros_(conv_weight)
+        c1, c2, t, h, w = conv_weight.size()
+        one_matrix = torch.eye(c1, c2)
+        init_matrix = one_matrix
+        nn.init.zeros_(conv_weight)
+        # conv_weight.data[:,:,-1,1,1] = init_matrix * 0.5
+        conv_weight.data[:, :, 1, 0, 0] = init_matrix  # * 0.5
+        conv.weight.data.copy_(conv_weight)
+        nn.init.zeros_(conv.bias.data)
+
+    def init_weight2(self, conv):
+        conv_weight = conv.weight.data
+        nn.init.zeros_(conv_weight)
+        c1, c2, t, h, w = conv_weight.size()
+        init_matrix = torch.eye(c1 // 2, c2)
+        # init_matrix = repeat(init_matrix, 'o ... -> (o 2) ...').permute(1,0,2).contiguous().reshape(c1,c2)
+        conv_weight[: c1 // 2, :, -1, 0, 0] = init_matrix
+        conv_weight[c1 // 2 :, :, -1, 0, 0] = init_matrix
+        conv.weight.data.copy_(conv_weight)
+        nn.init.zeros_(conv.bias.data)
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, in_dim, out_dim, dropout=0.0):
+        super().__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+
+        # layers
+        self.residual = nn.Sequential(
+            RMS_norm(in_dim, images=False),
+            nn.SiLU(),
+            CausalConv3d(in_dim, out_dim, 3, padding=1),
+            RMS_norm(out_dim, images=False),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+            CausalConv3d(out_dim, out_dim, 3, padding=1),
+        )
+        self.shortcut = (
+            CausalConv3d(in_dim, out_dim, 1) if in_dim != out_dim else nn.Identity()
+        )
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        h = self.shortcut(x)
+        for layer in self.residual:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    # cache last frame of last two chunk
+                    cache_x = torch.cat(
+                        [
+                            feat_cache[idx][:, :, -1, :, :]
+                            .unsqueeze(2)
+                            .to(cache_x.device),
+                            cache_x,
+                        ],
+                        dim=2,
+                    )
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x + h
+
+
+class AttentionBlock(nn.Module):
+    """
+    Causal self-attention with a single head.
+    """
+
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+        # layers
+        self.norm = RMS_norm(dim)
+        self.to_qkv = nn.Conv2d(dim, dim * 3, 1)
+        self.proj = nn.Conv2d(dim, dim, 1)
+
+        # zero out the last layer params
+        nn.init.zeros_(self.proj.weight)
+
+    def forward(self, x):
+        identity = x
+        b, c, t, h, w = x.size()
+        x = rearrange(x, "b c t h w -> (b t) c h w")
+        x = self.norm(x)
+        # compute query, key, value
+        q, k, v = (
+            self.to_qkv(x)
+            .reshape(b * t, 1, c * 3, -1)
+            .permute(0, 1, 3, 2)
+            .contiguous()
+            .chunk(3, dim=-1)
+        )
+
+        # apply attention
+        x = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+        )
+        x = x.squeeze(1).permute(0, 2, 1).reshape(b * t, c, h, w)
+
+        # output
+        x = self.proj(x)
+        x = rearrange(x, "(b t) c h w-> b c t h w", t=t)
+        return x + identity
+
+
+class Encoder3d(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[True, True, False],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_downsample = temperal_downsample
+
+        # dimensions
+        dims = [dim * u for u in [1] + dim_mult]
+        scale = 1.0
+
+        # init block
+        self.conv1 = CausalConv3d(3, dims[0], 3, padding=1)
+
+        # downsample blocks
+        downsamples = []
+        for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            # residual (+attention) blocks
+            for _ in range(num_res_blocks):
+                downsamples.append(ResidualBlock(in_dim, out_dim, dropout))
+                if scale in attn_scales:
+                    downsamples.append(AttentionBlock(out_dim))
+                in_dim = out_dim
+
+            # downsample block
+            if i != len(dim_mult) - 1:
+                mode = "downsample3d" if temperal_downsample[i] else "downsample2d"
+                downsamples.append(Resample(out_dim, mode=mode))
+                scale /= 2.0
+        self.downsamples = nn.Sequential(*downsamples)
+
+        # middle blocks
+        self.middle = nn.Sequential(
+            ResidualBlock(out_dim, out_dim, dropout),
+            AttentionBlock(out_dim),
+            ResidualBlock(out_dim, out_dim, dropout),
+        )
+
+        # output blocks
+        self.head = nn.Sequential(
+            RMS_norm(out_dim, images=False),
+            nn.SiLU(),
+            CausalConv3d(out_dim, z_dim, 3, padding=1),
+        )
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        if feat_cache is not None:
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:, :, :].clone()
+            if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                # cache last frame of last two chunk
+                cache_x = torch.cat(
+                    [
+                        feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device),
+                        cache_x,
+                    ],
+                    dim=2,
+                )
+            x = self.conv1(x, feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = self.conv1(x)
+
+        # downsamples
+        for layer in self.downsamples:
+            if feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # middle
+        for layer in self.middle:
+            if isinstance(layer, ResidualBlock) and feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # head
+        for layer in self.head:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    # cache last frame of last two chunk
+                    cache_x = torch.cat(
+                        [
+                            feat_cache[idx][:, :, -1, :, :]
+                            .unsqueeze(2)
+                            .to(cache_x.device),
+                            cache_x,
+                        ],
+                        dim=2,
+                    )
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x
+
+
+class Decoder3d(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_upsample=[False, True, True],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_upsample = temperal_upsample
+
+        # dimensions
+        dims = [dim * u for u in [dim_mult[-1]] + dim_mult[::-1]]
+        scale = 1.0 / 2 ** (len(dim_mult) - 2)
+
+        # init block
+        self.conv1 = CausalConv3d(z_dim, dims[0], 3, padding=1)
+
+        # middle blocks
+        self.middle = nn.Sequential(
+            ResidualBlock(dims[0], dims[0], dropout),
+            AttentionBlock(dims[0]),
+            ResidualBlock(dims[0], dims[0], dropout),
+        )
+
+        # upsample blocks
+        upsamples = []
+        for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            # residual (+attention) blocks
+            if i == 1 or i == 2 or i == 3:
+                in_dim = in_dim // 2
+            for _ in range(num_res_blocks + 1):
+                upsamples.append(ResidualBlock(in_dim, out_dim, dropout))
+                if scale in attn_scales:
+                    upsamples.append(AttentionBlock(out_dim))
+                in_dim = out_dim
+
+            # upsample block
+            if i != len(dim_mult) - 1:
+                mode = "upsample3d" if temperal_upsample[i] else "upsample2d"
+                upsamples.append(Resample(out_dim, mode=mode))
+                scale *= 2.0
+        self.upsamples = nn.Sequential(*upsamples)
+
+        # output blocks
+        self.head = nn.Sequential(
+            RMS_norm(out_dim, images=False),
+            nn.SiLU(),
+            CausalConv3d(out_dim, 3, 3, padding=1),
+        )
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        # conv1
+        if feat_cache is not None:
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:, :, :].clone()
+            if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                # cache last frame of last two chunk
+                cache_x = torch.cat(
+                    [
+                        feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device),
+                        cache_x,
+                    ],
+                    dim=2,
+                )
+            x = self.conv1(x, feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = self.conv1(x)
+
+        # middle
+        for layer in self.middle:
+            if isinstance(layer, ResidualBlock) and feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # upsamples
+        for layer in self.upsamples:
+            if feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        # head
+        for layer in self.head:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    # cache last frame of last two chunk
+                    cache_x = torch.cat(
+                        [
+                            feat_cache[idx][:, :, -1, :, :]
+                            .unsqueeze(2)
+                            .to(cache_x.device),
+                            cache_x,
+                        ],
+                        dim=2,
+                    )
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x
+
+
+def count_conv3d(model):
+    count = 0
+    for m in model.modules():
+        if isinstance(m, CausalConv3d):
+            count += 1
+    return count
+
+
+class WanVAE_(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[True, True, False],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_downsample = temperal_downsample
+        self.temperal_upsample = temperal_downsample[::-1]
+
+        # modules
+        self.encoder = Encoder3d(
+            dim,
+            z_dim * 2,
+            dim_mult,
+            num_res_blocks,
+            attn_scales,
+            self.temperal_downsample,
+            dropout,
+        )
+        self.conv1 = CausalConv3d(z_dim * 2, z_dim * 2, 1)
+        self.conv2 = CausalConv3d(z_dim, z_dim, 1)
+        self.decoder = Decoder3d(
+            dim,
+            z_dim,
+            dim_mult,
+            num_res_blocks,
+            attn_scales,
+            self.temperal_upsample,
+            dropout,
+        )
+        self.first_batch = True
+
+    def forward(self, x):
+        mu, log_var = self.encode(x)
+        z = self.reparameterize(mu, log_var)
+        x_recon = self.decode(z)
+        return x_recon, mu, log_var
+
+    def encode(self, x, scale):
+        self.clear_cache()
+        # cache
+        t = x.shape[2]
+        iter_ = 1 + (t - 1) // 4
+        # 对encode输入的x，按时间拆分为1、4、4、4....
+        for i in range(iter_):
+            self._enc_conv_idx = [0]
+            if i == 0:
+                out = self.encoder(
+                    x[:, :, :1, :, :],
+                    feat_cache=self._enc_feat_map,
+                    feat_idx=self._enc_conv_idx,
+                )
+            else:
+                out_ = self.encoder(
+                    x[:, :, 1 + 4 * (i - 1) : 1 + 4 * i, :, :],
+                    feat_cache=self._enc_feat_map,
+                    feat_idx=self._enc_conv_idx,
+                )
+                out = torch.cat([out, out_], 2)
+        mu, log_var = self.conv1(out).chunk(2, dim=1)
+        if isinstance(scale[0], torch.Tensor):
+            mu = (mu - scale[0].view(1, self.z_dim, 1, 1, 1)) * scale[1].view(
+                1, self.z_dim, 1, 1, 1
+            )
+        else:
+            mu = (mu - scale[0]) * scale[1]
+        self.clear_cache()
+        return mu
+
+    def stream_encode(self, x):
+        # cache
+        t = x.shape[2]
+        if self.first_batch:
+            self.clear_cache_encode()
+            self._enc_conv_idx = [0]
+            out = self.encoder(
+                x[:, :, :1, :, :],
+                feat_cache=self._enc_feat_map,
+                feat_idx=self._enc_conv_idx,
+            )
+            self._enc_conv_idx = [0]
+            out_ = self.encoder(
+                x[:, :, 1:, :, :],
+                feat_cache=self._enc_feat_map,
+                feat_idx=self._enc_conv_idx,
+            )
+            out = torch.cat([out, out_], 2)
+        else:
+            out = []
+            for i in range(t // 4):
+                self._enc_conv_idx = [0]
+                out.append(
+                    self.encoder(
+                        x[:, :, i * 4 : (i + 1) * 4, :, :],
+                        feat_cache=self._enc_feat_map,
+                        feat_idx=self._enc_conv_idx,
+                    )
+                )
+            out = torch.cat(out, 2)
+        mu, log_var = self.conv1(out).chunk(2, dim=1)
+        # self.clear_cache()
+        return mu
+
+    def decode(self, z, scale):
+        self.clear_cache()
+        # z: [b,c,t,h,w]
+        if isinstance(scale[0], torch.Tensor):
+            z = z / scale[1].view(1, self.z_dim, 1, 1, 1) + scale[0].view(
+                1, self.z_dim, 1, 1, 1
+            )
+        else:
+            z = z / scale[1] + scale[0]
+        iter_ = z.shape[2]
+        x = self.conv2(z)
+        for i in range(iter_):
+            self._conv_idx = [0]
+            if i == 0:
+                out = self.decoder(
+                    x[:, :, i : i + 1, :, :],
+                    feat_cache=self._feat_map,
+                    feat_idx=self._conv_idx,
+                )
+            else:
+                out_ = self.decoder(
+                    x[:, :, i : i + 1, :, :],
+                    feat_cache=self._feat_map,
+                    feat_idx=self._conv_idx,
+                )
+                out = torch.cat([out, out_], 2)
+        self.clear_cache()
+        return out
+
+    def stream_decode(self, z, scale):
+        # z: [b,c,t,h,w]
+        t = z.shape[2]
+        if isinstance(scale[0], torch.Tensor):
+            z = z / scale[1].view(1, self.z_dim, 1, 1, 1) + scale[0].view(
+                1, self.z_dim, 1, 1, 1
+            )
+        else:
+            z = z / scale[1] + scale[0]
+        x = self.conv2(z)
+        if self.first_batch:
+            self.clear_cache_decode()
+            self.first_batch = False
+            self._conv_idx = [0]
+            out = self.decoder(
+                x[:, :, :1, :, :],
+                feat_cache=self._feat_map,
+                feat_idx=self._conv_idx,
+            )
+            self._conv_idx = [0]
+            out_ = self.decoder(
+                x[:, :, 1:, :, :],
+                feat_cache=self._feat_map,
+                feat_idx=self._conv_idx,
+            )
+            out = torch.cat([out, out_], 2)
+        else:
+            out = []
+            for i in range(t):
+                self._conv_idx = [0]
+                out.append(
+                    self.decoder(
+                        x[:, :, i : (i + 1), :, :],
+                        feat_cache=self._feat_map,
+                        feat_idx=self._conv_idx,
+                    )
+                )
+            out = torch.cat(out, 2)
+        # self.clear_cache()
+        return out
+
+    def reparameterize(self, mu, log_var):
+        std = torch.exp(0.5 * log_var)
+        eps = torch.randn_like(std)
+        return eps * std + mu
+
+    def sample(self, imgs, deterministic=False):
+        mu, log_var = self.encode(imgs)
+        if deterministic:
+            return mu
+        std = torch.exp(0.5 * log_var.clamp(-30.0, 20.0))
+        return mu + std * torch.randn_like(std)
+
+    def clear_cache(self):
+        self._conv_num = count_conv3d(self.decoder)
+        self._conv_idx = [0]
+        self._feat_map = [None] * self._conv_num
+        # cache encode
+        self._enc_conv_num = count_conv3d(self.encoder)
+        self._enc_conv_idx = [0]
+        self._enc_feat_map = [None] * self._enc_conv_num
+
+    def clear_cache_decode(self):
+        self._conv_num = count_conv3d(self.decoder)
+        self._conv_idx = [0]
+        self._feat_map = [None] * self._conv_num
+
+    def clear_cache_encode(self):
+        self._enc_conv_num = count_conv3d(self.encoder)
+        self._enc_conv_idx = [0]
+        self._enc_feat_map = [None] * self._enc_conv_num
+
+
+def _video_vae(pretrained_path=None, z_dim=None, device="cpu", **kwargs):
+    """
+    Autoencoder3d adapted from Stable Diffusion 1.x, 2.x and XL.
+    """
+    # params
+    cfg = dict(
+        dim=96,
+        z_dim=z_dim,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[False, True, True],
+        dropout=0.0,
+    )
+    cfg.update(**kwargs)
+
+    # init model
+    with torch.device("meta"):
+        model = WanVAE_(**cfg)
+
+    # load checkpoint
+    logging.info(f"loading {pretrained_path}")
+    model.load_state_dict(torch.load(pretrained_path, map_location=device), assign=True)
+
+    return model
+
+
+class WanVAE:
+    def __init__(
+        self,
+        z_dim=16,
+        vae_pth="cache/vae_step_411000.pth",
+        dtype=torch.float,
+        device="cuda",
+    ):
+        self.dtype = dtype
+        self.device = device
+
+        mean = [
+            -0.7571,
+            -0.7089,
+            -0.9113,
+            0.1075,
+            -0.1745,
+            0.9653,
+            -0.1517,
+            1.5508,
+            0.4134,
+            -0.0715,
+            0.5517,
+            -0.3632,
+            -0.1922,
+            -0.9497,
+            0.2503,
+            -0.2921,
+        ]
+        std = [
+            2.8184,
+            1.4541,
+            2.3275,
+            2.6558,
+            1.2196,
+            1.7708,
+            2.6052,
+            2.0743,
+            3.2687,
+            2.1526,
+            2.8652,
+            1.5579,
+            1.6382,
+            1.1253,
+            2.8251,
+            1.9160,
+        ]
+        self.mean = torch.tensor(mean, dtype=dtype, device=device)
+        self.std = torch.tensor(std, dtype=dtype, device=device)
+        self.scale = [self.mean, 1.0 / self.std]
+
+        # init model
+        self.model = (
+            _video_vae(
+                pretrained_path=vae_pth,
+                z_dim=z_dim,
+            )
+            .eval()
+            .requires_grad_(False)
+            .to(device)
+        )
+
+    def encode(self, videos):
+        """
+        videos: A list of videos each with shape [C, T, H, W].
+        """
+        with amp.autocast(dtype=self.dtype):
+            return [
+                self.model.encode(u.unsqueeze(0), self.scale).float().squeeze(0)
+                for u in videos
+            ]
+
+    def decode(self, zs):
+        with amp.autocast(dtype=self.dtype):
+            return [
+                self.model.decode(u.unsqueeze(0), self.scale)
+                .float()
+                .clamp_(-1, 1)
+                .squeeze(0)
+                for u in zs
+            ]

--- a/src/scope/core/pipelines/wan2_1/vae/wan.py
+++ b/src/scope/core/pipelines/wan2_1/vae/wan.py
@@ -1,0 +1,173 @@
+"""Unified Wan VAE wrapper with streaming and batch encoding/decoding."""
+
+import os
+
+import torch
+
+from .constants import WAN_VAE_LATENT_MEAN, WAN_VAE_LATENT_STD
+from .modules.vae import _video_vae
+
+# Default filename for standard Wan2.1 VAE checkpoint
+DEFAULT_VAE_FILENAME = "Wan2.1_VAE.pth"
+
+
+class WanVAEWrapper(torch.nn.Module):
+    """Unified VAE wrapper for Wan2.1 models.
+
+    This VAE supports both streaming (cached) and batch encoding/decoding modes.
+    Normalization is always applied during encoding for consistent latent distributions.
+    """
+
+    def __init__(
+        self,
+        model_dir: str = "wan_models",
+        model_name: str = "Wan2.1-T2V-1.3B",
+        vae_path: str | None = None,
+    ):
+        super().__init__()
+
+        # Determine paths with priority: explicit vae_path > model_dir/model_name default
+        if vae_path is None:
+            vae_path = os.path.join(model_dir, model_name, DEFAULT_VAE_FILENAME)
+
+        self.register_buffer(
+            "mean", torch.tensor(WAN_VAE_LATENT_MEAN, dtype=torch.float32)
+        )
+        self.register_buffer(
+            "std", torch.tensor(WAN_VAE_LATENT_STD, dtype=torch.float32)
+        )
+        self.z_dim = 16
+
+        self.model = (
+            _video_vae(
+                pretrained_path=vae_path,
+                z_dim=self.z_dim,
+            )
+            .eval()
+            .requires_grad_(False)
+        )
+
+    def _get_scale(self, device: torch.device, dtype: torch.dtype) -> list:
+        """Get normalization scale parameters on the correct device/dtype."""
+        return [
+            self.mean.to(device=device, dtype=dtype),
+            1.0 / self.std.to(device=device, dtype=dtype),
+        ]
+
+    def _apply_encoding_normalization(
+        self, latent: torch.Tensor, scale: list
+    ) -> torch.Tensor:
+        """Apply normalization to encoded latents."""
+        if isinstance(scale[0], torch.Tensor):
+            return (latent - scale[0].view(1, self.z_dim, 1, 1, 1)) * scale[1].view(
+                1, self.z_dim, 1, 1, 1
+            )
+        return (latent - scale[0]) * scale[1]
+
+    def _create_encoder_cache(self) -> list:
+        """Create a fresh encoder feature cache."""
+        return [None] * 55
+
+    def encode_to_latent(
+        self,
+        pixel: torch.Tensor,
+        use_cache: bool = True,
+        feat_cache: list | None = None,
+    ) -> torch.Tensor:
+        """Encode video pixels to latents.
+
+        Args:
+            pixel: Input video tensor [batch, channels, frames, height, width]
+            use_cache: If True, use streaming encode (maintains cache state).
+                      If False, use batch encode with a temporary cache.
+            feat_cache: Optional external cache. If provided, this cache is used
+                       instead of the internal streaming cache, allowing one-time
+                       encodes without affecting the streaming state (e.g., for
+                       re-encoding the first frame in Krea pipeline).
+
+        Returns:
+            Latent tensor [batch, frames, channels, height, width]
+        """
+        device, dtype = pixel.device, pixel.dtype
+        scale = self._get_scale(device, dtype)
+
+        if use_cache and feat_cache is None:
+            # Streaming encode - cache is maintained across calls
+            latent = self.model.stream_encode(pixel)
+            # Apply normalization (stream_encode returns unnormalized)
+            latent = self._apply_encoding_normalization(latent, scale)
+        else:
+            # Batch encode with one-time cache (does not affect streaming state)
+            # Use provided cache or create a temporary one
+            cache = (
+                feat_cache if feat_cache is not None else self._create_encoder_cache()
+            )
+            latent = self._encode_with_cache(pixel, scale, cache)
+
+        # [batch, channels, frames, h, w] -> [batch, frames, channels, h, w]
+        return latent.permute(0, 2, 1, 3, 4)
+
+    def _encode_with_cache(
+        self, x: torch.Tensor, scale: list, feat_cache: list
+    ) -> torch.Tensor:
+        """Encode using an explicit cache without affecting internal streaming state.
+
+        This follows the approach from the spike branch where the cache is passed
+        explicitly, allowing one-time encodes for operations like first-frame
+        re-encoding without clearing the streaming cache.
+        """
+        t = x.shape[2]
+        iter_ = 1 + (t - 1) // 4
+
+        for i in range(iter_):
+            conv_idx = [0]
+            if i == 0:
+                out = self.model.encoder(
+                    x[:, :, :1, :, :],
+                    feat_cache=feat_cache,
+                    feat_idx=conv_idx,
+                )
+            else:
+                out_ = self.model.encoder(
+                    x[:, :, 1 + 4 * (i - 1) : 1 + 4 * i, :, :],
+                    feat_cache=feat_cache,
+                    feat_idx=conv_idx,
+                )
+                out = torch.cat([out, out_], 2)
+
+        mu, _ = self.model.conv1(out).chunk(2, dim=1)
+        # Apply normalization
+        return self._apply_encoding_normalization(mu, scale)
+
+    def decode_to_pixel(
+        self, latent: torch.Tensor, use_cache: bool = True
+    ) -> torch.Tensor:
+        """Decode latents to video pixels.
+
+        Args:
+            latent: Latent tensor [batch, frames, channels, height, width]
+            use_cache: If True, use streaming decode (maintains cache state).
+                      If False, use batch decode (clears cache before/after).
+
+        Returns:
+            Video tensor [batch, frames, channels, height, width] in range [-1, 1]
+        """
+        # [batch, frames, channels, h, w] -> [batch, channels, frames, h, w]
+        zs = latent.permute(0, 2, 1, 3, 4)
+        zs = zs.to(torch.bfloat16).to("cuda")
+
+        device, dtype = latent.device, latent.dtype
+        scale = self._get_scale(device, dtype)
+
+        if use_cache:
+            output = self.model.stream_decode(zs, scale)
+        else:
+            output = self.model.decode(zs, scale)
+
+        output = output.float().clamp_(-1, 1)
+        # [batch, channels, frames, h, w] -> [batch, frames, channels, h, w]
+        return output.permute(0, 2, 1, 3, 4)
+
+    def clear_cache(self):
+        """Clear encoder/decoder cache for next sequence."""
+        self.model.first_batch = True


### PR DESCRIPTION
Add `base/vae` module with factory pattern for VAE selection.

- New VAE implementations: `KreaRealtimeVideoVAE`, `LongLiveVAE`, `StreamDiffusionV2VAE`
- Factory function `create_vae()` for strategy-based instantiation
- Shared constants for latent normalization

Purely additive - no existing code modified.

Will be utilized in following PRs.