### PR TITLE
fix: use input frame rate for v2v consumption instead of production rate

### DIFF
--- a/src/scope/server/tracks.py
+++ b/src/scope/server/tracks.py
@@ -3,7 +3,6 @@ import fractions
 import logging
 import threading
 import time
-from collections import deque
 
 from aiortc import MediaStreamTrack
 from aiortc.mediastreams import VIDEO_CLOCK_RATE, VIDEO_TIME_BASE, MediaStreamError
@@ -13,10 +12,6 @@ from .frame_processor import FrameProcessor
 from .pipeline_manager import PipelineManager
 
 logger = logging.getLogger(__name__)
-
-# Input FPS measurement constants
-INPUT_FPS_SAMPLE_SIZE = 30  # Number of frame intervals to track
-INPUT_FPS_MIN_SAMPLES = 5  # Minimum samples needed before using input FPS
 
 
 class VideoProcessingTrack(MediaStreamTrack):
@@ -44,21 +39,13 @@ class VideoProcessingTrack(MediaStreamTrack):
         self._paused_lock = threading.Lock()
         self._last_frame = None
 
-        # Input FPS measurement: track timestamps of incoming frames
-        self._input_frame_times = deque(maxlen=INPUT_FPS_SAMPLE_SIZE)
-        self._input_fps_lock = threading.Lock()
-
     async def input_loop(self):
         """Background loop that continuously feeds frames to the processor"""
         while self.input_task_running:
             try:
                 input_frame = await self.track.recv()
 
-                # Track input frame timestamp for FPS measurement
-                with self._input_fps_lock:
-                    self._input_frame_times.append(time.time())
-
-                # Store raw VideoFrame for later processing
+                # Store raw VideoFrame for later processing (tracks input FPS internally)
                 self.frame_processor.put(input_frame)
 
             except asyncio.CancelledError:
@@ -68,30 +55,6 @@ class VideoProcessingTrack(MediaStreamTrack):
                 logger.error(f"Error in input loop, stopping: {e}")
                 self.input_task_running = False
                 break
-
-    def _get_input_fps(self) -> float | None:
-        """Calculate input FPS from recent frame timestamps.
-
-        Returns the measured input FPS if enough samples are available,
-        otherwise returns None to indicate fallback should be used.
-        """
-        with self._input_fps_lock:
-            if len(self._input_frame_times) < INPUT_FPS_MIN_SAMPLES:
-                return None
-
-            # Calculate FPS from frame intervals
-            times = list(self._input_frame_times)
-            if len(times) < 2:
-                return None
-
-            # Time span from first to last frame
-            time_span = times[-1] - times[0]
-            if time_span <= 0:
-                return None
-
-            # FPS = (number of intervals) / time_span
-            num_intervals = len(times) - 1
-            return num_intervals / time_span
 
     # Copied from https://github.com/livepeer/fastworld/blob/e649ef788cd33d78af6d8e1da915cd933761535e/backend/track.py#L267
     async def next_timestamp(self) -> tuple[int, fractions.Fraction]:
@@ -133,9 +96,6 @@ class VideoProcessingTrack(MediaStreamTrack):
     def initialize_input_processing(self, track: MediaStreamTrack):
         self.track = track
         self.input_task_running = True
-        # Clear input frame times for fresh FPS measurement
-        with self._input_fps_lock:
-            self._input_frame_times.clear()
         self.input_task = asyncio.create_task(self.input_loop())
 
     async def recv(self) -> VideoFrame:
@@ -144,13 +104,10 @@ class VideoProcessingTrack(MediaStreamTrack):
         self.initialize_output_processing()
         while self.input_task_running:
             try:
-                # Update FPS: prefer input FPS measurement, fall back to FrameProcessor
-                input_fps = self._get_input_fps()
-                if input_fps is not None:
-                    self.fps = input_fps
-                elif self.frame_processor:
-                    self.fps = self.frame_processor.get_current_pipeline_fps()
-                self.frame_ptime = 1.0 / self.fps
+                # Update FPS: use minimum of input FPS and pipeline FPS
+                if self.frame_processor:
+                    self.fps = self.frame_processor.get_output_fps()
+                    self.frame_ptime = 1.0 / self.fps
 
                 # If paused, wait for the appropriate frame interval before returning
                 with self._paused_lock:
@@ -203,9 +160,5 @@ class VideoProcessingTrack(MediaStreamTrack):
 
         if self.frame_processor is not None:
             self.frame_processor.stop()
-
-        # Clear input frame times
-        with self._input_fps_lock:
-            self._input_frame_times.clear()
 
         await super().stop()


### PR DESCRIPTION
## Summary
Fix v2v streaming choppiness when using fast VAEs (LightVAE/TAE) by basing frame consumption rate on measured input FPS rather than pipeline production throughput. This fix is required to introduce faster VAEs and likely other performance enhancements.

## Problem
LightVAE and TAE produced choppy playback during v2v streaming, where the boundaries of the chunks are visible. The slower Wan VAE worked perfectly. Symptoms:
- Choppiness only with fast VAEs
- Test scripts produced smooth output
- Choppiness went away after ~45 seconds or when using more denoise steps
- Choppiness _sometimes_ went away upon updating the prompt
- Lightvae and Wan vae are virtually identical apart from processing speed. Tae is faster still

## Root Cause
The frame consumption rate (how fast WebRTC sends frames to the client) was calculated from **production throughput** (how fast the GPU produces frames) rather than **content temporal rate** (how fast frames should be played).

Eg, when a fast VAE produces 12 frames in 0.3s, the code calculated FPS=40 and sent frames to the client at 40fps. But the video content should maintain its original temporal rate for correct motion - playing it faster causes choppy/jerky appearance.

The test scripts worked because they export with a fixed FPS value, not the production rate.

## Solution
Measure the actual input video frame rate by tracking timestamps of incoming frames, then use that rate for consumption:
- Track timestamps of last 30 incoming frames in `input_loop()`
- Calculate input FPS from frame intervals
- Use input FPS when available (>=5 samples)
- Fall back to existing pipeline FPS calculation otherwise (for t2v mode or during warm-up)

## Tested
- [x] no regression with Wan VAE