### PR TITLE
Fix Temporal Consistency Bug in reward_forcing v2v Mode

### DIFF
--- a/src/scope/core/pipelines/reward_forcing/blocks/__init__.py
+++ b/src/scope/core/pipelines/reward_forcing/blocks/__init__.py
@@ -1,0 +1,5 @@
+from .prepare_next_pixel import PrepareNextPixelFrameBlock
+
+__all__ = [
+    "PrepareNextPixelFrameBlock",
+]

--- a/src/scope/core/pipelines/reward_forcing/blocks/prepare_next_pixel.py
+++ b/src/scope/core/pipelines/reward_forcing/blocks/prepare_next_pixel.py
@@ -1,0 +1,78 @@
+from typing import Any
+
+import torch
+from diffusers.modular_pipelines import (
+    ModularPipelineBlocks,
+    PipelineState,
+)
+from diffusers.modular_pipelines.modular_pipeline_utils import (
+    ComponentSpec,
+    ConfigSpec,
+    InputParam,
+    OutputParam,
+)
+
+
+class PrepareNextPixelFrameBlock(ModularPipelineBlocks):
+    @property
+    def expected_components(self) -> list[ComponentSpec]:
+        return [
+            ComponentSpec("generator", torch.nn.Module),
+        ]
+
+    @property
+    def expected_configs(self) -> list[ConfigSpec]:
+        return [
+            ConfigSpec("num_frame_per_block", 3),
+        ]
+
+    @property
+    def description(self) -> str:
+        return "Prepare Next block for reward_forcing that tracks pixel frames instead of latent frames for proper v2v temporal alignment"
+
+    @property
+    def inputs(self) -> list[InputParam]:
+        return [
+            InputParam(
+                "current_start_frame",
+                required=True,
+                type_hint=int,
+                description="Current starting frame index of current block",
+            ),
+            InputParam(
+                "latents",
+                required=True,
+                type_hint=torch.Tensor,
+                description="Denoised latents",
+            ),
+            InputParam(
+                "output_video",
+                required=True,
+                type_hint=torch.Tensor,
+                description="Decoded video frames",
+            ),
+        ]
+
+    @property
+    def intermediate_outputs(self) -> list[OutputParam]:
+        return [
+            OutputParam(
+                "current_start_frame",
+                type_hint=int,
+                description="Current starting frame index of current block",
+            ),
+        ]
+
+    @torch.no_grad()
+    def __call__(self, components, state: PipelineState) -> tuple[Any, PipelineState]:
+        block_state = self.get_block_state(state)
+
+        _, _, num_output_frames, _, _ = block_state.output_video.shape
+        # Track pixel frames (not latent frames) for proper v2v temporal alignment.
+        # VAE expands latents to pixels (4 latent → 13 pixel on first batch,
+        # 3 latent → 12 pixel on subsequent batches), so we must track pixel space
+        # to align with input video chunk extraction.
+        block_state.current_start_frame += num_output_frames
+
+        self.set_block_state(state, block_state)
+        return components, state

--- a/src/scope/core/pipelines/reward_forcing/modular_blocks.py
+++ b/src/scope/core/pipelines/reward_forcing/modular_blocks.py
@@ -9,18 +9,19 @@ from ..wan2_1.blocks import (
     DecodeBlock,
     DenoiseBlock,
     EmbeddingBlendingBlock,
-    PrepareNextBlock,
     SetTimestepsBlock,
     SetTransformerBlocksLocalAttnSizeBlock,
     SetupCachesBlock,
     TextConditioningBlock,
 )
+from .blocks import PrepareNextPixelFrameBlock
 
 logger = diffusers_logging.get_logger(__name__)
 
 # Main pipeline blocks with multi-mode support (text-to-video and video-to-video)
 # AutoPreprocessVideoBlock: Routes to video preprocessing when 'video' input provided
 # AutoPrepareLatentsBlock: Routes to PrepareVideoLatentsBlock or PrepareLatentsBlock
+# PrepareNextPixelFrameBlock: reward_forcing-specific block that tracks pixel frames for proper v2v alignment
 ALL_BLOCKS = InsertableDict(
     [
         ("text_conditioning", TextConditioningBlock),
@@ -36,7 +37,7 @@ ALL_BLOCKS = InsertableDict(
         ("denoise", DenoiseBlock),
         ("clean_kv_cache", CleanKVCacheBlock),
         ("decode", DecodeBlock),
-        ("prepare_next", PrepareNextBlock),
+        ("prepare_next", PrepareNextPixelFrameBlock),
     ]
 )
 


### PR DESCRIPTION
### Problem
The reward_forcing pipeline had a temporal consistency bug in video-to-video (v2v) mode where `current_start_frame` tracked latent frames instead of pixel frames, apparently causing misalignment in temporal tracking.

### Root Cause
The shared `PrepareNextBlock` increments `current_start_frame` by latent frame count, but the VAE temporally expands latents to pixels (e.g., 4 latent frames → 13 pixel frames on first batch, 3 latent frames → 12 pixel frames on subsequent batches).

While `current_start_frame` is used internally by the generator/KV cache in latent space, proper v2v temporal consistency requires tracking the actual number of generated pixel frames for seed generation and state management.

**Note:** longlive may have the same underlying issue but uses `RecacheFramesBlock` which maintains a separate latent buffer that could mask the symptoms.

### Solution
Created reward_forcing-specific `PrepareNextPixelFrameBlock` that:
- Takes `output_video` from `DecodeBlock` as input
- Increments `current_start_frame` by actual pixel frames generated
- Ensures proper temporal tracking aligned with VAE output
- Maintains compatibility with existing generator/KV cache usage

NOTE: A more architectural solution would separate latent vs pixel frame tracking globally, but that requires changes across shared blocks and all pipelines. This could be considered more seriously if we implement another pipeline requiring pixel frame tracking. This pipeline-specific fix achieves the same result with minimal impact.