### PR TITLE
Fix mode switch from text to video

### DIFF
--- a/src/scope/core/pipelines/krea_realtime_video/pipeline.py
+++ b/src/scope/core/pipelines/krea_realtime_video/pipeline.py
@@ -211,6 +211,10 @@ class KreaRealtimeVideoPipeline(Pipeline, LoRAEnabledPipeline):
         if "transition" not in kwargs:
             self.state.set("transition", None)
 
+        # Clear video from state if not provided to prevent stale video data
+        if "video" not in kwargs:
+            self.state.set("video", None)
+
         if self.state.get("denoising_step_list") is None:
             self.state.set("denoising_step_list", DEFAULT_DENOISING_STEP_LIST)
 

--- a/src/scope/core/pipelines/longlive/pipeline.py
+++ b/src/scope/core/pipelines/longlive/pipeline.py
@@ -196,6 +196,10 @@ class LongLivePipeline(Pipeline, LoRAEnabledPipeline):
         if "transition" not in kwargs:
             self.state.set("transition", None)
 
+        # Clear video from state if not provided to prevent stale video data
+        if "video" not in kwargs:
+            self.state.set("video", None)
+
         if self.state.get("denoising_step_list") is None:
             self.state.set("denoising_step_list", DEFAULT_DENOISING_STEP_LIST)
 

--- a/src/scope/core/pipelines/reward_forcing/pipeline.py
+++ b/src/scope/core/pipelines/reward_forcing/pipeline.py
@@ -171,6 +171,10 @@ class RewardForcingPipeline(Pipeline, LoRAEnabledPipeline):
         if "transition" not in kwargs:
             self.state.set("transition", None)
 
+        # Clear video from state if not provided to prevent stale video data
+        if "video" not in kwargs:
+            self.state.set("video", None)
+
         if self.state.get("denoising_step_list") is None:
             self.state.set("denoising_step_list", DEFAULT_DENOISING_STEP_LIST)
 

--- a/src/scope/core/pipelines/streamdiffusionv2/pipeline.py
+++ b/src/scope/core/pipelines/streamdiffusionv2/pipeline.py
@@ -179,6 +179,10 @@ class StreamDiffusionV2Pipeline(Pipeline, LoRAEnabledPipeline):
         if "transition" not in kwargs:
             self.state.set("transition", None)
 
+        # Clear video from state if not provided to prevent stale video data
+        if "video" not in kwargs:
+            self.state.set("video", None)
+
         if self.state.get("denoising_step_list") is None:
             self.state.set("denoising_step_list", DEFAULT_DENOISING_STEP_LIST)
 

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -647,6 +647,10 @@ class FrameProcessor:
                 ):
                     self.parameters.pop("transition", None)
 
+                # Update video mode if input_mode parameter changes
+                if "input_mode" in new_parameters:
+                    self._video_mode = new_parameters.get("input_mode") == "video"
+
                 # Merge new parameters with existing ones to preserve any missing keys
                 self.parameters = {**self.parameters, **new_parameters}
         except queue.Empty:


### PR DESCRIPTION
I encountered the following error when switching from Video to Text mode in the UI for streamdiffusionv2:

```
12:46:08,300 - scope.server.frame_processor - ERROR - Error processing chunk: unsupported operand type(s) for *: 'Tensor' and 'NoneType'
Traceback (most recent call last):
  File "C:\Users\yondo\Development\scope\src\scope\server\frame_processor.py", line 719, in process_chunk
    output = pipeline(**call_params)
  File "C:\Users\yondo\Development\scope\src\scope\core\pipelines\streamdiffusionv2\pipeline.py", line 162, in __call__
    return self._generate(**kwargs)
  File "C:\Users\yondo\Development\scope\src\scope\core\pipelines\streamdiffusionv2\pipeline.py", line 189, in _generate
    _, self.state = self.blocks(self.components, self.state)
  File "C:\Users\yondo\Development\scope\.venv\lib\site-packages\torch\utils\_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "C:\Users\yondo\Development\scope\.venv\lib\site-packages\diffusers\modular_pipelines\modular_pipeline.py", line 917, in __call__
    pipeline, state = block(pipeline, state)
  File "C:\Users\yondo\Development\scope\.venv\lib\site-packages\torch\utils\_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "C:\Users\yondo\Development\scope\.venv\lib\site-packages\diffusers\modular_pipelines\modular_pipeline.py", line 646, in __call__
    return block(pipeline, state)
  File "C:\Users\yondo\Development\scope\.venv\lib\site-packages\torch\utils\_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "C:\Users\yondo\Development\scope\src\scope\core\pipelines\wan2_1\blocks\prepare_video_latents.py", line 129, in __call__
    block_state.latents = noise * block_state.noise_scale + latents * (
TypeError: unsupported operand type(s) for *: 'Tensor' and 'NoneType' please help investigate and fix
```

This PR includes two changes for the fix:
1. When the FrameProcessor receives new parameters check if video is present and if not update the `_video_mode` state.
2. In all pipelines, clear `video` from state if `video` is not included in the parameters to make sure that the pipeline does not rely on stale value of `video` which is important if we switch input modes.