### PR TITLE
Bump to v0.1.0-alpha.9

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daydream-scope-desktop",
   "productName": "Daydream Scope",
-  "version": "0.1.0-rc1",
+  "version": "0.1.0-alpha.9",
   "description": "A tool for running and customizing real-time, interactive generative AI pipelines and models",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daydream-scope-frontend",
-  "version": "0.1.0a8",
+  "version": "0.1.0-alpha.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daydream-scope-frontend",
-      "version": "0.1.0a8",
+      "version": "0.1.0-alpha.9",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daydream-scope-frontend",
   "private": true,
-  "version": "0.1.0a8",
+  "version": "0.1.0-alpha.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream-scope"
-version = "0.1.0a8"
+version = "0.1.0a9"
 description = "A tool for running and customizing real-time, interactive generative AI pipelines and models"
 readme = "README.md"
 requires-python = ">=3.10.12"

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "daydream-scope"
-version = "0.1.0a8"
+version = "0.1.0a9"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
The frontend and Electron app uses semver eg 0.1.0-alpha.9, but the Python project uses 0.1.0a9 which compiles with [PEP 440](https://peps.python.org/pep-0440/) which appears to be more standard in the Python ecosystem.