### PR TITLE
Add initial VACE support for RewardForcing

### DIFF
--- a/frontend/src/components/InputAndControlsPanel.tsx
+++ b/frontend/src/components/InputAndControlsPanel.tsx
@@ -294,37 +294,35 @@ export function InputAndControlsPanel({
         )}
 
         {/* VACE Reference Images - only show when VACE is enabled */}
-        {/* VACE available for LongLive and StreamDiffusion */}
-        {vaceEnabled &&
-          (pipelineId === "longlive" || pipelineId === "streamdiffusionv2") && (
-            <div>
-              <ImageManager
-                images={refImages}
-                onImagesChange={onRefImagesChange || (() => {})}
-                disabled={isDownloading}
-              />
-              {onSendHints && refImages && refImages.length > 0 && (
-                <div className="flex items-center justify-end mt-2">
-                  <Button
-                    onMouseDown={e => {
-                      e.preventDefault();
-                      onSendHints(refImages.filter(img => img));
-                    }}
-                    disabled={isDownloading || !isStreaming}
-                    size="sm"
-                    className="rounded-full w-8 h-8 p-0 bg-black hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                    title={
-                      !isStreaming
-                        ? "Start streaming to send hints"
-                        : "Submit all reference images"
-                    }
-                  >
-                    <ArrowUp className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
-            </div>
-          )}
+        {vaceEnabled && (
+          <div>
+            <ImageManager
+              images={refImages}
+              onImagesChange={onRefImagesChange || (() => {})}
+              disabled={isDownloading}
+            />
+            {onSendHints && refImages && refImages.length > 0 && (
+              <div className="flex items-center justify-end mt-2">
+                <Button
+                  onMouseDown={e => {
+                    e.preventDefault();
+                    onSendHints(refImages.filter(img => img));
+                  }}
+                  disabled={isDownloading || !isStreaming}
+                  size="sm"
+                  className="rounded-full w-8 h-8 p-0 bg-black hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                  title={
+                    !isStreaming
+                      ? "Start streaming to send hints"
+                      : "Submit all reference images"
+                  }
+                >
+                  <ArrowUp className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
 
         <div>
           {(() => {

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -20,7 +20,11 @@ import { Button } from "./ui/button";
 import { Toggle } from "./ui/toggle";
 import { SliderWithInput } from "./ui/slider-with-input";
 import { Hammer, Info, Minus, Plus, RotateCcw } from "lucide-react";
-import { PIPELINES, pipelineSupportsLoRA } from "../data/pipelines";
+import {
+  PIPELINES,
+  pipelineSupportsLoRA,
+  pipelineSupportsVACE,
+} from "../data/pipelines";
 import { PARAMETER_METADATA } from "../data/parameterMetadata";
 import { DenoisingStepsSlider } from "./DenoisingStepsSlider";
 import { useLocalSliderValue } from "../hooks/useLocalSliderValue";
@@ -333,8 +337,7 @@ export function SettingsPanel({
         )}
 
         {/* VACE Toggle */}
-        {/* VACE available for LongLive and StreamDiffusion */}
-        {(pipelineId === "longlive" || pipelineId === "streamdiffusionv2") && (
+        {pipelineSupportsVACE(pipelineId) && (
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-2">
               <LabelWithTooltip

--- a/frontend/src/data/pipelines.ts
+++ b/frontend/src/data/pipelines.ts
@@ -18,6 +18,7 @@ export interface PipelineInfo {
   defaultTemporalInterpolationMethod?: "linear" | "slerp"; // Default method for temporal interpolation
   defaultTemporalInterpolationSteps?: number; // Default number of steps for temporal interpolation
   supportsLoRA?: boolean; // Whether this pipeline supports LoRA adapters
+  supportsVACE?: boolean; // Whether this pipeline supports VACE (Video All-In-One Creation and Editing)
 
   // Multi-mode support
   supportedModes: InputMode[];
@@ -37,6 +38,7 @@ export const PIPELINES: Record<string, PipelineInfo> = {
     defaultTemporalInterpolationMethod: "slerp",
     defaultTemporalInterpolationSteps: 0,
     supportsLoRA: true,
+    supportsVACE: true,
     // Multi-mode support
     supportedModes: ["text", "video"],
     defaultMode: "video",
@@ -53,6 +55,7 @@ export const PIPELINES: Record<string, PipelineInfo> = {
     defaultTemporalInterpolationMethod: "slerp",
     defaultTemporalInterpolationSteps: 0,
     supportsLoRA: true,
+    supportsVACE: true,
     // Multi-mode support
     supportedModes: ["text", "video"],
     defaultMode: "text",
@@ -78,13 +81,14 @@ export const PIPELINES: Record<string, PipelineInfo> = {
     docsUrl:
       "https://github.com/daydreamlive/scope/blob/main/src/scope/core/pipelines/reward_forcing/docs/usage.md",
     about:
-      "A streaming pipeline and autoregressive video diffusion model from ZJU, Ant Group, SIAS-ZJU, HUST and SJTU. The model is trained with Rewarded Distribution Matching Distillation using Wan2.1 1.3b as the base model.",
+      "A streaming pipeline and autoregressive video diffusion model from ZJU, Ant Group, SIAS-ZJU, HUST and SJTU. The model is trained with Rewarded Distribution Matching Distillation using Wan2.1 1.3b as the base model. Includes VACE (All-In-One Video Creation and Editing) for reference image conditioning and structural guidance (depth, flow, pose).",
     modified: true,
     estimatedVram: 20,
     requiresModels: true,
     defaultTemporalInterpolationMethod: "slerp",
     defaultTemporalInterpolationSteps: 0,
     supportsLoRA: true,
+    supportsVACE: true,
     // Multi-mode support
     supportedModes: ["text", "video"],
     defaultMode: "text",
@@ -102,6 +106,10 @@ export const PIPELINES: Record<string, PipelineInfo> = {
 
 export function pipelineSupportsLoRA(pipelineId: string): boolean {
   return PIPELINES[pipelineId]?.supportsLoRA === true;
+}
+
+export function pipelineSupportsVACE(pipelineId: string): boolean {
+  return PIPELINES[pipelineId]?.supportsVACE === true;
 }
 
 export function pipelineSupportsMode(

--- a/src/scope/core/pipelines/longlive/modular_blocks.py
+++ b/src/scope/core/pipelines/longlive/modular_blocks.py
@@ -26,7 +26,7 @@ logger = diffusers_logging.get_logger(__name__)
 # Main pipeline blocks with multi-mode support (text-to-video and video-to-video)
 # AutoPreprocessVideoBlock: Routes to video preprocessing when 'video' input provided
 # AutoPrepareLatentsBlock: Routes to PrepareVideoLatentsBlock or PrepareLatentsBlock
-# VaceEncodingBlock: Encodes VACE context (R2V or depth) for conditioning
+# VaceEncodingBlock: Encodes VACE context for conditioning
 ALL_BLOCKS = InsertableDict(
     [
         ("text_conditioning", TextConditioningBlock),

--- a/src/scope/core/pipelines/longlive/pipeline.py
+++ b/src/scope/core/pipelines/longlive/pipeline.py
@@ -198,17 +198,6 @@ class LongLivePipeline(Pipeline, LoRAEnabledPipeline, VACEEnabledPipeline):
             if self.state.get("manage_cache", True):
                 kwargs["init_cache"] = True
 
-        # Log vace_ref_images before setting into state
-        if "vace_ref_images" in kwargs:
-            ref_images = kwargs.get("vace_ref_images", [])
-            logger.info(
-                f"LongLivePipeline._generate: Setting vace_ref_images into state: "
-                f"count={len(ref_images) if ref_images else 0}, "
-                f"paths={ref_images if ref_images else 'None'}"
-            )
-        else:
-            logger.debug("LongLivePipeline._generate: No ref_images in kwargs")
-
         for k, v in kwargs.items():
             self.state.set(k, v)
 

--- a/src/scope/core/pipelines/reward_forcing/modular_blocks.py
+++ b/src/scope/core/pipelines/reward_forcing/modular_blocks.py
@@ -14,6 +14,7 @@ from ..wan2_1.blocks import (
     SetupCachesBlock,
     TextConditioningBlock,
 )
+from ..wan2_1.vace.blocks import VaceEncodingBlock
 from .blocks import PrepareNextBlock
 
 logger = diffusers_logging.get_logger(__name__)
@@ -21,6 +22,7 @@ logger = diffusers_logging.get_logger(__name__)
 # Main pipeline blocks with multi-mode support (text-to-video and video-to-video)
 # AutoPreprocessVideoBlock: Routes to video preprocessing when 'video' input provided
 # AutoPrepareLatentsBlock: Routes to PrepareVideoLatentsBlock or PrepareLatentsBlock
+# VaceEncodingBlock: Encodes VACE context for conditioning
 ALL_BLOCKS = InsertableDict(
     [
         ("text_conditioning", TextConditioningBlock),
@@ -33,6 +35,7 @@ ALL_BLOCKS = InsertableDict(
             SetTransformerBlocksLocalAttnSizeBlock,
         ),
         ("auto_prepare_latents", AutoPrepareLatentsBlock),
+        ("vace_encoding", VaceEncodingBlock),
         ("denoise", DenoiseBlock),
         ("clean_kv_cache", CleanKVCacheBlock),
         ("decode", DecodeBlock),

--- a/src/scope/core/pipelines/reward_forcing/pipeline.py
+++ b/src/scope/core/pipelines/reward_forcing/pipeline.py
@@ -19,6 +19,7 @@ from ..schema import RewardForcingConfig
 from ..utils import Quantization, load_model_config
 from ..wan2_1.components import WanDiffusionWrapper, WanTextEncoderWrapper
 from ..wan2_1.lora.mixin import LoRAEnabledPipeline
+from ..wan2_1.vace.mixin import VACEEnabledPipeline
 from ..wan2_1.vae import WanVAEWrapper
 from .modular_blocks import RewardForcingBlocks
 from .modules.causal_model import CausalWanModel
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_DENOISING_STEP_LIST = [1000, 750, 500, 250]
 
 
-class RewardForcingPipeline(Pipeline, LoRAEnabledPipeline):
+class RewardForcingPipeline(Pipeline, LoRAEnabledPipeline, VACEEnabledPipeline):
     @classmethod
     def get_config_class(cls) -> type["BasePipelineConfig"]:
         return RewardForcingConfig
@@ -52,7 +53,9 @@ class RewardForcingPipeline(Pipeline, LoRAEnabledPipeline):
         base_model_name = getattr(model_config, "base_model_name", "Wan2.1-T2V-1.3B")
         base_model_kwargs = getattr(model_config, "base_model_kwargs", {})
 
-        # Load generator
+        # Load generator with VACE support via upfront loading
+        # Strategy: Load base model, wrap with VACE (if enabled), then apply LoRA
+        # (VACE loaded before LoRA to ensure correct wrapper ordering)
         start = time.time()
         generator = WanDiffusionWrapper(
             CausalWanModel,
@@ -63,6 +66,12 @@ class RewardForcingPipeline(Pipeline, LoRAEnabledPipeline):
         )
 
         print(f"Loaded diffusion model in {time.time() - start:.3f}s")
+
+        # Apply VACE wrapper if vace_path is configured (upfront loading)
+        # This must happen before LoRA to get correct ordering: LoRA -> VACE -> Base
+        generator.model = self._init_vace(
+            config, generator.model, device=device, dtype=dtype
+        )
 
         # Initialize any additional, user-configured LoRA adapters via shared manager.
         generator.model = self._init_loras(config, generator.model)
@@ -174,6 +183,10 @@ class RewardForcingPipeline(Pipeline, LoRAEnabledPipeline):
         # Clear video from state if not provided to prevent stale video data
         if "video" not in kwargs:
             self.state.set("video", None)
+
+        # Clear vace_ref_images from state if not provided to prevent encoding on chunks where they weren't sent
+        if "vace_ref_images" not in kwargs:
+            self.state.set("vace_ref_images", None)
 
         if self.state.get("denoising_step_list") is None:
             self.state.set("denoising_step_list", DEFAULT_DENOISING_STEP_LIST)

--- a/src/scope/core/pipelines/schema.py
+++ b/src/scope/core/pipelines/schema.py
@@ -386,7 +386,7 @@ class RewardForcingConfig(BasePipelineConfig):
     supported_modes: ClassVar[list[InputMode]] = ["text", "video"]
     default_mode: ClassVar[InputMode] = "text"
 
-    # LongLive defaults (text mode baseline)
+    # RewardForcing defaults (text mode baseline)
     height: int = Field(default=320, ge=1, description="Output height in pixels")
     width: int = Field(default=576, ge=1, description="Output width in pixels")
     denoising_steps: list[int] | None = Field(
@@ -397,6 +397,18 @@ class RewardForcingConfig(BasePipelineConfig):
     noise_scale: Annotated[float, Field(ge=0.0, le=1.0)] | None = Field(
         default=None,
         description="Amount of noise to add during video generation (video mode only)",
+    )
+
+    # VACE (optional reference image conditioning)
+    ref_images: list[str] | None = Field(
+        default=None,
+        description="List of reference image paths for VACE conditioning",
+    )
+    vace_context_scale: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=2.0,
+        description="Scaling factor for VACE hint injection (0.0 to 2.0)",
     )
 
     @classmethod

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -214,7 +214,7 @@ class PipelineManager:
             return False
 
     def _get_vace_checkpoint_path(self) -> str:
-        """Get the path to the VACE checkpoint (required for streamdiffusionv2 and longlive).
+        """Get the path to the VACE checkpoint.
 
         Returns:
             str: Path to VACE checkpoint file
@@ -535,6 +535,16 @@ class PipelineManager:
                     ),
                 }
             )
+
+            # Configure VACE support if enabled in load_params (default: True)
+            vace_enabled = True
+            if load_params:
+                vace_enabled = load_params.get("vace_enabled", True)
+
+            if vace_enabled:
+                self._configure_vace(config, load_params)
+            else:
+                logger.info("VACE disabled by load_params, skipping VACE configuration")
 
             # Apply load parameters (resolution, seed, LoRAs) to config
             self._apply_load_params(


### PR DESCRIPTION
The most notable change here is that the CausalWanModel impl for RewardForcing needed to add a conditional to handle the scenario where `kv_cache` is None which is the case during the forward pass for VACE. LongLive and StreamDiffusionV2 already have this conditional (see [LongLive](https://github.com/daydreamlive/scope/blob/8df66e706cdf7fd6d8afb5469aa9de3bba3367fe/src/scope/core/pipelines/longlive/modules/causal_model.py#L133)).