### PR TITLE
Download and load VACE module instead of full

### DIFF
--- a/src/scope/server/pipeline_artifacts.py
+++ b/src/scope/server/pipeline_artifacts.py
@@ -16,8 +16,8 @@ UMT5_ENCODER_ARTIFACT = HuggingfaceRepoArtifact(
 )
 
 VACE_ARTIFACT = HuggingfaceRepoArtifact(
-    repo_id="Wan-AI/Wan2.1-VACE-1.3B",
-    files=["diffusion_pytorch_model.safetensors"],
+    repo_id="Kijai/WanVideo_comfy",
+    files=["Wan2_1-VACE_module_1_3B_bf16.safetensors"],
 )
 
 # Pipeline-specific artifacts

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -214,15 +214,17 @@ class PipelineManager:
             return False
 
     def _get_vace_checkpoint_path(self) -> str:
-        """Get the path to the VACE checkpoint.
+        """Get the path to the VACE module checkpoint.
 
         Returns:
-            str: Path to VACE checkpoint file
+            str: Path to VACE module checkpoint file (contains only VACE weights)
         """
         from .models_config import get_model_file_path
 
         return str(
-            get_model_file_path("Wan2.1-VACE-1.3B/diffusion_pytorch_model.safetensors")
+            get_model_file_path(
+                "WanVideo_comfy/Wan2_1-VACE_module_1_3B_bf16.safetensors"
+            )
         )
 
     def _configure_vace(self, config: dict, load_params: dict | None = None) -> None:


### PR DESCRIPTION
This updates the download/loading code for VACE to use Kijai's VACE module (from [here](https://huggingface.co/Kijai/WanVideo_comfy)) checkpoint that contains *only* VACE specific weights (in bfloat16).

This means a user only needs to download and load a 1.47GB file instead of the 7.15GB Wan2.1 1.3B + VACE checkpoint from [here](https://huggingface.co/Wan-AI/Wan2.1-VACE-1.3B) - a 80% reduction in data to download and load.

