### PR TITLE
Use global_sink = True for longlive

### DIFF
--- a/src/scope/core/pipelines/longlive/model.yaml
+++ b/src/scope/core/pipelines/longlive/model.yaml
@@ -5,6 +5,7 @@ base_model_kwargs:
 generator_model_name: "generator"
 num_frame_per_block: 3
 local_attn_size: 12
+global_sink: true
 vae_spatial_downsample_factor: 8
 vae_temporal_downsample_factor: 4
 patch_embedding_spatial_downsample_factor: 2

--- a/src/scope/core/pipelines/longlive/modules/causal_model.py
+++ b/src/scope/core/pipelines/longlive/modules/causal_model.py
@@ -108,6 +108,7 @@ class CausalWanSelfAttention(nn.Module):
         kv_cache=None,
         current_start=0,
         cache_start=None,
+        sink_recache_after_switch=False,
     ):
         r"""
         Args:
@@ -319,6 +320,8 @@ class CausalWanSelfAttention(nn.Module):
                     if is_recompute
                     else local_start_index
                 )
+                if sink_recache_after_switch:
+                    write_start_index = local_start_index
                 roped_offset = max(0, write_start_index - local_start_index)
                 write_len = max(0, local_end_index - write_start_index)
                 if write_len > 0:
@@ -363,6 +366,8 @@ class CausalWanSelfAttention(nn.Module):
                     if is_recompute
                     else local_start_index
                 )
+                if sink_recache_after_switch:
+                    write_start_index = local_start_index
                 roped_offset = max(0, write_start_index - local_start_index)
                 write_len = max(0, local_end_index - write_start_index)
                 if write_len > 0:
@@ -483,6 +488,7 @@ class CausalWanAttentionBlock(nn.Module):
         crossattn_cache=None,
         current_start=0,
         cache_start=None,
+        sink_recache_after_switch=False,
     ):
         r"""
         Args:
@@ -512,6 +518,7 @@ class CausalWanAttentionBlock(nn.Module):
             kv_cache,
             current_start,
             cache_start,
+            sink_recache_after_switch,
         )
 
         if kv_cache is not None:
@@ -1054,6 +1061,7 @@ class CausalWanModel(ModelMixin, ConfigMixin):
         crossattn_cache: dict = None,
         current_start: int = 0,
         cache_start: int = 0,
+        sink_recache_after_switch=False,
     ):
         r"""
         Run the diffusion model with kv caching.
@@ -1145,6 +1153,7 @@ class CausalWanModel(ModelMixin, ConfigMixin):
             context=context,
             context_lens=context_lens,
             block_mask=self.block_mask,
+            sink_recache_after_switch=sink_recache_after_switch,
         )
 
         # print("kwargs done")

--- a/src/scope/core/pipelines/wan2_1/components/generator.py
+++ b/src/scope/core/pipelines/wan2_1/components/generator.py
@@ -215,6 +215,7 @@ class WanDiffusionWrapper(torch.nn.Module):
         kv_cache_attention_bias: float = 1.0,
         vace_context: torch.Tensor | None = None,
         vace_context_scale: float = 1.0,
+        sink_recache_after_switch: bool = False,
     ) -> torch.Tensor:
         prompt_embeds = conditional_dict["prompt_embeds"]
 
@@ -240,6 +241,7 @@ class WanDiffusionWrapper(torch.nn.Module):
                 kv_cache_attention_bias=kv_cache_attention_bias,
                 vace_context=vace_context,
                 vace_context_scale=vace_context_scale,
+                sink_recache_after_switch=sink_recache_after_switch,
             ).permute(0, 2, 1, 3, 4)
         else:
             if clean_x is not None:


### PR DESCRIPTION
This PR ports [this commit](https://github.com/NVlabs/LongLive/commit/7b56712800769ec73c80e9ce731730449c67d587) into the longlive pipeline. It also introduces the `global_sink` config var and defaults it to True. After reviewing the discussion in https://github.com/NVlabs/LongLive/pull/21 and running a few quick tests it seems that preserving sink tokens during frame recache (when global_sink = True) leads to better coherence with the start of the video.