### PR TITLE
Fix evicting oldest non-sink tokens in reward-forcing

### DIFF
--- a/src/scope/core/pipelines/reward_forcing/modules/causal_model.py
+++ b/src/scope/core/pipelines/reward_forcing/modules/causal_model.py
@@ -208,8 +208,8 @@ class CausalWanSelfAttention(nn.Module):
                 num_evicted_tokens = num_new_tokens + kv_cache["local_end_index"].item() - kv_cache_size
                 num_rolled_tokens = kv_cache["local_end_index"].item() - num_evicted_tokens - total_sink_tokens
 
-                evicted_start = total_sink_tokens + num_rolled_tokens
-                evicted_end = total_sink_tokens + num_rolled_tokens + num_evicted_tokens
+                evicted_start = total_sink_tokens
+                evicted_end = total_sink_tokens + num_evicted_tokens
                 evicted_k = kv_cache["k"][:, evicted_start:evicted_end].clone()
                 evicted_v = kv_cache["v"][:, evicted_start:evicted_end].clone()
                 evicted_tokens_exist = True


### PR DESCRIPTION
This PR ports [this commit](https://github.com/JaydenLyh/Reward-Forcing/commit/4317f5a0d29d1cee6a0f2e80ed5f5724bee97c66) for the reward-forcing pipeline. After reviewing the discussion in https://github.com/JaydenLyh/Reward-Forcing/issues/5 it seems that the proper strategy here is to evict the oldest non-sink tokens.