### PR TITLE
Use explicit media_type when serving frontend

### DIFF
--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -831,7 +831,27 @@ async def serve_frontend(request: Request, path: str):
     # Check if requesting a specific file that exists
     file_path = frontend_dist / path
     if file_path.exists() and file_path.is_file():
-        return FileResponse(file_path)
+        # Determine media type based on extension to fix MIME type issues on Windows
+        file_extension = file_path.suffix.lower()
+        media_types = {
+            ".js": "application/javascript",
+            ".mjs": "application/javascript",
+            ".css": "text/css",
+            ".html": "text/html",
+            ".json": "application/json",
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".gif": "image/gif",
+            ".svg": "image/svg+xml",
+            ".ico": "image/x-icon",
+            ".woff": "font/woff",
+            ".woff2": "font/woff2",
+            ".ttf": "font/ttf",
+            ".eot": "application/vnd.ms-fontobject",
+        }
+        media_type = media_types.get(file_extension)
+        return FileResponse(file_path, media_type=media_type)
 
     # Fallback to index.html for SPA routing
     # This ensures clients like Electron alway fetch the latest HTML (which references hashed assets)
@@ -839,6 +859,7 @@ async def serve_frontend(request: Request, path: str):
     if index_file.exists():
         return FileResponse(
             index_file,
+            media_type="text/html",
             headers={
                 "Cache-Control": "no-cache, no-store, must-revalidate",
                 "Pragma": "no-cache",


### PR DESCRIPTION
# Background

A user on Windows encountered an issue where the browser/desktop app just displayed a black screen and they saw the following in the browser dev tools console:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/plain". Strict MIME type checking is enforced for module scripts per HTML spec.Understand this error
(index):1 Unchecked runtime.lastError: Could not establish connection. Receiving end does not exist.Understand this error
```

They had to do the following to resolve the issue:

```
regedit
HKEY_CLASSES_ROOT -> .js.    then Content Type.
If it says text/plain, change the value to application/javascript
```

# Solution

This PR should resolve this issue without requiring the user to take action. The root cause of the issue is that the server did not explicitly set the `media_type` of its response when serving the frontend HTML file and on Windows it seems that the mime type defaults to `text/plain` which the browser complains about. The solution is to explicitly set the `media_type` of files served for the frontend.