### PR TITLE
Add vae_type support for reward-forcing and memflow pipelines

### DIFF
--- a/src/scope/core/pipelines/memflow/pipeline.py
+++ b/src/scope/core/pipelines/memflow/pipeline.py
@@ -20,7 +20,7 @@ from ..wan2_1.components import WanDiffusionWrapper, WanTextEncoderWrapper
 from ..wan2_1.lora.mixin import LoRAEnabledPipeline
 from ..wan2_1.lora.strategies.module_targeted_lora import ModuleTargetedLoRAStrategy
 from ..wan2_1.vace import VACEEnabledPipeline
-from ..wan2_1.vae import WanVAEWrapper
+from ..wan2_1.vae import create_vae
 from .modular_blocks import MemFlowBlocks
 from .schema import MemFlowConfig
 
@@ -145,10 +145,13 @@ class MemFlowPipeline(Pipeline, LoRAEnabledPipeline, VACEEnabledPipeline):
         # Move text encoder to target device but use dtype of weights
         text_encoder = text_encoder.to(device=device)
 
-        # Load VAE using unified WanVAEWrapper
+        # Load VAE using create_vae factory (supports multiple VAE types)
+        vae_type = getattr(config, "vae_type", "wan")
         start = time.time()
-        vae = WanVAEWrapper(model_dir=model_dir, model_name=base_model_name)
-        print(f"Loaded VAE in {time.time() - start:.3f}s")
+        vae = create_vae(
+            model_dir=model_dir, model_name=base_model_name, vae_type=vae_type
+        )
+        print(f"Loaded VAE (type={vae_type}) in {time.time() - start:.3f}s")
         # Move VAE to target device and use target dtype
         vae = vae.to(device=device, dtype=dtype)
 

--- a/src/scope/core/pipelines/memflow/schema.py
+++ b/src/scope/core/pipelines/memflow/schema.py
@@ -1,4 +1,7 @@
+from pydantic import Field
+
 from ..base_schema import BasePipelineConfig, ModeDefaults
+from ..utils import VaeType
 
 
 class MemFlowConfig(BasePipelineConfig):
@@ -23,6 +26,10 @@ class MemFlowConfig(BasePipelineConfig):
     height: int = 320
     width: int = 576
     denoising_steps: list[int] = [1000, 750, 500, 250]
+    vae_type: VaeType = Field(
+        default=VaeType.WAN,
+        description="VAE type to use. 'wan' is the full VAE, 'lightvae' is 75% pruned (faster but lower quality).",
+    )
 
     modes = {
         "text": ModeDefaults(default=True),

--- a/src/scope/core/pipelines/reward_forcing/pipeline.py
+++ b/src/scope/core/pipelines/reward_forcing/pipeline.py
@@ -19,7 +19,7 @@ from ..utils import Quantization, load_model_config, validate_resolution
 from ..wan2_1.components import WanDiffusionWrapper, WanTextEncoderWrapper
 from ..wan2_1.lora.mixin import LoRAEnabledPipeline
 from ..wan2_1.vace.mixin import VACEEnabledPipeline
-from ..wan2_1.vae import WanVAEWrapper
+from ..wan2_1.vae import create_vae
 from .modular_blocks import RewardForcingBlocks
 from .schema import RewardForcingConfig
 
@@ -119,10 +119,13 @@ class RewardForcingPipeline(Pipeline, LoRAEnabledPipeline, VACEEnabledPipeline):
         # Move text encoder to target device but use dtype of weights
         text_encoder = text_encoder.to(device=device)
 
-        # Load VAE using unified WanVAEWrapper
+        # Load VAE using create_vae factory (supports multiple VAE types)
+        vae_type = getattr(config, "vae_type", "wan")
         start = time.time()
-        vae = WanVAEWrapper(model_dir=model_dir, model_name=base_model_name)
-        print(f"Loaded VAE in {time.time() - start:.3f}s")
+        vae = create_vae(
+            model_dir=model_dir, model_name=base_model_name, vae_type=vae_type
+        )
+        print(f"Loaded VAE (type={vae_type}) in {time.time() - start:.3f}s")
         # Move VAE to target device and use target dtype
         vae = vae.to(device=device, dtype=dtype)
 

--- a/src/scope/core/pipelines/reward_forcing/schema.py
+++ b/src/scope/core/pipelines/reward_forcing/schema.py
@@ -1,4 +1,7 @@
+from pydantic import Field
+
 from ..base_schema import BasePipelineConfig, ModeDefaults
+from ..utils import VaeType
 
 
 class RewardForcingConfig(BasePipelineConfig):
@@ -22,6 +25,10 @@ class RewardForcingConfig(BasePipelineConfig):
     height: int = 320
     width: int = 576
     denoising_steps: list[int] = [1000, 750, 500, 250]
+    vae_type: VaeType = Field(
+        default=VaeType.WAN,
+        description="VAE type to use. 'wan' is the full VAE, 'lightvae' is 75% pruned (faster but lower quality).",
+    )
 
     modes = {
         "text": ModeDefaults(default=True),


### PR DESCRIPTION
## Summary

- Added `vae_type` field to reward-forcing and memflow pipeline schemas
- Updated both pipelines to use `create_vae()` factory instead of hardcoded `WanVAEWrapper`
- Enables UI selection of all VAE types (wan, lightvae, tae, lighttae) for these pipelines

## Test plan

- [x] Load reward-forcing pipeline and verify VAE type dropdown appears in Settings
- [x] Select each VAE type and confirm pipeline loads correctly
- [x] Repeat for memflow pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)