### PR TITLE
fix: TAE memory pollution in VACE dual-encode with explicit cache obj…

### DIFF
--- a/src/scope/core/pipelines/longlive/test_vace.py
+++ b/src/scope/core/pipelines/longlive/test_vace.py
@@ -35,9 +35,9 @@ from .pipeline import LongLivePipeline
 
 CONFIG = {
     # ===== MODE SELECTION =====
-    "use_r2v": True,  # Reference-to-Video: condition on reference images
+    "use_r2v": False,  # Reference-to-Video: condition on reference images
     "use_depth": False,  # Depth guidance: structural control via depth maps
-    "use_inpainting": False,  # Inpainting: masked video-to-video generation
+    "use_inpainting": True,  # Inpainting: masked video-to-video generation
     # ===== INPUT PATHS =====
     # R2V: List of reference image paths
     "ref_images": [
@@ -63,6 +63,7 @@ CONFIG = {
     "mask_value": 127,  # Gray value for masked regions (0-255)
     # ===== OUTPUT =====
     "output_dir": "vace_tests/unified",  # path/to/output_dir
+    "vae_type": "tae",
 }
 
 # ========================= END CONFIGURATION =========================
@@ -487,6 +488,7 @@ def main():
             "model_config": OmegaConf.load(script_dir / "model.yaml"),
             "height": config["height"],
             "width": config["width"],
+            "vae_type": config["vae_type"],
         }
     )
 

--- a/src/scope/core/pipelines/wan2_1/vae/wan.py
+++ b/src/scope/core/pipelines/wan2_1/vae/wan.py
@@ -94,10 +94,23 @@ class WanVAEWrapper(torch.nn.Module):
         """Create a fresh encoder feature cache with dynamic sizing."""
         return [None] * self._encoder_conv_count
 
+    def create_encoder_cache(self):
+        """Create encoder cache (TAE compatibility).
+
+        WanVAE's CausalConv3d uses raw frame prepending for temporal context,
+        so it doesn't have TAE's MemBlock memory pollution issue. This method
+        exists for interface compatibility with TAEWrapper.
+
+        Returns:
+            None (WanVAE doesn't need explicit caches)
+        """
+        return None
+
     def encode_to_latent(
         self,
         pixel: torch.Tensor,
         use_cache: bool = True,
+        encoder_cache=None,
     ) -> torch.Tensor:
         """Encode video pixels to latents.
 
@@ -105,6 +118,9 @@ class WanVAEWrapper(torch.nn.Module):
             pixel: Input video tensor [batch, channels, frames, height, width]
             use_cache: If True, use streaming encode (maintains cache state).
                       If False, use batch encode with a temporary cache.
+            encoder_cache: Ignored (TAE compatibility). WanVAE's CausalConv3d
+                          prepends raw frames as context, avoiding the MemBlock
+                          memory pollution issue that requires separate caches.
 
         Returns:
             Latent tensor [batch, frames, channels, height, width]


### PR DESCRIPTION
…ects

TAE's MemBlock architecture mixes processed memory state with input via channel concatenation. When VACE encodes inactive and reactive streams interleaved (for depth/flow/pose/inpainting modes), they pollute each other's memory, causing visual artifacts.

Root cause: Unlike WanVAE's CausalConv3d which prepends raw frames as temporal context, TAE's MemBlock accumulates processed state that gets corrupted when different content streams share the same memory.

Solution: Explicit encoder cache objects following WanVAE's feat_cache pattern. Each VACE stream gets its own isolated cache instance:

- Add TAEEncoderCache dataclass to hold MemBlock memory state
- Add create_encoder_cache() to TAEWrapper (returns cache) and WanVAEWrapper (returns None for compatibility)
- Add encoder_cache parameter to encode_to_latent()
- Update vace_encode_frames() with inactive_cache/reactive_cache params
- Update VaceEncodingBlock to manage caches across chunks

This provides:
- Explicit ownership: caller creates and manages cache lifecycle
- Temporal continuity: each stream maintains its own memory across chunks
- No cross-contamination: inactive and reactive encodings stay isolated
- Backwards compatibility: default internal cache when none provided
- Works for all VACE modes: inpainting, depth, r2v
- Works in absence of VACE: t2v, v2v

Tested with Longlive.

This has implications for #287 which i will address.