### PR TITLE
fix: unexpected keyword argument 'encoder_cache'

### DIFF
--- a/src/scope/core/pipelines/streamdiffusionv2/components/vae.py
+++ b/src/scope/core/pipelines/streamdiffusionv2/components/vae.py
@@ -6,7 +6,7 @@ from scope.core.pipelines.wan2_1.vae.wan import WanVAEWrapper
 # StreamDiffusionV2 does not expect the latent to be normalized, so we override the encode_to_latent method to skip that step
 class StreamDiffusionV2WanVAEWrapper(WanVAEWrapper):
     def encode_to_latent(
-        self, pixel: torch.Tensor, use_cache: bool = True
+        self, pixel: torch.Tensor, use_cache: bool = True, encoder_cache=None
     ) -> torch.Tensor:
         """Encode video pixels to latents without normalization.
 
@@ -14,6 +14,9 @@ class StreamDiffusionV2WanVAEWrapper(WanVAEWrapper):
             pixel: Input video tensor [batch, channels, frames, height, width]
             use_cache: If True, use streaming encode (maintains cache state).
                       If False, use batch encode with a temporary cache.
+            encoder_cache: Ignored (TAE compatibility). WanVAE's CausalConv3d
+                          prepends raw frames as context, avoiding the MemBlock
+                          memory pollution issue that requires separate caches.
 
         Returns:
             Latent tensor [batch, frames, channels, height, width]


### PR DESCRIPTION
`TypeError: StreamDiffusionV2WanVAEWrapper.encode_to_latent() got an unexpected keyword argument 'encoder_cache'` 

This regression was introduced when the VACE encoding code was updated to pass explicit encoder_cache objects to prevent TAE memory pollution (31b34087), but the StreamDiffusionV2 VAE wrapper wasn't updated to match the interface.