### PR TITLE
feat: auto-generate spatial masks for FFLF extension mode

### DIFF
--- a/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
+++ b/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
@@ -89,6 +89,7 @@ class VaceEncodingBlock(ModularPipelineBlocks):
         return [
             ConfigSpec("num_frame_per_block", 3),
             ConfigSpec("vae_temporal_downsample_factor", 4),
+            ConfigSpec("vae_spatial_downsample_factor", 8),  # Used by vae_stride tuple
             ConfigSpec("device", torch.device("cuda")),
         ]
 
@@ -316,7 +317,7 @@ class VaceEncodingBlock(ModularPipelineBlocks):
             # Load BOTH images for firstlastframe mode
             images_to_load = [first_frame_image, last_frame_image]
 
-        # Load images with spatial mask detection for auto-masking of padding regions
+        # Load and crop-to-fill reference images (spatial masks always zeros with crop strategy)
         prepared_refs, spatial_masks = load_and_prepare_reference_images(
             images_to_load,
             block_state.height,

--- a/src/scope/core/pipelines/wan2_1/vace/utils/encoding.py
+++ b/src/scope/core/pipelines/wan2_1/vace/utils/encoding.py
@@ -219,6 +219,10 @@ def load_and_prepare_reference_images(
     """
     Load and prepare reference images for VACE conditioning.
 
+    Uses crop-to-fill strategy: scales image to cover target dimensions, then
+    center-crops to exact size. This avoids padding artifacts at the cost of
+    losing a small amount of edge content when aspect ratios differ.
+
     Args:
         ref_image_paths: List of paths to reference images
         target_height: Target frame height
@@ -229,8 +233,8 @@ def load_and_prepare_reference_images(
         Tuple of (prepared_images, spatial_masks) where:
         - prepared_images: List of image tensors [C, 1, H, W] normalized to [-1, 1]
         - spatial_masks: List of mask tensors [1, 1, H, W] indicating padding regions
-          (0=image region to preserve, 1=padding region to generate). All-zeros when
-          no padding was needed.
+          (0=image region to preserve, 1=padding region to generate). Always all-zeros
+          with crop-to-fill since entire frame is image content.
     """
     prepared_refs = []
     spatial_masks = []
@@ -246,17 +250,12 @@ def load_and_prepare_reference_images(
         if ref_img.shape[-2:] != (target_height, target_width):
             ref_height, ref_width = ref_img.shape[-2:]
 
-            # Create white canvas
-            white_canvas = torch.ones(
-                (3, 1, target_height, target_width), device=device
-            )
-
-            # Calculate scale to fit
-            scale = min(target_height / ref_height, target_width / ref_width)
+            # Scale to fill (crop-to-fit) - use max to ensure image covers target
+            scale = max(target_height / ref_height, target_width / ref_width)
             new_height = int(ref_height * scale)
             new_width = int(ref_width * scale)
 
-            # Resize
+            # Resize to cover target dimensions
             resized_image = (
                 F.interpolate(
                     ref_img.squeeze(1).unsqueeze(0),
@@ -268,21 +267,19 @@ def load_and_prepare_reference_images(
                 .unsqueeze(1)
             )
 
-            # Center on canvas
-            top = (target_height - new_height) // 2
-            left = (target_width - new_width) // 2
-            white_canvas[:, :, top : top + new_height, left : left + new_width] = (
-                resized_image
-            )
-            ref_img = white_canvas
+            # Center-crop to target size
+            top = (new_height - target_height) // 2
+            left = (new_width - target_width) // 2
+            ref_img = resized_image[
+                :, :, top : top + target_height, left : left + target_width
+            ].to(device)
 
-            # Create spatial mask: 0=image region, 1=padding region
-            spatial_mask = torch.ones(
+            # No padding, so spatial mask is all zeros (entire frame is image)
+            spatial_mask = torch.zeros(
                 (1, 1, target_height, target_width),
                 device=device,
                 dtype=torch.float32,
             )
-            spatial_mask[:, :, top : top + new_height, left : left + new_width] = 0.0
             spatial_masks.append(spatial_mask)
         else:
             ref_img = ref_img.to(device)


### PR DESCRIPTION
When reference images require padding to fit target resolution, spatial masks now indicate padding regions (1=generate) vs image regions (0=preserve). This allows the model to freely generate in padded areas while preserving the first/last frame influence only where the actual image content exists.

User provided masks to follow.