### PR TITLE
feat: add API support for first-frame-last-frame (FFLF) extension mode

### DIFF
--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -449,16 +449,17 @@ class PipelineProcessor:
 
             output = self.pipeline(**call_params)
 
-            # Clear vace_ref_images from parameters after use to prevent sending them on subsequent chunks
-            # vace_ref_images should only be sent when explicitly provided in parameter updates
-            if (
-                "vace_ref_images" in call_params
-                and "vace_ref_images" in self.parameters
-            ):
-                self.parameters.pop("vace_ref_images", None)
-
-            if "images" in call_params and "images" in self.parameters:
-                self.parameters.pop("images", None)
+            # Clear one-shot parameters after use to prevent sending them on subsequent chunks
+            # These parameters should only be sent when explicitly provided in parameter updates
+            one_shot_params = [
+                "vace_ref_images",
+                "images",
+                "first_frame_image",
+                "last_frame_image",
+            ]
+            for param in one_shot_params:
+                if param in call_params and param in self.parameters:
+                    self.parameters.pop(param, None)
 
             # Clear transition when complete
             if "transition" in call_params and "transition" in self.parameters:

--- a/src/scope/server/schema.py
+++ b/src/scope/server/schema.py
@@ -137,6 +137,14 @@ class Parameters(BaseModel):
         default=None,
         description="List of pipeline IDs to execute in a chain. If not provided, uses the currently loaded pipeline.",
     )
+    first_frame_image: str | None = Field(
+        default=None,
+        description="Path to first frame reference image for extension mode. When provided alone, enables 'firstframe' mode (reference at start, generate continuation). When provided with last_frame_image, enables 'firstlastframe' mode (references at both ends). Images should be located in the assets directory.",
+    )
+    last_frame_image: str | None = Field(
+        default=None,
+        description="Path to last frame reference image for extension mode. When provided alone, enables 'lastframe' mode (generate lead-up, reference at end). When provided with first_frame_image, enables 'firstlastframe' mode (references at both ends). Images should be located in the assets directory.",
+    )
 
 
 class SpoutConfig(BaseModel):


### PR DESCRIPTION
Expose first_frame_image and last_frame_image parameters in the API schema to enable FFLF extension mode for all VACE-enabled pipelines. These parameters allow users to set reference frames at the start and/or end of chunks:
- firstframe mode: reference at start, generate continuation
- lastframe mode: generate lead-up, reference at end
- firstlastframe mode: references at both ends

The parameters are automatically cleared after use to prevent unintended persistence across generation chunks.