### PR TITLE
KREA Default Params 5090 Fix

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -375,6 +375,17 @@ export function SettingsPanel({
               </Toggle>
             </div>
 
+            {/* Warning when VACE is enabled and quantization is set */}
+            {vaceEnabled && quantization !== null && (
+              <div className="flex items-start gap-1.5 p-2 rounded-md bg-amber-500/10 border border-amber-500/20">
+                <Info className="h-3.5 w-3.5 mt-0.5 shrink-0 text-amber-600 dark:text-amber-500" />
+                <p className="text-xs text-amber-600 dark:text-amber-500">
+                  VACE is incompatible with FP8 quantization. Please disable
+                  quantization to use VACE.
+                </p>
+              </div>
+            )}
+
             {vaceEnabled && (
               <div className="rounded-lg border bg-card p-3 space-y-3">
                 <div className="flex items-center justify-between gap-2">
@@ -765,7 +776,7 @@ export function SettingsPanel({
                         value === "none" ? null : (value as "fp8_e4m3fn")
                       );
                     }}
-                    disabled={isStreaming}
+                    disabled={isStreaming || vaceEnabled}
                   >
                     <SelectTrigger className="w-[140px] h-7">
                       <SelectValue />
@@ -778,6 +789,13 @@ export function SettingsPanel({
                     </SelectContent>
                   </Select>
                 </div>
+                {/* Note when quantization is disabled due to VACE */}
+                {vaceEnabled && (
+                  <p className="text-xs text-muted-foreground">
+                    Disabled because VACE is enabled. Disable VACE to use FP8
+                    quantization.
+                  </p>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
This alleviates user frustration by defaulting VACE to "OFF" when on 5090 so KREA works with default params. It also handles FP8 when enabled while VACE is enabled.

Fix https://github.com/daydreamlive/scope/issues/334