### PR TITLE
Fix controller-viz pipeline loading

### DIFF
--- a/src/scope/core/pipelines/__init__.py
+++ b/src/scope/core/pipelines/__init__.py
@@ -32,6 +32,10 @@ def __getattr__(name):
         from .video_depth_anything.pipeline import VideoDepthAnythingPipeline
 
         return VideoDepthAnythingPipeline
+    elif name == "ControllerVisualizerPipeline":
+        from .controller_viz.pipeline import ControllerVisualizerPipeline
+
+        return ControllerVisualizerPipeline
     # Config classes
     elif name == "BasePipelineConfig":
         from .base_schema import BasePipelineConfig
@@ -77,6 +81,7 @@ __all__ = [
     "PassthroughPipeline",
     "MemFlowPipeline",
     "VideoDepthAnythingPipeline",
+    "ControllerVisualizerPipeline",
     # Config classes
     "BasePipelineConfig",
     "LongLiveConfig",

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -517,6 +517,7 @@ class PipelineManager:
             "reward-forcing",
             "memflow",
             "video-depth-anything",
+            "controller-viz",
         }
 
         if pipeline_class is not None and pipeline_id not in BUILTIN_PIPELINES:
@@ -896,6 +897,25 @@ class PipelineManager:
                 dtype=torch.float16,
             )
             logger.info("VideoDepthAnything pipeline initialized")
+            return pipeline
+
+        elif pipeline_id == "controller-viz":
+            from scope.core.pipelines import ControllerVisualizerPipeline
+
+            # Use load parameters for resolution, default to 512x512
+            height = 512
+            width = 512
+            if load_params:
+                height = load_params.get("height", 512)
+                width = load_params.get("width", 512)
+
+            pipeline = ControllerVisualizerPipeline(
+                height=height,
+                width=width,
+                device=get_device(),
+                dtype=torch.float32,
+            )
+            logger.info("ControllerVisualizer pipeline initialized")
             return pipeline
 
         else:


### PR DESCRIPTION
## Summary
- Add `controller-viz` to `BUILTIN_PIPELINES` set and initialization logic
- Export `ControllerVisualizerPipeline` from pipelines package

Fixes the pipeline incorrectly showing "Loading plugin pipeline" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)