### PR TITLE
Remove confusing model removal suggestion from error toasts

### DIFF
--- a/frontend/src/hooks/usePipeline.ts
+++ b/frontend/src/hooks/usePipeline.ts
@@ -32,11 +32,10 @@ export function usePipeline(options: UsePipelineOptions = {}) {
 
       if (statusResponse.status === "error") {
         const errorMessage = statusResponse.error || "Unknown pipeline error";
-        const fullMessage = `${errorMessage}. If this error persists, consider removing the models directory and re-downloading models.`;
         // Show toast if we haven't shown this error yet
         if (shownErrorRef.current !== errorMessage) {
           toast.error("Pipeline Error", {
-            description: fullMessage,
+            description: errorMessage,
             duration: 8000,
           });
           shownErrorRef.current = errorMessage;
@@ -88,11 +87,10 @@ export function usePipeline(options: UsePipelineOptions = {}) {
 
         if (statusResponse.status === "error") {
           const errorMessage = statusResponse.error || "Unknown pipeline error";
-          const fullMessage = `${errorMessage}. If this error persists, consider removing the models directory and re-downloading models.`;
           // Show toast if we haven't shown this error yet
           if (shownErrorRef.current !== errorMessage) {
             toast.error("Pipeline Error", {
-              description: fullMessage,
+              description: errorMessage,
               duration: 8000,
             });
             shownErrorRef.current = errorMessage;
@@ -185,11 +183,10 @@ export function usePipeline(options: UsePipelineOptions = {}) {
                 resolve(true);
               } else if (currentStatus.status === "error") {
                 const errorMsg = currentStatus.error || "Pipeline load failed";
-                const fullMessage = `${errorMsg}. If this error persists, consider removing the models directory and re-downloading models.`;
                 // Show toast for load completion errors
                 if (shownErrorRef.current !== errorMsg) {
                   toast.error("Pipeline Error", {
-                    description: fullMessage,
+                    description: errorMsg,
                     duration: 8000,
                   });
                   shownErrorRef.current = errorMsg;
@@ -220,12 +217,11 @@ export function usePipeline(options: UsePipelineOptions = {}) {
       } catch (err) {
         const errorMessage =
           err instanceof Error ? err.message : "Failed to load pipeline";
-        const fullMessage = `${errorMessage}. If this error persists, consider removing the models directory and re-downloading models.`;
-        console.error("Pipeline load error:", fullMessage);
+        console.error("Pipeline load error:", errorMessage);
         // Show toast for load errors
         if (shownErrorRef.current !== errorMessage) {
           toast.error("Pipeline Error", {
-            description: fullMessage,
+            description: errorMessage,
             duration: 8000,
           });
           shownErrorRef.current = errorMessage;


### PR DESCRIPTION
## Summary
- Remove the suggestion to remove the models directory from pipeline error toast messages
- The suggestion was confusing to users since it appeared on all errors, not just model-related issues
- Error toasts now show only the actual error message

## Test plan
- [x] Trigger a pipeline error and verify the toast only shows the error message without the model removal suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)