### PR TITLE
Fix Electron App and non-GPU setup

### DIFF
--- a/app/build/afterPack.js
+++ b/app/build/afterPack.js
@@ -41,6 +41,7 @@ exports.default = async function afterPack(context) {
     { src: path.join(projectRoot, 'README.md'), dest: path.join(resourcesPath, 'README.md') },
     { src: path.join(projectRoot, 'LICENSE.md'), dest: path.join(resourcesPath, 'LICENSE.md') },
     { src: path.join(projectRoot, 'frontend', 'dist'), dest: path.join(resourcesPath, 'frontend', 'dist') },
+    { src: path.join(projectRoot, 'patches.pth'), dest: path.join(resourcesPath, 'patches.pth') },
   ];
 
   // Copy files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ preview = true
 # Override cuDNN version to fix PyTorch 2.9.1 Conv3D bf16 performance regression
 # See: https://github.com/pytorch/pytorch/issues/168167
 override-dependencies = [
-    "nvidia-cudnn-cu12>=9.15",
+    "nvidia-cudnn-cu12>=9.15; sys_platform == 'linux' or sys_platform == 'win32'",
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/src/scope/core/pipelines/krea_realtime_video/modules/model.py
+++ b/src/scope/core/pipelines/krea_realtime_video/modules/model.py
@@ -20,7 +20,7 @@ def sinusoidal_embedding_1d(dim, position):
     position = position.type(torch.float64)
 
     # calculation
-    sinusoid = torch.outer(position, torch.pow(10000, -torch.arange(half, device=torch.cuda.current_device(), dtype=torch.float64).div(half)))
+    sinusoid = torch.outer(position, torch.pow(10000, -torch.arange(half, device=position.device, dtype=torch.float64).div(half)))
     x = torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
     return x
 

--- a/src/scope/core/pipelines/video_depth_anything/schema.py
+++ b/src/scope/core/pipelines/video_depth_anything/schema.py
@@ -17,6 +17,7 @@ class VideoDepthAnythingConfig(BasePipelineConfig):
         "for video sequences using Video-Depth-Anything Small model."
     )
     docs_url = "https://github.com/DepthAnything/Video-Depth-Anything"
+    estimated_vram_gb = 1.0
     artifacts = [
         HuggingfaceRepoArtifact(
             repo_id="depth-anything/Video-Depth-Anything-Small",

--- a/src/scope/core/pipelines/wan2_1/modules/t5.py
+++ b/src/scope/core/pipelines/wan2_1/modules/t5.py
@@ -525,11 +525,15 @@ class T5EncoderModel:
         self,
         text_len,
         dtype=torch.bfloat16,
-        device=torch.cuda.current_device(),
+        device=None,
         checkpoint_path=None,
         tokenizer_path=None,
         shard_fn=None,
     ):
+        # Determine device if not provided: CUDA if available, CPU otherwise
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
         self.text_len = text_len
         self.dtype = dtype
         self.device = device

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "nvidia-cudnn-cu12", specifier = ">=9.15" }]
+overrides = [{ name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = ">=9.15" }]
 
 [[package]]
 name = "accelerate"
@@ -1498,7 +1498,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.17.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/55/9987152bd99746b6d5d899a3e920f72f565f5adb4835dc44899382482e2c/nvidia_cudnn_cu12-9.17.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:d18d61bdd596fca0dbe459c129f6eb7a24ed2e6de1d7988b0a37ac63184ee05d", size = 646648394, upload-time = "2025-12-22T16:42:08.8Z" },
@@ -2436,7 +2436,6 @@ dependencies = [
     { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "setuptools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },


### PR DESCRIPTION
- Fix Electron App by adding the required `patches.pth` file into Electron package
- Fix non-GPU setups by making CUDA conditional in the modules code
- Make "nvidia-cudnn-cu12>=9.15" non-required on MacOS
- Make video-depth-anything pipeline not show up on non-GPU devices