### PR TITLE
feat: multi output processors

### DIFF
--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -10,6 +10,7 @@ from typing import Any
 import torch
 
 from scope.core.pipelines.controller import parse_ctrl_input
+from scope.core.pipelines.wan2_1.vace import VACEEnabledPipeline
 
 from .pipeline_manager import PipelineNotAvailableException
 
@@ -84,6 +85,9 @@ class PipelineProcessor:
             "vace_use_input_video", True
         )
 
+        # Cache VACE support check to avoid isinstance on every chunk
+        self._pipeline_supports_vace = isinstance(pipeline, VACEEnabledPipeline)
+
         self.output_size = None
 
     def _resize_output_queue(self, target_size: int):
@@ -125,6 +129,7 @@ class PipelineProcessor:
         self.next_processor = next_processor
 
         # Calculate output queue size based on next processor's requirements
+        # Also pass chunk size to this processor so preprocessors can use it
         next_pipeline = next_processor.pipeline
         if hasattr(next_pipeline, "prepare"):
             requirements = next_pipeline.prepare(video=True)
@@ -379,28 +384,29 @@ class PipelineProcessor:
                 self.parameters["ctrl_input"]["mouse"] = [0.0, 0.0]
 
             # Route video input based on VACE status
-            # We do not support combining latent initialization and VACE conditioning
-            if video_input is not None:
-                # Check if pipeline actually supports VACE before routing to vace_input_frames
-                from scope.core.pipelines.wan2_1.vace import VACEEnabledPipeline
-
-                pipeline_supports_vace = isinstance(self.pipeline, VACEEnabledPipeline)
-
+            # Don't overwrite if preprocessor already provided vace_input_frames
+            if video_input is not None and "vace_input_frames" not in call_params:
                 if (
-                    pipeline_supports_vace
+                    self._pipeline_supports_vace
                     and self.vace_enabled
                     and self.vace_use_input_video
                 ):
-                    # VACE conditioning: route to vace_input_frames
                     call_params["vace_input_frames"] = video_input
                 else:
-                    # Latent initialization: route to video
                     call_params["video"] = video_input
 
             output_dict = self.pipeline(**call_params)
 
             # Extract video from the returned dictionary
-            output = output_dict["video"]
+            output = output_dict.get("video")
+            if output is None:
+                return
+
+            # Forward extra params to downstream pipeline (dual-output pattern)
+            # Preprocessors return {"video": frames, "vace_input_frames": ..., "vace_input_masks": ...}
+            extra_params = {k: v for k, v in output_dict.items() if k != "video"}
+            if extra_params and self.next_processor is not None:
+                self.next_processor.update_parameters(extra_params)
 
             # Update prev_output_size parameter
             num_frames = output.shape[0]


### PR DESCRIPTION
## NOTE: rebase on main after #378 is merged


This is to support masking preprocessor plugins for VACE. 

An example plugin implementation: 
https://github.com/daydreamlive/scope_yolo_mask

Other more advanced masking techniques can be revisited later (SAM2, SAM3) using this same infrastructure. 

This change will enable inpainting with VACE, regional LoRA, background removal/preservation, and more. 
