### PR TITLE
Propagate prev_output_size and next_input_size parameters

### DIFF
--- a/src/scope/core/pipelines/rife/pipeline.py
+++ b/src/scope/core/pipelines/rife/pipeline.py
@@ -55,7 +55,7 @@ class RIFEPipeline(Pipeline):
         logger.info("RIFE HDv3 model loaded successfully")
 
     def prepare(self, **kwargs) -> Requirements:
-        return Requirements(input_size=12)
+        return Requirements(input_size=kwargs.get("prev_output_size", 12))
 
     def __call__(
         self,


### PR DESCRIPTION
A pipeline may want to decide on its input depending on the previous pipeline output size or the next pipeline input size.

I initially thought this would be the `auto_adjust` param in the Requirements, but not I think we should just propagate this param.