### PR TITLE
Fix scribble pipeline returning None

### DIFF
--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -959,6 +959,7 @@ class PipelineManager:
                 dtype=torch.float16,
             )
             logger.info("Scribble pipeline initialized")
+            return pipeline
         elif pipeline_id == "gray":
             from scope.core.pipelines import GrayPipeline
 


### PR DESCRIPTION
## Summary
- Add missing `return pipeline` statement in scribble pipeline initialization
- Fixes `TypeError: 'NoneType' object is not callable` when processing frames

## Test plan
- [x] Run the server with `uv run daydream-scope`
- [x] Load the scribble pipeline from the UI
- [x] Verify no TypeError errors appear and frames process correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)