### PR TITLE
feat: add auto_resize flag for outpainting support

### DIFF
--- a/src/scope/core/pipelines/longlive/test_vace.py
+++ b/src/scope/core/pipelines/longlive/test_vace.py
@@ -70,6 +70,10 @@ CONFIG = {
     "first_frame_image": "frontend/public/assets/example.png",  # For firstframe or firstlastframe modes
     "last_frame_image": "frontend/public/assets/woman2.jpg",  # For lastframe or firstlastframe modes
     "extension_mode": "firstframe",  # "firstframe", "lastframe", or "firstlastframe"
+    # Auto-resize for first/last frame images:
+    # - True (default): Scale to fill target dimensions (seamless UX)
+    # - False: Center at original size, pad for outpainting
+    "auto_resize": True,
     # ===== GENERATION PARAMETERS =====
     "prompt": None,  # Set to override mode-specific prompts, or None to use defaults
     "prompt_r2v": "",  # Default prompt for R2V mode
@@ -722,8 +726,11 @@ def main():
                     kwargs["first_frame_image"] = first_frame_image
                 if last_frame_image is not None:
                     kwargs["last_frame_image"] = last_frame_image
+                # Pass auto_resize setting (False for outpainting)
+                kwargs["auto_resize"] = config.get("auto_resize", True)
                 print(
                     f"Chunk {chunk_index}: Extension mode={extension_mode}, "
+                    f"auto_resize={kwargs['auto_resize']}, "
                     f"chunk={'first' if is_first_chunk else 'last' if is_last_chunk else 'middle'}"
                 )
 

--- a/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
+++ b/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
@@ -144,6 +144,13 @@ class VaceEncodingBlock(ModularPipelineBlocks):
                 type_hint=int,
                 description="Current starting frame index",
             ),
+            InputParam(
+                "auto_resize",
+                default=True,
+                type_hint=bool,
+                description="If True (default), scale images to fill target dimensions for seamless UX. "
+                "If False, center images at original size and pad for outpainting.",
+            ),
         ]
 
     @property
@@ -321,12 +328,16 @@ class VaceEncodingBlock(ModularPipelineBlocks):
             # Load BOTH images for firstlastframe mode
             images_to_load = [first_frame_image, last_frame_image]
 
-        # Load and crop-to-fill reference images (spatial masks always zeros with crop strategy)
+        # Get auto_resize setting (True for seamless UX, False for outpainting)
+        auto_resize = getattr(block_state, "auto_resize", True)
+
+        # Load and prepare reference images
         prepared_refs, spatial_masks = load_and_prepare_reference_images(
             images_to_load,
             block_state.height,
             block_state.width,
             components.config.device,
+            auto_resize=auto_resize,
         )
 
         vae = components.vae


### PR DESCRIPTION
depends upon #388 

Adds auto_resize parameter to first/last frame image handling:
- auto_resize=True (default): Existing behavior - scale image to fill target dimensions
  - auto_resize=False: Center image at original size, pad with black, generate spatial mask for outpainting regions

  This allows users to send smaller images and let the model generate content in the surrounding area, rather than always scaling to fit.