### PR TITLE
Separate built-in vs plugin pipelines in dropdown

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -3,7 +3,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
@@ -257,11 +260,44 @@ export function SettingsPanel({
             </SelectTrigger>
             <SelectContent>
               {pipelines &&
-                Object.entries(pipelines).map(([id]) => (
-                  <SelectItem key={id} value={id}>
-                    {id}
-                  </SelectItem>
-                ))}
+                (() => {
+                  const entries = Object.entries(pipelines);
+                  const builtIn = entries.filter(
+                    ([, info]) => !info.pluginName
+                  );
+                  const plugin = entries.filter(([, info]) => info.pluginName);
+                  return (
+                    <>
+                      {builtIn.length > 0 && (
+                        <SelectGroup>
+                          <SelectLabel className="text-xs text-muted-foreground font-bold">
+                            Built-in Pipelines
+                          </SelectLabel>
+                          {builtIn.map(([id]) => (
+                            <SelectItem key={id} value={id}>
+                              {id}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      )}
+                      {builtIn.length > 0 && plugin.length > 0 && (
+                        <SelectSeparator />
+                      )}
+                      {plugin.length > 0 && (
+                        <SelectGroup>
+                          <SelectLabel className="text-xs text-muted-foreground font-bold">
+                            Plugin Pipelines
+                          </SelectLabel>
+                          {plugin.map(([id]) => (
+                            <SelectItem key={id} value={id}>
+                              {id}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      )}
+                    </>
+                  );
+                })()}
             </SelectContent>
           </Select>
         </div>
@@ -272,6 +308,12 @@ export function SettingsPanel({
               <div>
                 <h4 className="text-sm font-semibold">
                   {currentPipeline.name}
+                  {currentPipeline.pluginName && (
+                    <span className="font-normal text-muted-foreground">
+                      {" "}
+                      ({currentPipeline.pluginName})
+                    </span>
+                  )}
                 </h4>
               </div>
 

--- a/frontend/src/hooks/usePipelines.ts
+++ b/frontend/src/hooks/usePipelines.ts
@@ -52,6 +52,7 @@ export function usePipelines() {
           recommendedQuantizationVramThreshold:
             schema.recommended_quantization_vram_threshold ?? undefined,
           modified: schema.modified,
+          pluginName: schema.plugin_name ?? undefined,
           supportsControllerInput,
           supportsImages,
           configSchema: schema.config_schema,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -422,6 +422,7 @@ export interface PipelineSchemaInfo {
   min_dimension: number;
   recommended_quantization_vram_threshold: number | null;
   modified: boolean;
+  plugin_name: string | null;
 }
 
 export interface PipelineSchemasResponse {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -116,6 +116,7 @@ export interface PipelineInfo {
   minDimension?: number;
   recommendedQuantizationVramThreshold?: number | null;
   // Controller input support - presence of ctrl_input field in pipeline schema
+  pluginName?: string;
   supportsControllerInput?: boolean;
   // Images input support - presence of images field in pipeline schema
   supportsImages?: boolean;

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -481,7 +481,9 @@ async def get_pipeline_schemas():
     The frontend should use this as the source of truth for parameter defaults.
     """
     from scope.core.pipelines.registry import PipelineRegistry
+    from scope.core.plugins import get_plugin_manager
 
+    plugin_manager = get_plugin_manager()
     pipelines: dict = {}
 
     for pipeline_id in PipelineRegistry.list_pipelines():
@@ -490,6 +492,9 @@ async def get_pipeline_schemas():
             # get_schema_with_metadata() includes supported_modes, default_mode,
             # and mode_defaults directly from the config class
             schema_data = config_class.get_schema_with_metadata()
+            schema_data["plugin_name"] = plugin_manager.get_plugin_for_pipeline(
+                pipeline_id
+            )
             pipelines[pipeline_id] = schema_data
 
     return PipelineSchemasResponse(pipelines=pipelines)


### PR DESCRIPTION
## Summary
- Groups the pipeline dropdown into "Built-in Pipelines" and "Plugin Pipelines" sections with bold labels, a visual separator, and smaller muted font
- Adds `plugin_name` field to the pipeline schema API response (from the plugin manager)
- Shows the plugin name in parentheses next to the pipeline name in the pipeline card when a plugin pipeline is selected

## Test plan
- [x] Run `uv run daydream-scope` and confirm server starts without errors
- [x] Open the app, expand the pipeline dropdown, verify "Built-in Pipelines" and "Plugin Pipelines" labels appear with a separator between them
- [x] Install a plugin and verify its pipelines appear under the "Plugin Pipelines" group
- [x] Select a plugin pipeline and verify the plugin name shows in parentheses in the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)