### PR TITLE
feat: follow symlinks when listing directory contents

### DIFF
--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -32,6 +32,12 @@ if TYPE_CHECKING:
 
 from .download_models import download_models
 from .download_progress_manager import download_progress_manager
+from .file_utils import (
+    IMAGE_EXTENSIONS,
+    LORA_EXTENSIONS,
+    VIDEO_EXTENSIONS,
+    iter_files,
+)
 from .logs_config import (
     cleanup_old_logs,
     ensure_logs_dir,
@@ -684,11 +690,8 @@ async def list_lora_files():
         lora_dir = get_models_dir() / "lora"
         lora_files: list[LoRAFileInfo] = []
 
-        if lora_dir.exists() and lora_dir.is_dir():
-            for pattern in ("*.safetensors", "*.bin", "*.pt"):
-                for file_path in lora_dir.rglob(pattern):
-                    if file_path.is_file():
-                        lora_files.append(process_lora_file(file_path, lora_dir))
+        for file_path in iter_files(lora_dir, LORA_EXTENSIONS):
+            lora_files.append(process_lora_file(file_path, lora_dir))
 
         lora_files.sort(key=lambda x: (x.folder or "", x.name))
         return LoRAFilesResponse(lora_files=lora_files)
@@ -727,25 +730,17 @@ async def list_assets(
         assets_dir = get_assets_dir()
         asset_files: list[AssetFileInfo] = []
 
-        if assets_dir.exists() and assets_dir.is_dir():
-            # Define patterns based on type filter
-            if type == "image" or type is None:
-                image_patterns = ("*.png", "*.jpg", "*.jpeg", "*.webp", "*.bmp")
-                for pattern in image_patterns:
-                    for file_path in assets_dir.rglob(pattern):
-                        if file_path.is_file():
-                            asset_files.append(
-                                process_asset_file(file_path, assets_dir, "image")
-                            )
+        if type == "image":
+            extensions = IMAGE_EXTENSIONS
+        elif type == "video":
+            extensions = VIDEO_EXTENSIONS
+        else:
+            extensions = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
 
-            if type == "video" or type is None:
-                video_patterns = ("*.mp4", "*.avi", "*.mov", "*.mkv", "*.webm")
-                for pattern in video_patterns:
-                    for file_path in assets_dir.rglob(pattern):
-                        if file_path.is_file():
-                            asset_files.append(
-                                process_asset_file(file_path, assets_dir, "video")
-                            )
+        for file_path in iter_files(assets_dir, extensions):
+            ext = file_path.suffix.lower()
+            asset_type = "image" if ext in IMAGE_EXTENSIONS else "video"
+            asset_files.append(process_asset_file(file_path, assets_dir, asset_type))
 
         # Sort by created_at (most recent first), then by folder and name
         asset_files.sort(key=lambda x: (-x.created_at, x.folder or "", x.name))
@@ -761,9 +756,7 @@ async def upload_asset(request: Request, filename: str = Query(...)):
     """Upload an asset file (image or video) to the assets directory."""
     try:
         # Validate file type - support both images and videos
-        allowed_image_extensions = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
-        allowed_video_extensions = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
-        allowed_extensions = allowed_image_extensions | allowed_video_extensions
+        allowed_extensions = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
 
         file_extension = Path(filename).suffix.lower()
         if file_extension not in allowed_extensions:
@@ -773,7 +766,7 @@ async def upload_asset(request: Request, filename: str = Query(...)):
             )
 
         # Determine asset type
-        if file_extension in allowed_image_extensions:
+        if file_extension in IMAGE_EXTENSIONS:
             asset_type = "image"
         else:
             asset_type = "video"

--- a/src/scope/server/file_utils.py
+++ b/src/scope/server/file_utils.py
@@ -1,0 +1,44 @@
+"""Filesystem utilities for directory traversal with symlink support."""
+
+import logging
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
+LORA_EXTENSIONS = {".safetensors", ".bin", ".pt"}
+
+
+def iter_files(
+    directory: Path,
+    extensions: set[str],
+    *,
+    follow_symlinks: bool = True,
+) -> Iterator[Path]:
+    """Walk *directory* yielding files whose suffix is in *extensions*.
+
+    Uses :func:`os.walk` with ``followlinks=follow_symlinks`` so that
+    symlinked directories are traversed by default.  This is important on
+    Windows where ``pathlib.rglob`` does not follow symlinks.
+
+    Broken symlinks and inaccessible files are silently skipped.
+    """
+    if not directory.is_dir():
+        return
+
+    for root, _dirs, files in os.walk(directory, followlinks=follow_symlinks):
+        root_path = Path(root)
+        for filename in files:
+            if Path(filename).suffix.lower() not in extensions:
+                continue
+            file_path = root_path / filename
+            try:
+                if file_path.is_file():
+                    yield file_path
+            except (OSError, PermissionError) as e:
+                logger.debug(
+                    "iter_files: skipping inaccessible file %s: %s", file_path, e
+                )


### PR DESCRIPTION
Replace pathlib.rglob() with a shared iter_files() utility (scope.server.file_utils) that wraps os.walk(followlinks=True). This ensures symlinked directories are traversed on all platforms — notably Windows, where rglob does not follow symlinks.