### PR TITLE
Fix Git Bash path handling for plugin installation on Windows

### DIFF
--- a/frontend/src/components/settings/PluginsTab.tsx
+++ b/frontend/src/components/settings/PluginsTab.tsx
@@ -69,11 +69,7 @@ export function PluginsTab({
           <Input
             value={installPath}
             onChange={e => onInstallPathChange(e.target.value)}
-            placeholder={
-              isElectron
-                ? "PyPI package name, Git URL or local path"
-                : "PyPI package name or Git URL"
-            }
+            placeholder="PyPI package name, Git URL or local path"
             className="flex-1"
           />
           {isElectron && (

--- a/src/scope/core/plugins/manager.py
+++ b/src/scope/core/plugins/manager.py
@@ -839,6 +839,15 @@ class PluginManager:
         from .venv_snapshot import VenvSnapshot
 
         # Resolve package name early so we can clean up plugins.txt
+        # Convert Git Bash POSIX-style paths (e.g. /c/Users/...) to Windows paths
+        if (
+            sys.platform == "win32"
+            and len(package) >= 3
+            and package[0] == "/"
+            and package[1].isalpha()
+            and package[2] == "/"
+        ):
+            package = f"{package[1].upper()}:{package[2:]}"
         package_path = Path(package).resolve()
         package_name = self._get_package_name_from_path(package_path)
         normalized_name = self._normalize_package_name(package_name)
@@ -870,7 +879,7 @@ class PluginManager:
             "install",
             *_get_torch_backend_args(),
             "--editable",
-            package,
+            str(package_path),
         ]
 
         env = {**os.environ, "PYTHONUTF8": "1"}


### PR DESCRIPTION
## Summary
- Convert Git Bash POSIX-style paths (e.g. `/c/Users/...`) to proper Windows paths (`C:\Users\...`) before passing to `uv pip install --editable`, fixing plugin installation failures on Windows when using Git Bash
- Use the already-resolved `package_path` instead of raw input string in the subprocess call
- Allow pasting local paths in the plugin install input regardless of whether the app is running in Electron or browser

## Test plan
- [x] On Windows with Git Bash, paste a POSIX-style path (e.g. `/c/Users/yondo/Development/my-plugin`) into the plugin install input and verify it installs correctly
- [x] Verify normal Windows paths still work as before
- [x] Verify PyPI package names and Git URLs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)