### PR TITLE
docs: clarify local plugins work without desktop app

### DIFF
--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -168,6 +168,8 @@ For local/editable plugins, developers can trigger a reload to pick up code chan
 
 This triggers a server restart to ensure Python modules are fully reloaded.
 
+In standalone mode (without the desktop app), the reload flow is the same except the server performs a self-restart instead of being respawned by the desktop app (see [Standalone Mode](#standalone-mode)).
+
 ### Deep Link Installation Flow
 
 External sources can facilitate plugin installation via protocol URLs:
@@ -225,6 +227,8 @@ The `<spec>` parameter must be URL encoded. Examples:
 | **Deep Link Handler** | Receives and parses protocol URLs |
 | **IPC Bridge** | Communicates between main process and renderer |
 | **File Browser** | Native dialog for selecting local plugin directories |
+
+> **Note:** The File Browser is a desktop convenience feature. In standalone mode, users can type local paths directly into the plugin installation input field.
 
 ---
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -63,7 +63,7 @@ When using a local plugin directory, you can reload it after making code changes
 The experience of using plugins with a manual installation of Scope is very similar to the experience in the desktop app with the following exceptions:
 
 - No deep link support eg a website cannot auto-open the UI to facilitate plugin installation
-- No local plugin support
+- No browse button for selecting local plugin directories (you can still type a local path manually into the install field)
 
 ## Plugin Sources
 
@@ -475,3 +475,5 @@ def __init__(self, intensity: float = 1.0, **kwargs):
 ### Testing Your Plugin
 
 Make code changes and then see the section on [reloading local plugins](#reloading-a-plugin-local-plugins-only).
+
+> **Tip:** In the desktop app, you can use the browse button to select your local plugin directory. Without the desktop app, you can run `pwd` in the plugin directory to get the full path to paste into the install field which also works if you are running the server on a remote machine (eg. Runpod).


### PR DESCRIPTION
## Summary

- Updated plugin user guide and architecture docs to clarify that local plugins work in both desktop and standalone modes
- Replaced incorrect "No local plugin support" bullet with accurate description (only the browse button is desktop-exclusive)
- Added notes about standalone mode reload flow and File Browser being a convenience feature
- Added tip in Testing section for how to install local plugins with and without the desktop app

## Test plan

- [x] Read through both updated docs to confirm no remaining language implies local plugins are desktop-only
- [x] `npm run build` passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)