### PR TITLE
Add CLI commands section to plugins user guide

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -77,6 +77,52 @@ The experience of using plugins with a manual installation of Scope is very simi
 - No deep link support eg a website cannot auto-open the UI to facilitate plugin installation
 - No browse button for selecting local plugin directories (you can still type a local path manually into the install field)
 
+### Using Plugins from the CLI
+
+The `daydream-scope` CLI provides commands for managing plugins and pipelines directly from the terminal.
+
+#### Listing Installed Plugins
+
+```
+uv run daydream-scope plugins
+```
+
+Shows all installed plugins with their name, version, source, and registered pipelines.
+
+#### Installing a Plugin
+
+```
+uv run daydream-scope install <package>
+```
+
+Examples for each source type:
+
+```bash
+# From a Git repository
+uv run daydream-scope install https://github.com/user/plugin-repo
+
+# From PyPI
+uv run daydream-scope install my-scope-plugin
+
+# From a local directory (editable mode)
+uv run daydream-scope install -e /path/to/my-plugin
+```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `--upgrade` | Upgrade the plugin to the latest version |
+| `-e`, `--editable` | Install a project in editable mode from a local path |
+
+#### Uninstalling a Plugin
+
+```
+uv run daydream-scope uninstall <name>
+```
+
+Removes the plugin and unloads any active pipelines it provided.
+
 ## Plugin Sources
 
 Plugins can be installed from three sources:


### PR DESCRIPTION
## Summary
- Adds a new "Using Plugins from the CLI" section to `docs/plugins.md` documenting the `plugins`,  `install`, and `uninstall` CLI commands
- Covers command usage, examples for each plugin source type (Git, PyPI, local), and install options (`--upgrade`, `-e`/`--editable`)
- Placed after the existing "Manual Installation" section to group all three usage methods together

## Test plan
- [x] Verify rendered markdown displays correctly on GitHub
- [x] Confirm command examples match actual CLI behavior from `src/scope/server/app.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)