### PR TITLE
fix: stringify enum option values in plugin settings dropdown

### DIFF
--- a/frontend/src/components/PrimitiveFields.tsx
+++ b/frontend/src/components/PrimitiveFields.tsx
@@ -287,8 +287,8 @@ export function EnumField({
           </SelectTrigger>
           <SelectContent>
             {options.map(opt => (
-              <SelectItem key={opt} value={opt}>
-                {opt}
+              <SelectItem key={String(opt)} value={String(opt)}>
+                {String(opt)}
               </SelectItem>
             ))}
           </SelectContent>


### PR DESCRIPTION
  The EnumField component stringified the selected value but not the
  dropdown options, causing Radix Select's strict equality check to fail
  for non-string Literal types (e.g. Literal[0, 1]). The dropdown would
  render options when opened but show nothing when closed.