### PR TITLE
Fix docs inaccuracies in API examples and import paths

### DIFF
--- a/docs/api/sendreceive.md
+++ b/docs/api/sendreceive.md
@@ -279,8 +279,9 @@ When VACE is enabled on the pipeline (default), input video is routed through VA
 
 ```javascript
 // Load with VACE disabled for traditional V2V
-await loadPipeline("longlive", {
-  vace_enabled: false
+await loadPipeline({
+  pipeline_ids: ["longlive"],
+  load_params: { vace_enabled: false }
 });
 ```
 

--- a/docs/api/vace.md
+++ b/docs/api/vace.md
@@ -17,8 +17,9 @@ VACE allows you to:
 1. Pipeline loaded with VACE enabled (default):
 
 ```javascript
-await loadPipeline("longlive", {
-  vace_enabled: true  // This is the default
+await loadPipeline({
+  pipeline_ids: ["longlive"],
+  load_params: { vace_enabled: true }  // This is the default
 });
 ```
 

--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -423,7 +423,7 @@ The registry maintains a mapping of pipeline IDs to their implementation classes
 **Plugin pipelines** register through the pluggy hook system:
 
 ```python
-from scope.core.pipelines.hookspecs import hookimpl
+from scope.core.plugins.hookspecs import hookimpl
 
 @hookimpl
 def register_pipelines(register):

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -409,7 +409,7 @@ my_plugin = "my_plugin.plugin"
 ### Hook Implementation
 
 ```python
-from scope.core.pipelines.hookspecs import hookimpl
+from scope.core.plugins.hookspecs import hookimpl
 
 @hookimpl
 def register_pipelines(register):

--- a/docs/server.md
+++ b/docs/server.md
@@ -81,7 +81,7 @@ Create a file named `index.html` with the following content:
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          pipeline_id: "longlive"
+          pipeline_ids: ["longlive"]
         })
       });
 


### PR DESCRIPTION
## Summary

- **Quick Start** (`server.md`): Fixed `pipeline_id: "longlive"` → `pipeline_ids: ["longlive"]` to match `PipelineLoadRequest` schema
- **Send-Receive API** (`api/sendreceive.md`): Fixed `loadPipeline()` call from undefined two-arg signature to canonical `{ pipeline_ids, load_params }` form
- **VACE API** (`api/vace.md`): Same `loadPipeline()` signature fix
- **Pipeline Architecture** (`architecture/pipelines.md`): Fixed `hookimpl` import from `scope.core.pipelines.hookspecs` → `scope.core.plugins.hookspecs`
- **Plugin Architecture** (`architecture/plugins.md`): Same import path fix

These were found during the Mintlify docs migration by cross-referencing against the actual codebase (`server/schema.py`, `core/plugins/hookspecs.py`).