### PR TITLE
Fix memflow unflatten crash when sequence length is multiple of 128

### DIFF
--- a/src/scope/core/pipelines/memflow/modules/causal_model.py
+++ b/src/scope/core/pipelines/memflow/modules/causal_model.py
@@ -298,7 +298,10 @@ class CausalWanSelfAttention(nn.Module):
                     key=padded_roped_key.transpose(2, 1),
                     value=padded_v.transpose(2, 1),
                     block_mask=block_mask,
-                )[:, :, :-padded_length].transpose(2, 1)
+                )
+                if padded_length > 0:
+                    x = x[:, :, :-padded_length]
+                x = x.transpose(2, 1)
 
             else:
                 roped_query = rope_apply(q, grid_sizes, freqs).type_as(v)
@@ -346,7 +349,10 @@ class CausalWanSelfAttention(nn.Module):
                     key=padded_roped_key.transpose(2, 1),
                     value=padded_v.transpose(2, 1),
                     block_mask=block_mask,
-                )[:, :, :-padded_length].transpose(2, 1)
+                )
+                if padded_length > 0:
+                    x = x[:, :, :-padded_length]
+                x = x.transpose(2, 1)
         else:
             frame_seqlen = math.prod(grid_sizes[0][1:]).item()
             current_start_frame = current_start // frame_seqlen


### PR DESCRIPTION
## Summary
- **Commit 1 (formatting):** Auto-formats `causal_model.py` with ruff (import sorting, trailing commas, line wrapping). No behavioral changes — reviewers can skip this commit.
- **Commit 2 (bug fix):** Adds `if padded_length > 0:` guards before slicing `x[:, :, :-padded_length]` in two places in `CausalWanSelfAttention.forward()`. When the sequence length is already a multiple of 128, `padded_length` is 0 and `[:-0]` returns an empty tensor instead of a no-op, causing a crash.

Replaces #418 with cleanly separated commits.

## Test plan
- [ ] Verify `git diff HEAD~1` shows only the 4-line fix
- [ ] Run memflow pipeline with a sequence length that is a multiple of 128
- [ ] Run memflow pipeline with a sequence length that is NOT a multiple of 128 (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)