### PR TITLE
Fix gray pipeline missing return statement

### DIFF
--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -1072,6 +1072,7 @@ class PipelineManager:
                 device=get_device(),
             )
             logger.info("Gray pipeline initialized")
+            return pipeline
 
         elif pipeline_id == "optical-flow":
             from scope.core.pipelines import OpticalFlowPipeline


### PR DESCRIPTION
## Summary
- Added missing `return pipeline` in the gray pipeline case of `_load_pipeline_implementation`, which caused the function to implicitly return `None`
- This resulted in `'NoneType' object is not callable` errors when processing frames through the gray pipeline
- All other built-in pipelines already had their return statements; gray was the only one missing it

## Test plan
- [x] Load the gray pipeline and verify frames are processed without errors
- [x] Confirm no regression in other built-in pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)