### PR TITLE
Add runtime kernel validation for SageAttention

### DIFF
--- a/src/scope/core/pipelines/wan2_1/modules/sage.py
+++ b/src/scope/core/pipelines/wan2_1/modules/sage.py
@@ -29,6 +29,41 @@ try:
     def _sageattn_fake(q, k, v, attn_mask=None, dropout_p=0, is_causal=False):
         return torch.empty(*q.shape, device=q.device, dtype=q.dtype)
 
+    # Runtime kernel probe: verify the AOT-compiled CUDA kernels support this GPU.
+    # The import can succeed even when kernels are incompatible (e.g. precompiled
+    # wheel missing sm_89). The error is async, so torch.cuda.synchronize() is
+    # needed to surface it.
+    if torch.cuda.is_available():
+        _q = torch.randn(1, 16, 64, 128, dtype=torch.bfloat16, device="cuda")
+        _k = torch.randn(1, 16, 64, 128, dtype=torch.bfloat16, device="cuda")
+        _v = torch.randn(1, 16, 64, 128, dtype=torch.bfloat16, device="cuda")
+        try:
+            sageattn_func(_q, _k, _v)
+            torch.cuda.synchronize()
+        except Exception as probe_err:
+            raise RuntimeError(
+                "SageAttention kernel probe failed — kernels are not "
+                f"compatible with this GPU: {probe_err}"
+            ) from probe_err
+        finally:
+            del _q, _k, _v
+
+        # CUDA health check: verify the CUDA context is still functional after
+        # loading SageAttention's native extensions.  Some builds register
+        # kernels whose deferred errors only surface on the next CUDA call.
+        _a = _b = None
+        try:
+            _a = torch.randn(256, 256, dtype=torch.bfloat16, device="cuda")
+            _b = _a @ _a.T
+            torch.cuda.synchronize()
+        except Exception as health_err:
+            raise RuntimeError(
+                "CUDA health check failed after loading SageAttention — "
+                f"native extensions are incompatible with this GPU: {health_err}"
+            ) from health_err
+        finally:
+            del _a, _b
+
     print("SageAttention loaded successfully")
 
     SAGEATTN_AVAILABLE = True
@@ -38,4 +73,6 @@ except Exception as e:
         print("sageattention package is not installed")
     elif isinstance(e, ImportError) and "DLL" in str(e):
         print("sageattention DLL loading error")
+    elif "kernel probe failed" in str(e) or "health check failed" in str(e):
+        print("sageattention kernels are not compatible with this GPU.")
     sageattn_func = None


### PR DESCRIPTION
## Summary
- Adds a runtime CUDA kernel probe after the SageAttention import succeeds, catching incompatible precompiled kernels (e.g. `cudaErrorNoKernelImageForDevice`) before inference rather than at inference time
- Allocates small test tensors, calls `sageattn()`, and `torch.cuda.synchronize()` to surface async CUDA errors
- On failure, sets `SAGEATTN_AVAILABLE = False` with a clear diagnostic message, allowing automatic fallback to Flash Attention

## Test plan
- [ ] `uv run daydream-scope --no-browser` starts without errors on a machine with compatible SageAttention
- [ ] On a machine with incompatible SageAttention kernels (e.g. precompiled wheel missing the GPU's sm arch), the probe fails gracefully and prints `sageattention kernels are not compatible with this GPU.`
- [ ] `DISABLE_SAGEATTENTION=1` still bypasses SageAttention before the probe runs
- [ ] Inference works via Flash Attention fallback when probe fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)