### PR TITLE
Fix none error on session close

### DIFF
--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -115,7 +115,7 @@ class FrameProcessor:
         # This determines whether we wait for video frames or generate immediately.
         self._video_mode = (initial_parameters or {}).get("input_mode") == "video"
 
-        # Pipeline chaining support (local mode only)
+        # Pipeline chaining support
         self.pipeline_processors: list[PipelineProcessor] = []
         self.pipeline_ids: list[str] = []
 

--- a/src/scope/server/tracks.py
+++ b/src/scope/server/tracks.py
@@ -185,4 +185,4 @@ class VideoProcessingTrack(MediaStreamTrack):
         if self.frame_processor is not None:
             self.frame_processor.stop()
 
-        await super().stop()
+        super().stop()

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -78,7 +78,10 @@ class Session:
             if self.video_track is not None:
                 await self.video_track.stop()
 
-            if self.pc.connectionState not in ["closed", "failed"]:
+            if self.pc is not None and self.pc.connectionState not in [
+                "closed",
+                "failed",
+            ]:
                 await self.pc.close()
 
             logger.info(f"Session {self.id} closed")


### PR DESCRIPTION
The culprit ended up being:
https://github.com/daydreamlive/scope/blob/6d504dcb0713bd7c6accb3db23cd6781876ac454/src/scope/server/tracks.py#L188

This was not an async function so await was returning `object NoneType can't be used in 'await' expression`