### PR TITLE
Avoid sending local image paths for cloud mode

### DIFF
--- a/frontend/src/components/InputAndControlsPanel.tsx
+++ b/frontend/src/components/InputAndControlsPanel.tsx
@@ -27,6 +27,7 @@ import {
   parseInputFields,
 } from "../lib/schemaSettings";
 import { SchemaPrimitiveField } from "./PrimitiveFields";
+import { useCloudStatus } from "../hooks/useCloudStatus";
 
 interface InputAndControlsPanelProps {
   className?: string;
@@ -173,6 +174,33 @@ export function InputAndControlsPanel({
       videoRef.current.srcObject = localStream;
     }
   }, [localStream]);
+
+  // Track cloud connection state and clear images when it changes
+  // (switching between local/cloud means different asset lists)
+  const { isConnected: isCloudConnected } = useCloudStatus();
+  const prevCloudConnectedRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    // On first render, just store the initial state
+    if (prevCloudConnectedRef.current === null) {
+      prevCloudConnectedRef.current = isCloudConnected;
+      return;
+    }
+
+    // Clear images when cloud connection state changes (connected or disconnected)
+    if (prevCloudConnectedRef.current !== isCloudConnected) {
+      onRefImagesChange?.([]);
+      onFirstFrameImageChange?.(undefined);
+      onLastFrameImageChange?.(undefined);
+    }
+
+    prevCloudConnectedRef.current = isCloudConnected;
+  }, [
+    isCloudConnected,
+    onRefImagesChange,
+    onFirstFrameImageChange,
+    onLastFrameImageChange,
+  ]);
 
   const handleFileUpload = async (
     event: React.ChangeEvent<HTMLInputElement>

--- a/frontend/src/components/MediaPicker.tsx
+++ b/frontend/src/components/MediaPicker.tsx
@@ -7,6 +7,7 @@ import {
   getAssetUrl,
   type AssetFileInfo,
 } from "../lib/api";
+import { useCloudStatus } from "../hooks/useCloudStatus";
 
 interface MediaPickerProps {
   isOpen: boolean;
@@ -44,6 +45,25 @@ export function MediaPicker({
       loadImages();
     }
   }, [isOpen]);
+
+  // Refresh image list when cloud connection state changes while picker is open
+  const { isConnected: isCloudConnected } = useCloudStatus();
+  const prevCloudConnectedRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    // Skip first render
+    if (prevCloudConnectedRef.current === null) {
+      prevCloudConnectedRef.current = isCloudConnected;
+      return;
+    }
+
+    // If connection state changed and picker is open, reload images
+    if (prevCloudConnectedRef.current !== isCloudConnected && isOpen) {
+      loadImages();
+    }
+
+    prevCloudConnectedRef.current = isCloudConnected;
+  }, [isCloudConnected, isOpen, loadImages]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/src/scope/cloud/fal_app.py
+++ b/src/scope/cloud/fal_app.py
@@ -437,7 +437,6 @@ class ScopeApp(fal.App, keep_alive=300):
         async def check_max_duration_exceeded() -> bool:
             """Check if connection has exceeded max duration. Returns True if should close."""
             elapsed_seconds = time.time() - connection_start_time
-            print(f"[{log_prefix()}] Checking max duration: {elapsed_seconds:.0f}s")
             if elapsed_seconds >= MAX_CONNECTION_DURATION_SECONDS:
                 print(
                     f"[{log_prefix()}] Closing due to max duration ({elapsed_seconds:.0f}s)"


### PR DESCRIPTION
Fix the situation where we might reference local image paths on the cloud server, we now:
- Clear previously selected images on cloud connection state change
- Refresh the list in the image picker dynamically when the connection state changes rather than only when opening the picker