### PR TITLE
Prevalidate plugin entrypoints to check for broken plugins

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import {
   restartServer,
   waitForServer,
   getServerInfo,
+  type FailedPluginInfo,
 } from "@/lib/api";
 import { toast } from "sonner";
 
@@ -70,6 +71,7 @@ export function SettingsDialog({
   const [reportBugOpen, setReportBugOpen] = useState(false);
   const [pluginInstallPath, setPluginInstallPath] = useState(initialPluginPath);
   const [plugins, setPlugins] = useState<InstalledPlugin[]>([]);
+  const [failedPlugins, setFailedPlugins] = useState<FailedPluginInfo[]>([]);
   const [isLoadingPlugins, setIsLoadingPlugins] = useState(false);
   const [isInstalling, setIsInstalling] = useState(false);
   const [activeTab, setActiveTab] = useState<string>(initialTab);
@@ -117,6 +119,7 @@ export function SettingsDialog({
           package_spec: p.package_spec,
         }))
       );
+      setFailedPlugins(response.failed_plugins ?? []);
     } catch (error) {
       console.error("Failed to fetch plugins:", error);
       // Don't show error toast during install/update/uninstall operations
@@ -274,6 +277,9 @@ export function SettingsDialog({
 
         // Optimistically remove plugin from local state
         setPlugins(prev => prev.filter(p => p.name !== pluginName));
+        setFailedPlugins(prev =>
+          prev.filter(fp => fp.package_name !== pluginName)
+        );
 
         // Trigger restart and wait for server to come back
         const oldStartTime = await restartServer();
@@ -377,6 +383,7 @@ export function SettingsDialog({
             <TabsContent value="plugins" className="mt-0">
               <PluginsTab
                 plugins={plugins}
+                failedPlugins={failedPlugins}
                 installPath={pluginInstallPath}
                 onInstallPathChange={setPluginInstallPath}
                 onBrowse={handleBrowseLocalPlugin}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -467,9 +467,17 @@ export interface PluginInfo {
   package_spec: string | null;
 }
 
+export interface FailedPluginInfo {
+  package_name: string;
+  entry_point_name: string;
+  error_type: string;
+  error_message: string;
+}
+
 export interface PluginListResponse {
   plugins: PluginInfo[];
   total: number;
+  failed_plugins: FailedPluginInfo[];
 }
 
 export interface PluginInstallRequest {

--- a/src/scope/core/pipelines/registry.py
+++ b/src/scope/core/pipelines/registry.py
@@ -220,10 +220,15 @@ def _initialize_registry():
     _register_pipelines()
 
     # Load and register plugin pipelines
-    from scope.core.plugins import load_plugins, register_plugin_pipelines
+    try:
+        from scope.core.plugins import load_plugins, register_plugin_pipelines
 
-    load_plugins()
-    register_plugin_pipelines(PipelineRegistry)
+        load_plugins()
+        register_plugin_pipelines(PipelineRegistry)
+    except Exception as e:
+        logger.error(
+            f"Failed to load plugins: {e}. Built-in pipelines are still available."
+        )
 
     pipeline_count = len(PipelineRegistry.list_pipelines())
     logger.info(f"Registry initialized with {pipeline_count} pipeline(s)")

--- a/src/scope/core/plugins/__init__.py
+++ b/src/scope/core/plugins/__init__.py
@@ -2,6 +2,7 @@
 
 from .hookspecs import hookimpl
 from .manager import (
+    FailedPluginInfo,
     PluginDependencyError,
     PluginInstallError,
     PluginInUseError,
@@ -21,6 +22,7 @@ __all__ = [
     "pm",
     "register_plugin_pipelines",
     "get_plugin_manager",
+    "FailedPluginInfo",
     "PluginManager",
     "PluginNotFoundError",
     "PluginNotEditableError",

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -1309,7 +1309,7 @@ async def list_plugins():
     """List all installed plugins with metadata."""
     from scope.core.plugins import get_plugin_manager
 
-    from .schema import PluginListResponse
+    from .schema import FailedPluginInfoSchema, PluginListResponse
 
     try:
         plugin_manager = get_plugin_manager()
@@ -1317,7 +1317,19 @@ async def list_plugins():
 
         plugins = [_convert_plugin_dict_to_info(p) for p in plugins_data]
 
-        return PluginListResponse(plugins=plugins, total=len(plugins))
+        failed = [
+            FailedPluginInfoSchema(
+                package_name=f.package_name,
+                entry_point_name=f.entry_point_name,
+                error_type=f.error_type,
+                error_message=f.error_message,
+            )
+            for f in plugin_manager.get_failed_plugins()
+        ]
+
+        return PluginListResponse(
+            plugins=plugins, total=len(plugins), failed_plugins=failed
+        )
     except Exception as e:
         logger.error(f"Error listing plugins: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/scope/server/schema.py
+++ b/src/scope/server/schema.py
@@ -565,11 +565,28 @@ class PluginInfo(BaseModel):
     )
 
 
+class FailedPluginInfoSchema(BaseModel):
+    """Information about a plugin entry point that failed to load."""
+
+    package_name: str = Field(..., description="Package name of the failed plugin")
+    entry_point_name: str = Field(
+        ..., description="Entry point name that failed to load"
+    )
+    error_type: str = Field(
+        ..., description="Exception type (e.g. ModuleNotFoundError)"
+    )
+    error_message: str = Field(..., description="Error message from the exception")
+
+
 class PluginListResponse(BaseModel):
     """Response containing list of all installed plugins."""
 
     plugins: list[PluginInfo] = Field(..., description="List of installed plugins")
     total: int = Field(..., description="Total number of plugins")
+    failed_plugins: list[FailedPluginInfoSchema] = Field(
+        default_factory=list,
+        description="Plugins that failed to load at startup",
+    )
 
 
 class PluginInstallRequest(BaseModel):


### PR DESCRIPTION
## Summary
- **Plugin manager**: Added `_prevalidate_entrypoints()` which enforces a single entry point per plugin, records failures as `FailedPluginInfo`, and blocks broken entry points from being registered in pluggy
- **API**: `GET /api/v1/plugins` now returns `failed_plugins` alongside `plugins` so the frontend can surface errors
- **Frontend**: `PluginsTab` shows a warning banner and per-plugin error details when plugins fail to load
- **Registry**: Wraps plugin pipeline loading in try/except so built-in pipelines survive plugin failures
- **Tests**: 8 new tests covering error handling, blocking, failure recording, and pipeline registration resilience

## Test plan
- [x] Run `uv run pytest tests/test_plugin_manager.py` — all 8 new tests pass
- [x] Install a plugin with a broken entry point (e.g. bad import) and confirm it appears in the failed plugins UI
- [x] Confirm healthy plugins still load and built-in pipelines are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)