### PR TITLE
Fix desktop app running stale code and deps after updates

### DIFF
--- a/app/src/services/pythonProcess.ts
+++ b/app/src/services/pythonProcess.ts
@@ -84,7 +84,6 @@ export class ScopePythonProcessService implements PythonProcessService {
 
     const child = spawn(uvCommand, [
       'run',
-      '--no-sync',
       'daydream-scope',
       '--host',
       SERVER_CONFIG.host,
@@ -98,6 +97,10 @@ export class ScopePythonProcessService implements PythonProcessService {
       env: {
         ...process.env,
         PATH: pathEnv,
+        // Always use the project's own source code, even if the installed
+        // editable package points at a stale location. PYTHONPATH is checked
+        // before site-packages, so third-party deps still resolve from the venv.
+        PYTHONPATH: path.join(projectRoot, 'src'),
         PYTHONUNBUFFERED: '1',
         // Use UV_PROJECT_ENVIRONMENT to use .venv from userData (writable)
         // while running source code from resources (read-only)


### PR DESCRIPTION
## Summary

- **Add `PYTHONPATH`** pointing at `projectRoot/src` so Python always reads current source code before site-packages, fixing stale editable-install imports.
- **Remove `--no-sync`** from `uv run` spawn args so uv's default inexact sync installs missing packages from `uv.lock` on each launch. Inexact sync does not remove extra packages, so plugins remain safe.

## Test plan

- [x] Build the desktop app and confirm the server starts normally
- [x] Verify that after updating source code, the desktop app runs the new code
- [x] Install a plugin, restart the app, and confirm the plugin persists (not removed by sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)