### PR TITLE
fix: clear Electron HTTP cache on startup to prevent stale frontend

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -828,6 +828,9 @@ function configureProcessSecurity(): void {
  * Application ready handler
  */
 app.on('ready', async () => {
+  // Clear HTTP cache to ensure fresh frontend after updates
+  await session.defaultSession.clearCache();
+
   // Configure session permissions early
   await configureSessionPermissions();
 


### PR DESCRIPTION
## Summary
- Clears Chromium's HTTP session cache at the start of `app.on('ready')` before any window creation or frontend loading
- Prevents stale frontend assets from being served after app updates, since the cache in `%APPDATA%/daydream-scope/` persists across updates
- Single-line addition: `await session.defaultSession.clearCache()`

## Test plan
- [x] Build packaged app (`npm run dist:win`), run it, confirm it starts correctly
- [x] Verify no regressions in the setup/loading flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)