### PR TITLE
fix(ci): skip postinstall script when updating app lock file

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: frontend
 
       - name: Update app lock file
-        run: npm install --package-lock-only
+        run: npm install --package-lock-only --ignore-scripts
         working-directory: app
 
       - name: Verify versions updated


### PR DESCRIPTION
## Summary
- Adds `--ignore-scripts` to `npm install --package-lock-only` for the `app/` lock file update in the version-bump workflow
- The `app/package.json` postinstall script (`npx electron-builder install-app-deps`) fails when no `node_modules` are present, which is the case during a lock-file-only install
- We only need the lock file updated, so skipping lifecycle scripts is safe

## Test plan
- [ ] Re-run the `version-bump.yml` workflow and verify the app lock file step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)