### PR TITLE
fix: clear stale pipeline error statuses when loading new pipelines

### DIFF
--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -403,6 +403,14 @@ class PipelineManager:
         with self._lock:
             self._load_params = load_params
 
+            # Clear stale statuses for pipelines not in the new load list
+            # This prevents ERROR statuses from a previous failed load from
+            # poisoning the overall status when loading new pipelines
+            new_pipeline_set = set(pipeline_ids)
+            for pid in list(self._pipeline_statuses.keys()):
+                if pid not in new_pipeline_set:
+                    del self._pipeline_statuses[pid]
+
             # Identify pipelines that need to be unloaded:
             # 1. Currently loaded but not in new list
             # 2. In new list but with different load_params (e.g., different resolution)


### PR DESCRIPTION
## Summary
- After a pipeline fails to load, its ERROR status persists in `_pipeline_statuses`. When loading a different pipeline next, `get_status_info()` still sees the stale ERROR and reports overall status as ERROR — preventing the new pipeline from ever starting.
- Fix: clear statuses for pipelines not in the new load list at the start of `_load_pipelines_sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)