### PR TITLE
Dual push Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -101,5 +101,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.tag.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/daydreamlive/scope
+            org.opencontainers.image.description=Daydream Scope
+            org.opencontainers.image.licenses=MIT
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
We've been hitting issues with pull rate limiting on Docker Hub, so adding GHCR as a second option.