### PR TITLE
Fix plugins disappearing after server restart

### DIFF
--- a/src/scope/core/pipelines/registry.py
+++ b/src/scope/core/pipelines/registry.py
@@ -221,8 +221,13 @@ def _initialize_registry():
 
     # Load and register plugin pipelines
     try:
-        from scope.core.plugins import load_plugins, register_plugin_pipelines
+        from scope.core.plugins import (
+            ensure_plugins_installed,
+            load_plugins,
+            register_plugin_pipelines,
+        )
 
+        ensure_plugins_installed()
         load_plugins()
         register_plugin_pipelines(PipelineRegistry)
     except Exception as e:

--- a/src/scope/core/plugins/__init__.py
+++ b/src/scope/core/plugins/__init__.py
@@ -10,6 +10,7 @@ from .manager import (
     PluginNameCollisionError,
     PluginNotEditableError,
     PluginNotFoundError,
+    ensure_plugins_installed,
     get_plugin_manager,
     load_plugins,
     pm,
@@ -18,6 +19,7 @@ from .manager import (
 
 __all__ = [
     "hookimpl",
+    "ensure_plugins_installed",
     "load_plugins",
     "pm",
     "register_plugin_pipelines",


### PR DESCRIPTION
## Summary

- Adds self-healing plugin re-sync on server startup that detects missing plugin packages and reinstalls them from `resolved.txt`
- Fixes #465: plugins disappear after server restart when the venv is recreated (e.g., uv upgrade in desktop app)
- Adds unit tests for the new `_is_package_installed()` and `ensure_plugins_installed()` methods

## How it works

On every server startup, before plugin discovery runs, `ensure_plugins_installed()` checks whether each plugin listed in `plugins.txt` is actually installed in the environment. If all are present, it returns immediately (fast no-op). If any are missing (e.g., due to venv recreation from a uv upgrade), it reinstalls them from `resolved.txt`, which skips already-installed packages quickly.

## Test plan

- [x] `uv run pytest tests/test_plugin_manager.py::TestIsPackageInstalled tests/test_plugin_manager.py::TestEnsurePluginsInstalled` — 13 tests pass
- [x] `uv run daydream-scope --no-browser` starts without errors
- [x] Install a plugin, then `uv pip uninstall <plugin>` (simulating venv loss), restart server — plugin is reinstalled from manifest
- [x] Restart server with all plugins present — no reinstall activity in logs (fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)