### PR TITLE
Fix plugins.txt name matching for git URLs and local paths

### DIFF
--- a/src/scope/core/plugins/manager.py
+++ b/src/scope/core/plugins/manager.py
@@ -16,7 +16,12 @@ import pluggy
 
 from .dependency_validator import DependencyValidator
 from .hookspecs import ScopeHookSpec
-from .plugins_config import ensure_plugins_dir, get_plugins_file, get_resolved_file
+from .plugins_config import (
+    ensure_plugins_dir,
+    get_plugins_dir,
+    get_plugins_file,
+    get_resolved_file,
+)
 
 if TYPE_CHECKING:
     from scope.core.pipelines.registry import PipelineRegistry
@@ -120,6 +125,75 @@ class PluginManager:
         ensure_plugins_dir()
         get_plugins_file().write_text("\n".join(plugins) + "\n" if plugins else "")
 
+    def _generate_constraints(self) -> Path | None:
+        """Generate a pip constraints file from uv.lock.
+
+        Finds the root project package in uv.lock (identified by
+        ``source.editable``), reads its direct dependency names, then looks up
+        each dependency's locked version to produce constraints of the form
+        ``name>=locked_version,<next_major`` (e.g. ``transformers>=4.57.5,<5``).
+        """
+        import tomllib
+
+        lock_file = Path.cwd() / "uv.lock"
+
+        if not lock_file.exists():
+            return None
+
+        try:
+            lock_text = lock_file.read_text(encoding="utf-8")
+            lock_data = tomllib.loads(lock_text)
+
+            packages = lock_data.get("package", [])
+
+            # Find the root project (editable source) and collect all versions
+            direct_dep_names: set[str] = set()
+            locked_versions: dict[str, str] = {}
+
+            for pkg in packages:
+                name = pkg.get("name", "")
+                version = pkg.get("version", "")
+                source = pkg.get("source", {})
+
+                if name and version:
+                    locked_versions[name.lower().replace("-", "_")] = version
+
+                # Root project has source = { editable = "." }
+                if isinstance(source, dict) and "editable" in source:
+                    for dep in pkg.get("dependencies", []):
+                        dep_name = dep.get("name", "")
+                        if dep_name:
+                            direct_dep_names.add(dep_name.lower().replace("-", "_"))
+
+            if not direct_dep_names:
+                return None
+
+            constraints = []
+            for norm_name in sorted(direct_dep_names):
+                version = locked_versions.get(norm_name)
+                if not version:
+                    continue
+
+                # Skip platform-specific builds (e.g. 2.9.1+cu128)
+                if "+" in version:
+                    continue
+
+                major = version.split(".")[0]
+                next_major = int(major) + 1
+                constraints.append(
+                    f"{norm_name.replace('_', '-')}>={version},<{next_major}"
+                )
+
+            if not constraints:
+                return None
+
+            constraints_file = get_plugins_dir() / "constraints.txt"
+            constraints_file.write_text("\n".join(constraints) + "\n")
+            return constraints_file
+        except Exception:
+            logger.warning("Failed to generate constraints", exc_info=True)
+            return None
+
     def _compile_plugins(
         self, upgrade_package: str | None = None
     ) -> tuple[bool, str, str | None]:
@@ -155,6 +229,10 @@ class PluginManager:
         # Add plugins file if it exists and has content
         if plugins_file.exists() and plugins_file.read_text().strip():
             args.append(str(plugins_file))
+
+        constraints_file = self._generate_constraints()
+        if constraints_file:
+            args.extend(["--constraint", str(constraints_file)])
 
         if upgrade_package:
             args.extend(["--upgrade-package", upgrade_package])
@@ -212,18 +290,26 @@ class PluginManager:
         """Extract package name from a specifier.
 
         Handles various formats:
-        - git+https://github.com/user/repo.git -> repo
-        - git+https://github.com/user/repo.git@branch -> repo
+        - git+https://github.com/user/repo.git -> package name from resolved.txt or repo
+        - git+https://github.com/user/repo.git@branch -> package name from resolved.txt or repo
+        - /path/to/local/dir -> package name from pyproject.toml or dir basename
         - package==1.0 -> package
         - package>=1.0,<2.0 -> package
         - package[extra] -> package
         """
-        # Handle git URLs: git+https://github.com/user/repo.git -> repo
         if spec.startswith("git+"):
-            # Extract repo name from URL
+            # Try resolved.txt for the authoritative name
+            resolved_name = self._get_name_from_resolved(spec)
+            if resolved_name:
+                return resolved_name
+            # Fallback to repo name
             url_part = spec.split("@")[0]  # Remove @branch or @commit
-            repo_name = url_part.split("/")[-1].replace(".git", "")
-            return repo_name
+            return url_part.split("/")[-1].replace(".git", "")
+
+        # Handle local directory paths (reuse existing helper)
+        path = Path(spec)
+        if path.is_dir():
+            return self._get_package_name_from_path(path)
 
         # Handle version specifiers and extras
         # Split on any version specifier chars and take first part
@@ -357,16 +443,22 @@ class PluginManager:
             f"{missing}. Re-installing from plugin manifest..."
         )
 
-        resolved_file = get_resolved_file()
-        if resolved_file.exists():
-            success, error = self._sync_plugins(str(resolved_file))
-        else:
-            logger.info("No resolved.txt found, recompiling plugins first...")
-            ok, resolved_path, compile_error = self._compile_plugins()
-            if not ok:
+        # Always recompile to ensure resolved.txt respects current lock constraints
+        logger.info("Compiling plugins against current lock constraints...")
+        ok, resolved_path, compile_error = self._compile_plugins()
+        if not ok:
+            # Fall back to existing resolved.txt if compile fails
+            resolved_file = get_resolved_file()
+            if resolved_file.exists():
+                logger.warning(
+                    f"Compile failed ({compile_error}), "
+                    "falling back to existing resolved.txt"
+                )
+                resolved_path = str(resolved_file)
+            else:
                 logger.error(f"Failed to compile plugins: {compile_error}")
                 return
-            success, error = self._sync_plugins(resolved_path)
+        success, error = self._sync_plugins(resolved_path)
 
         if success:
             logger.info("Successfully re-installed missing plugins")
@@ -742,6 +834,28 @@ class PluginManager:
         if match:
             return match.group(1)
 
+        return None
+
+    def _get_name_from_resolved(self, git_url: str) -> str | None:
+        """Look up the package name for a git URL from resolved.txt."""
+        resolved_file = get_resolved_file()
+        if not resolved_file.exists():
+            return None
+        content = resolved_file.read_text(encoding="utf-8")
+        # Normalize: strip git+ prefix and .git suffix for comparison
+        normalized_url = git_url.removeprefix("git+").removesuffix(".git").lower()
+        # Also strip @branch/@commit from the input URL
+        normalized_url = normalized_url.split("@")[0].removesuffix(".git")
+        for line in content.splitlines():
+            if " @ git+" not in line:
+                continue
+            # "flashvsr @ git+https://...@commit"
+            name_part, _, url_part = line.partition(" @ ")
+            url_base = (
+                url_part.removeprefix("git+").split("@")[0].removesuffix(".git").lower()
+            )
+            if url_base == normalized_url:
+                return name_part.strip()
         return None
 
     async def get_plugin_info_async(self, name: str) -> dict[str, Any] | None:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1506,8 +1506,27 @@ class TestEnsurePluginsInstalled:
 
         mock_sync.assert_not_called()
 
-    def test_syncs_from_resolved_when_missing(self, tmp_path):
-        """Should call _sync_plugins with resolved.txt when plugins are missing."""
+    def test_syncs_from_compile_when_missing(self):
+        """Should call _compile_plugins then _sync_plugins when plugins are missing."""
+        pm = PluginManager()
+
+        with patch.object(pm, "_read_plugins_file", return_value=["plugin-a"]):
+            with patch.object(pm, "_is_package_installed", return_value=False):
+                with patch.object(
+                    pm,
+                    "_compile_plugins",
+                    return_value=(True, "/tmp/resolved.txt", None),
+                ) as mock_compile:
+                    with patch.object(
+                        pm, "_sync_plugins", return_value=(True, None)
+                    ) as mock_sync:
+                        pm.ensure_plugins_installed()
+
+        mock_compile.assert_called_once()
+        mock_sync.assert_called_once_with("/tmp/resolved.txt")
+
+    def test_always_recompiles_even_when_resolved_exists(self, tmp_path):
+        """Should always recompile, not use existing resolved.txt directly."""
         pm = PluginManager()
 
         resolved = tmp_path / "resolved.txt"
@@ -1515,41 +1534,18 @@ class TestEnsurePluginsInstalled:
 
         with patch.object(pm, "_read_plugins_file", return_value=["plugin-a"]):
             with patch.object(pm, "_is_package_installed", return_value=False):
-                with patch(
-                    "scope.core.plugins.manager.get_resolved_file",
-                    return_value=resolved,
-                ):
+                with patch.object(
+                    pm,
+                    "_compile_plugins",
+                    return_value=(True, "/tmp/new-resolved.txt", None),
+                ) as mock_compile:
                     with patch.object(
                         pm, "_sync_plugins", return_value=(True, None)
                     ) as mock_sync:
                         pm.ensure_plugins_installed()
 
-        mock_sync.assert_called_once_with(str(resolved))
-
-    def test_compiles_then_syncs_when_no_resolved(self, tmp_path):
-        """Should compile first if resolved.txt doesn't exist."""
-        pm = PluginManager()
-
-        resolved = tmp_path / "resolved.txt"  # Does not exist
-
-        with patch.object(pm, "_read_plugins_file", return_value=["plugin-a"]):
-            with patch.object(pm, "_is_package_installed", return_value=False):
-                with patch(
-                    "scope.core.plugins.manager.get_resolved_file",
-                    return_value=resolved,
-                ):
-                    with patch.object(
-                        pm,
-                        "_compile_plugins",
-                        return_value=(True, "/tmp/resolved.txt", None),
-                    ) as mock_compile:
-                        with patch.object(
-                            pm, "_sync_plugins", return_value=(True, None)
-                        ) as mock_sync:
-                            pm.ensure_plugins_installed()
-
         mock_compile.assert_called_once()
-        mock_sync.assert_called_once_with("/tmp/resolved.txt")
+        mock_sync.assert_called_once_with("/tmp/new-resolved.txt")
 
     def test_logs_error_on_compile_failure(self, tmp_path):
         """Should log error and return if compile fails."""
@@ -1577,18 +1573,16 @@ class TestEnsurePluginsInstalled:
         mock_sync.assert_not_called()
         mock_logger.error.assert_called()
 
-    def test_logs_error_on_sync_failure(self, tmp_path):
+    def test_logs_error_on_sync_failure(self):
         """Should log error if sync fails."""
         pm = PluginManager()
 
-        resolved = tmp_path / "resolved.txt"
-        resolved.write_text("plugin-a==1.0.0\n")
-
         with patch.object(pm, "_read_plugins_file", return_value=["plugin-a"]):
             with patch.object(pm, "_is_package_installed", return_value=False):
-                with patch(
-                    "scope.core.plugins.manager.get_resolved_file",
-                    return_value=resolved,
+                with patch.object(
+                    pm,
+                    "_compile_plugins",
+                    return_value=(True, "/tmp/resolved.txt", None),
                 ):
                     with patch.object(
                         pm, "_sync_plugins", return_value=(False, "Install failed")
@@ -1600,12 +1594,9 @@ class TestEnsurePluginsInstalled:
         error_msg = str(mock_logger.error.call_args)
         assert "Install failed" in error_msg
 
-    def test_only_syncs_when_some_missing(self, tmp_path):
+    def test_only_syncs_when_some_missing(self):
         """Should sync when at least one plugin is missing, even if others are present."""
         pm = PluginManager()
-
-        resolved = tmp_path / "resolved.txt"
-        resolved.write_text("plugin-a==1.0.0\nplugin-b==2.0.0\n")
 
         def is_installed(name):
             return name == "plugin-a"  # plugin-b is missing
@@ -1614,9 +1605,10 @@ class TestEnsurePluginsInstalled:
             pm, "_read_plugins_file", return_value=["plugin-a", "plugin-b"]
         ):
             with patch.object(pm, "_is_package_installed", side_effect=is_installed):
-                with patch(
-                    "scope.core.plugins.manager.get_resolved_file",
-                    return_value=resolved,
+                with patch.object(
+                    pm,
+                    "_compile_plugins",
+                    return_value=(True, "/tmp/resolved.txt", None),
                 ):
                     with patch.object(
                         pm, "_sync_plugins", return_value=(True, None)
@@ -1656,3 +1648,489 @@ class TestEnsurePluginsInstalled:
                     pm.ensure_plugins_installed()
 
         mock_sync.assert_not_called()
+
+
+class TestGenerateConstraints:
+    """Tests for _generate_constraints method."""
+
+    LOCK_FIXTURE = """\
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "test-project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "transformers" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+
+[[package]]
+name = "transformers"
+version = "4.57.5"
+
+[[package]]
+name = "safetensors"
+version = "0.6.3"
+
+[[package]]
+name = "torch"
+version = "2.9.1"
+"""
+
+    def test_returns_none_when_no_lock_file(self, tmp_path):
+        """uv.lock doesn't exist in cwd -> returns None."""
+        pm = PluginManager()
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            result = pm._generate_constraints()
+
+        assert result is None
+
+    def test_generates_floor_and_ceiling(self, tmp_path):
+        """Should generate >=locked,<next_major constraints."""
+        pm = PluginManager()
+
+        (tmp_path / "uv.lock").write_text(self.LOCK_FIXTURE)
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            with patch(
+                "scope.core.plugins.manager.get_plugins_dir",
+                return_value=plugins_dir,
+            ):
+                result = pm._generate_constraints()
+
+        assert result is not None
+        content = result.read_text()
+        assert "transformers>=4.57.5,<5" in content
+        assert "safetensors>=0.6.3,<1" in content
+        assert "torch>=2.9.1,<3" in content
+
+    def test_only_constrains_direct_dependencies(self, tmp_path):
+        """Transitive deps in uv.lock should be skipped."""
+        pm = PluginManager()
+
+        lock = """\
+version = 1
+
+[[package]]
+name = "test-project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "transformers" },
+]
+
+[[package]]
+name = "transformers"
+version = "4.57.5"
+
+[[package]]
+name = "tokenizers"
+version = "0.21.1"
+"""
+        (tmp_path / "uv.lock").write_text(lock)
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            with patch(
+                "scope.core.plugins.manager.get_plugins_dir",
+                return_value=plugins_dir,
+            ):
+                result = pm._generate_constraints()
+
+        assert result is not None
+        content = result.read_text()
+        assert "transformers>=4.57.5,<5" in content
+        assert "tokenizers" not in content
+
+    def test_deduplicates_packages(self, tmp_path):
+        """Same dep listed twice should only appear once in constraints."""
+        pm = PluginManager()
+
+        lock = """\
+version = 1
+
+[[package]]
+name = "test-project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "transformers" },
+    { name = "transformers" },
+]
+
+[[package]]
+name = "transformers"
+version = "4.57.5"
+"""
+        (tmp_path / "uv.lock").write_text(lock)
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            with patch(
+                "scope.core.plugins.manager.get_plugins_dir",
+                return_value=plugins_dir,
+            ):
+                result = pm._generate_constraints()
+
+        assert result is not None
+        content = result.read_text()
+        assert content.count("transformers") == 1
+
+    def test_skips_packages_with_plus_in_version(self, tmp_path):
+        """Locked version with + (e.g. 2.9.1+cu128) should be skipped."""
+        pm = PluginManager()
+
+        lock = """\
+version = 1
+
+[[package]]
+name = "test-project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "torch" },
+    { name = "safetensors" },
+]
+
+[[package]]
+name = "torch"
+version = "2.9.1+cu128"
+
+[[package]]
+name = "safetensors"
+version = "0.6.3"
+"""
+        (tmp_path / "uv.lock").write_text(lock)
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            with patch(
+                "scope.core.plugins.manager.get_plugins_dir",
+                return_value=plugins_dir,
+            ):
+                result = pm._generate_constraints()
+
+        assert result is not None
+        content = result.read_text()
+        assert "torch" not in content
+        assert "safetensors>=0.6.3,<1" in content
+
+    def test_handles_marker_deps(self, tmp_path):
+        """Deps with markers in uv.lock should still be constrained."""
+        pm = PluginManager()
+
+        lock = """\
+version = 1
+
+[[package]]
+name = "test-project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "transformers" },
+]
+
+[[package]]
+name = "triton"
+version = "3.5.1"
+
+[[package]]
+name = "transformers"
+version = "4.57.5"
+"""
+        (tmp_path / "uv.lock").write_text(lock)
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            with patch(
+                "scope.core.plugins.manager.get_plugins_dir",
+                return_value=plugins_dir,
+            ):
+                result = pm._generate_constraints()
+
+        assert result is not None
+        content = result.read_text()
+        assert "triton>=3.5.1,<4" in content
+        assert "transformers>=4.57.5,<5" in content
+
+    def test_returns_none_on_parse_error(self, tmp_path):
+        """Invalid TOML in uv.lock -> returns None, doesn't raise."""
+        pm = PluginManager()
+
+        (tmp_path / "uv.lock").write_text("this is not valid { toml [")
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            result = pm._generate_constraints()
+
+        assert result is None
+
+
+class TestCompilePluginsConstraints:
+    """Tests that _compile_plugins() passes the constraint flag."""
+
+    def test_compile_includes_constraint_flag(self, tmp_path):
+        """Mock _generate_constraints to return a path -> verify --constraint in args."""
+        pm = PluginManager()
+
+        constraints_path = tmp_path / "lock-constraints.txt"
+        constraints_path.write_text("transformers==4.57.5\n")
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'test'\n")
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            with patch.object(
+                pm, "_generate_constraints", return_value=constraints_path
+            ):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(
+                        returncode=0, stdout="", stderr=""
+                    )
+                    pm._compile_plugins()
+
+        args = mock_run.call_args[0][0]
+        assert "--constraint" in args
+        assert str(constraints_path) in args
+
+    def test_compile_works_without_constraints(self, tmp_path):
+        """Mock _generate_constraints to return None -> verify no --constraint."""
+        pm = PluginManager()
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'test'\n")
+
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            with patch.object(pm, "_generate_constraints", return_value=None):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(
+                        returncode=0, stdout="", stderr=""
+                    )
+                    pm._compile_plugins()
+
+        args = mock_run.call_args[0][0]
+        assert "--constraint" not in args
+
+
+class TestEnsurePluginsInstalledRecompile:
+    """Tests for the always-recompile behavior in ensure_plugins_installed."""
+
+    def test_recompiles_when_plugins_missing(self):
+        """Plugins missing -> _compile_plugins is called before _sync_plugins."""
+        pm = PluginManager()
+
+        with patch.object(pm, "_read_plugins_file", return_value=["plugin-a"]):
+            with patch.object(pm, "_is_package_installed", return_value=False):
+                with patch.object(
+                    pm,
+                    "_compile_plugins",
+                    return_value=(True, "/tmp/resolved.txt", None),
+                ) as mock_compile:
+                    with patch.object(
+                        pm, "_sync_plugins", return_value=(True, None)
+                    ) as mock_sync:
+                        pm.ensure_plugins_installed()
+
+        mock_compile.assert_called_once()
+        mock_sync.assert_called_once_with("/tmp/resolved.txt")
+
+    def test_falls_back_to_resolved_on_compile_failure(self, tmp_path):
+        """_compile_plugins fails, resolved.txt exists -> _sync_plugins still called."""
+        pm = PluginManager()
+
+        resolved = tmp_path / "resolved.txt"
+        resolved.write_text("plugin-a==1.0.0\n")
+
+        with patch.object(pm, "_read_plugins_file", return_value=["plugin-a"]):
+            with patch.object(pm, "_is_package_installed", return_value=False):
+                with patch.object(
+                    pm,
+                    "_compile_plugins",
+                    return_value=(False, "", "Resolution error"),
+                ):
+                    with patch(
+                        "scope.core.plugins.manager.get_resolved_file",
+                        return_value=resolved,
+                    ):
+                        with patch.object(
+                            pm, "_sync_plugins", return_value=(True, None)
+                        ) as mock_sync:
+                            pm.ensure_plugins_installed()
+
+        mock_sync.assert_called_once_with(str(resolved))
+
+    def test_errors_when_compile_fails_and_no_resolved(self, tmp_path):
+        """_compile_plugins fails, no resolved.txt -> logs error, _sync_plugins not called."""
+        pm = PluginManager()
+
+        resolved = tmp_path / "resolved.txt"  # Does not exist
+
+        with patch.object(pm, "_read_plugins_file", return_value=["plugin-a"]):
+            with patch.object(pm, "_is_package_installed", return_value=False):
+                with patch.object(
+                    pm,
+                    "_compile_plugins",
+                    return_value=(False, "", "Resolution error"),
+                ):
+                    with patch(
+                        "scope.core.plugins.manager.get_resolved_file",
+                        return_value=resolved,
+                    ):
+                        with patch.object(pm, "_sync_plugins") as mock_sync:
+                            with patch(
+                                "scope.core.plugins.manager.logger"
+                            ) as mock_logger:
+                                pm.ensure_plugins_installed()
+
+        mock_sync.assert_not_called()
+        mock_logger.error.assert_called()
+
+
+class TestGetNameFromResolved:
+    """Tests for _get_name_from_resolved method."""
+
+    def test_finds_name_for_git_url(self, tmp_path):
+        """resolved.txt has flashvsr @ git+url -> returns flashvsr."""
+        pm = PluginManager()
+
+        resolved = tmp_path / "resolved.txt"
+        resolved.write_text(
+            "flashvsr @ git+https://github.com/varshith15/FlashVSR-Pro@abc123\n"
+        )
+
+        with patch(
+            "scope.core.plugins.manager.get_resolved_file", return_value=resolved
+        ):
+            result = pm._get_name_from_resolved(
+                "git+https://github.com/varshith15/FlashVSR-Pro"
+            )
+
+        assert result == "flashvsr"
+
+    def test_handles_git_suffix_mismatch(self, tmp_path):
+        """URL has .git suffix but resolved.txt doesn't -> still matches."""
+        pm = PluginManager()
+
+        resolved = tmp_path / "resolved.txt"
+        resolved.write_text(
+            "flashvsr @ git+https://github.com/varshith15/FlashVSR-Pro@abc123\n"
+        )
+
+        with patch(
+            "scope.core.plugins.manager.get_resolved_file", return_value=resolved
+        ):
+            result = pm._get_name_from_resolved(
+                "git+https://github.com/varshith15/FlashVSR-Pro.git"
+            )
+
+        assert result == "flashvsr"
+
+    def test_returns_none_when_no_resolved(self, tmp_path):
+        """No resolved.txt -> returns None."""
+        pm = PluginManager()
+
+        with patch(
+            "scope.core.plugins.manager.get_resolved_file",
+            return_value=tmp_path / "nonexistent.txt",
+        ):
+            result = pm._get_name_from_resolved("git+https://github.com/user/repo")
+
+        assert result is None
+
+    def test_returns_none_when_url_not_found(self, tmp_path):
+        """URL not in resolved.txt -> returns None."""
+        pm = PluginManager()
+
+        resolved = tmp_path / "resolved.txt"
+        resolved.write_text("other-pkg @ git+https://github.com/user/other@abc\n")
+
+        with patch(
+            "scope.core.plugins.manager.get_resolved_file", return_value=resolved
+        ):
+            result = pm._get_name_from_resolved(
+                "git+https://github.com/user/not-in-resolved"
+            )
+
+        assert result is None
+
+
+class TestExtractPackageName:
+    """Tests for _extract_package_name method."""
+
+    def test_git_url_uses_resolved(self, tmp_path):
+        """resolved.txt maps URL -> name, _extract_package_name returns that name."""
+        pm = PluginManager()
+
+        resolved = tmp_path / "resolved.txt"
+        resolved.write_text(
+            "flashvsr @ git+https://github.com/varshith15/FlashVSR-Pro@abc123\n"
+        )
+
+        with patch(
+            "scope.core.plugins.manager.get_resolved_file", return_value=resolved
+        ):
+            result = pm._extract_package_name(
+                "git+https://github.com/varshith15/FlashVSR-Pro"
+            )
+
+        assert result == "flashvsr"
+
+    def test_git_url_falls_back_to_repo_name(self, tmp_path):
+        """No resolved.txt -> returns repo name (existing behavior)."""
+        pm = PluginManager()
+
+        with patch(
+            "scope.core.plugins.manager.get_resolved_file",
+            return_value=tmp_path / "nonexistent.txt",
+        ):
+            result = pm._extract_package_name(
+                "git+https://github.com/varshith15/FlashVSR-Pro.git"
+            )
+
+        assert result == "FlashVSR-Pro"
+
+    def test_local_path_reads_pyproject(self, tmp_path):
+        """Local dir with pyproject.toml -> returns project name."""
+        pm = PluginManager()
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "my-cool-plugin"\n')
+
+        result = pm._extract_package_name(str(tmp_path))
+
+        assert result == "my-cool-plugin"
+
+    def test_local_path_uses_dir_basename(self, tmp_path):
+        """No pyproject.toml -> returns dir basename."""
+        pm = PluginManager()
+
+        sub = tmp_path / "scope-circle-controller"
+        sub.mkdir()
+
+        result = pm._extract_package_name(str(sub))
+
+        assert result == "scope-circle-controller"
+
+    def test_pypi_spec_unchanged(self):
+        """Existing behavior for PyPI specifiers preserved."""
+        pm = PluginManager()
+
+        assert pm._extract_package_name("my-plugin==1.0.0") == "my-plugin"
+        assert pm._extract_package_name("my-plugin>=1.0") == "my-plugin"
+        assert pm._extract_package_name("my-plugin[extra]") == "my-plugin"
+        assert pm._extract_package_name("my-plugin") == "my-plugin"


### PR DESCRIPTION
## Summary
- **Constrain plugin dependency versions from uv.lock**: Add `_generate_constraints` that reads `uv.lock` to produce floor+ceiling constraints (e.g. `transformers>=4.57.5,<5`) for the host project's direct dependencies. `_compile_plugins` now passes these constraints to `uv pip compile`, preventing plugins from pulling in incompatible major version bumps.
- **Always recompile on startup**: `ensure_plugins_installed` now always recompiles against current lock constraints instead of reusing a potentially stale `resolved.txt`, falling back to the existing resolved.txt only if compilation fails.
- **Fix git URL name matching**: `_extract_package_name` now looks up the authoritative package name from `resolved.txt` via a new `_get_name_from_resolved` helper (e.g. `git+https://…/FlashVSR-Pro` → `flashvsr`), falling back to the repo name when resolved.txt is unavailable.
- **Fix local path name matching**: `_extract_package_name` now delegates to the existing `_get_package_name_from_path` helper for directory paths, reading `pyproject.toml` for the real package name instead of returning the full path.

## Test plan
- [x] `TestGenerateConstraints` — 7 tests covering lock parsing, direct-only deps, deduplication, local version skipping, marker deps, and error handling
- [x] `TestCompilePluginsConstraints` — 2 tests verifying `--constraint` flag is passed/omitted correctly
- [x] `TestEnsurePluginsInstalledRecompile` — 3 tests covering recompile behavior and fallback
- [x] `TestGetNameFromResolved` — 4 tests covering successful lookup, `.git` suffix mismatch, missing resolved.txt, and URL not found
- [x] `TestExtractPackageName` — 5 tests covering git URL with resolved lookup, git URL fallback, local path with pyproject.toml, local path without pyproject.toml, and PyPI specs
- [x] All 99 tests pass (`uv run pytest tests/test_plugin_manager.py -v`)
- [x] Import check passes (`from scope.core.plugins.manager import PluginManager`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)