### PR TITLE
Cap video input resolution to pipeline's pixel budget

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -26,6 +26,43 @@ export function getResolutionScaleFactor(
 }
 
 /**
+ * Scales a source resolution down to fit within a pixel budget while preserving
+ * aspect ratio. Dimensions are rounded to the nearest multiple of scaleFactor.
+ * If the source already fits, it is returned as-is (rounded to scaleFactor).
+ */
+export function fitResolutionToPixelBudget(
+  sourceWidth: number,
+  sourceHeight: number,
+  maxPixels: number,
+  scaleFactor: number
+): { width: number; height: number } {
+  const sourcePixels = sourceWidth * sourceHeight;
+  if (sourcePixels <= maxPixels) {
+    return {
+      width: Math.max(
+        scaleFactor,
+        Math.round(sourceWidth / scaleFactor) * scaleFactor
+      ),
+      height: Math.max(
+        scaleFactor,
+        Math.round(sourceHeight / scaleFactor) * scaleFactor
+      ),
+    };
+  }
+  const scale = Math.sqrt(maxPixels / sourcePixels);
+  return {
+    width: Math.max(
+      scaleFactor,
+      Math.round((sourceWidth * scale) / scaleFactor) * scaleFactor
+    ),
+    height: Math.max(
+      scaleFactor,
+      Math.round((sourceHeight * scale) / scaleFactor) * scaleFactor
+    ),
+  };
+}
+
+/**
  * Adjusts resolution to be divisible by the required scale factor for the pipeline.
  * Returns the adjusted resolution and whether it was changed.
  */


### PR DESCRIPTION
## Summary
- Adds `fitResolutionToPixelBudget()` utility that scales a source resolution down to fit within a max pixel count while preserving aspect ratio (dimensions rounded to the pipeline's required scale factor)
- Applies pixel budget capping at all 5 places where video input resolution flows into pipeline settings: NDI source probing, webcam/uploaded video detection, mode switches, pipeline changes, and post-download initialization
- Raw `customVideoResolution` is preserved in state so it can be re-capped correctly when the user switches pipelines (different pipelines have different pixel budgets)

**Example**: NDI 1280×720 + LongLive text mode (default 576×320 = 184K pixels) → scaled to 576×320 (same 16:9 aspect ratio, fits pixel budget)

## Test plan
- [x] `npm run build` passes with no type errors
- [x] Connect an NDI source at 1280×720, select it in UI → resolution in settings shows ~576×320 for LongLive text mode (not 1280×720)
- [x] Upload a 1920×1080 video → resolution is capped to pipeline's pixel budget
- [x] Switch pipelines while in video mode → resolution re-caps to the new pipeline's budget
- [x] Switch from text to video mode with a previously uploaded video → resolution is capped

🤖 Generated with [Claude Code](https://claude.com/claude-code)