### PR TITLE
Fix prompt drop when input queue is not yet full at cache reset

### DIFF
--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -392,6 +392,11 @@ class PipelineProcessor:
 
             # Check if queue has enough frames before consuming them
             if input_queue_ref.qsize() < current_chunk_size:
+                # Preserve popped one-shot parameters so they are applied once frames arrive
+                if reset_cache is not None:
+                    self.parameters["reset_cache"] = reset_cache
+                if lora_scales is not None:
+                    self.parameters["lora_scales"] = lora_scales
                 # Not enough frames in queue, sleep briefly and try again next iteration
                 self.shutdown_event.wait(SLEEP_TIME)
                 return


### PR DESCRIPTION
When reset_cache and lora_scales are popped from self.parameters and the input queue doesn't yet have enough frames, the early return discards those values. On the next iteration init_cache defaults to False (pipeline already prepared), so the pipeline never resets its autoregressive cache and the new prompt has no visible effect from the user's perspective.

Restore reset_cache and lora_scales into self.parameters before the early return so they are applied together with the new prompt once frames are available.

Fixes #476