### PR TITLE
fix: remove --torch-backend from plugin dependency compilation

### DIFF
--- a/src/scope/core/plugins/manager.py
+++ b/src/scope/core/plugins/manager.py
@@ -221,7 +221,6 @@ class PluginManager:
             "pip",
             "compile",
             str(pyproject),
-            *_get_torch_backend_args(),
             "-o",
             str(resolved_file),
         ]


### PR DESCRIPTION
The compile step (_compile_plugins) resolves compatible package versions, while the install step (_sync_plugins) fetches platform-specific builds. Passing --torch-backend cu128 during compilation conflates these concerns — it forces the resolver to use the cu128 index for all torch ecosystem packages, even those that lack wheels on that index for the current platform (e.g. torchao 0.15.0+cu128 has no Windows wheels).

Without this flag, the compile step resolves versions from PyPI where torchao is available as a platform-independent wheel (py3-none-any). The install step still uses --torch-backend cu128 to fetch the correct CUDA builds for torch and torchvision. This works because local version tags (+cu128) only affect which binary is downloaded, not version resolution or dependency metadata.