### PR TITLE
fix: pin uv to 0.9.11 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
   && apt-get install -y nodejs
 
 # Install uv (Python package manager)
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl -LsSf https://astral.sh/uv/0.9.11/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 
 # Install Python dependencies


### PR DESCRIPTION
I think this might fix issues a few people had on Runpod with 0.1.4. Needs testing.

## Summary
- Pin uv to version 0.9.11 in the Dockerfile to match the rest of the repo (Electron app, CI workflows, Windows installer)
- Avoids a torchao resolution bug present in uv 0.9.17+

## Test plan
- [ ] Run `docker build .` and confirm the build succeeds and installs uv 0.9.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)