### PR TITLE
feat: optimize webrtc frame pipeline latency / correctness

### DIFF
--- a/src/scope/server/cloud_track.py
+++ b/src/scope/server/cloud_track.py
@@ -110,6 +110,7 @@ class CloudTrack(MediaStreamTrack):
             connection_id=self.connection_id,
             connection_info=self.connection_info,
         )
+        self.frame_processor.set_event_loop(asyncio.get_running_loop())
         self.frame_processor.start()
 
         # Start input processing if we have a source track
@@ -194,8 +195,7 @@ class CloudTrack(MediaStreamTrack):
                     self._last_frame = frame
                     return frame
 
-            # No frame yet, wait a bit
-            await asyncio.sleep(0.01)
+            await self.frame_processor.wait_for_output()
 
     def update_parameters(self, params: dict) -> None:
         """Update pipeline parameters on cloud."""

--- a/src/scope/server/tracks.py
+++ b/src/scope/server/tracks.py
@@ -114,6 +114,7 @@ class VideoProcessingTrack(MediaStreamTrack):
                 connection_id=self.connection_id,
                 connection_info=self.connection_info,
             )
+            self.frame_processor.set_event_loop(asyncio.get_running_loop())
             self.frame_processor.start()
 
     def initialize_input_processing(self, track: MediaStreamTrack):
@@ -158,8 +159,8 @@ class VideoProcessingTrack(MediaStreamTrack):
                     self._last_frame = frame
                     return frame
 
-                # No frame available, wait a bit before trying again
-                await asyncio.sleep(0.01)
+                # Wait for a frame to be produced
+                await self.frame_processor.wait_for_output()
 
             except Exception as e:
                 logger.error(f"Error getting processed frame: {e}")


### PR DESCRIPTION
perf: optimize WebRTC frame pipeline latency and correctness                                                                                             
                                                                                                                                                         
- Fix pinned buffer race condition with double-buffering for DMA transfers                                                                               
- Move GPU --> CPU transfer from asyncio thread to worker thread    
- Replace 10ms polling sleep with event-based output signaling