### PR TITLE
Mirror HF model repos to daydreamlive org

### DIFF
--- a/src/scope/core/pipelines/common_artifacts.py
+++ b/src/scope/core/pipelines/common_artifacts.py
@@ -16,7 +16,7 @@ WAN_1_3B_ARTIFACT = HuggingfaceRepoArtifact(
 
 UMT5_ENCODER_ARTIFACT = HuggingfaceRepoArtifact(
     repo_id="daydreamlive/WanVideo_comfy",
-    files=["umt5-xxl-enc-fp8_e4m3fn.safetensors"],
+    files=["config.json", "umt5-xxl-enc-fp8_e4m3fn.safetensors"],
 )
 
 VACE_ARTIFACT = HuggingfaceRepoArtifact(
@@ -33,7 +33,7 @@ VACE_14B_ARTIFACT = HuggingfaceRepoArtifact(
 # Extra VAE artifacts (lightweight/alternative encoders)
 LIGHTVAE_ARTIFACT = HuggingfaceRepoArtifact(
     repo_id="daydreamlive/Autoencoders",
-    files=["lightvaew2_1.pth"],
+    files=["config.json", "lightvaew2_1.pth"],
 )
 
 TAE_ARTIFACT = HuggingfaceRepoArtifact(

--- a/src/scope/core/pipelines/krea_realtime_video/schema.py
+++ b/src/scope/core/pipelines/krea_realtime_video/schema.py
@@ -38,7 +38,7 @@ class KreaRealtimeVideoConfig(BasePipelineConfig):
         ),
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/krea-realtime-video",
-            files=["krea-realtime-video-14b.safetensors"],
+            files=["config.json", "krea-realtime-video-14b.safetensors"],
         ),
     ]
 

--- a/src/scope/core/pipelines/longlive/schema.py
+++ b/src/scope/core/pipelines/longlive/schema.py
@@ -35,7 +35,7 @@ class LongLiveConfig(BasePipelineConfig):
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/LongLive-1.3B",
-            files=["models/longlive_base.pt", "models/lora.pt"],
+            files=["config.json", "models/longlive_base.pt", "models/lora.pt"],
         ),
     ]
 

--- a/src/scope/core/pipelines/memflow/schema.py
+++ b/src/scope/core/pipelines/memflow/schema.py
@@ -35,7 +35,7 @@ class MemFlowConfig(BasePipelineConfig):
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/MemFlow",
-            files=["base.pt", "lora.pt"],
+            files=["config.json", "base.pt", "lora.pt"],
         ),
     ]
 

--- a/src/scope/core/pipelines/reward_forcing/schema.py
+++ b/src/scope/core/pipelines/reward_forcing/schema.py
@@ -34,7 +34,7 @@ class RewardForcingConfig(BasePipelineConfig):
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/Reward-Forcing-T2V-1.3B",
-            files=["rewardforcing.pt"],
+            files=["config.json", "rewardforcing.pt"],
         ),
     ]
 

--- a/src/scope/core/pipelines/rife/schema.py
+++ b/src/scope/core/pipelines/rife/schema.py
@@ -22,7 +22,7 @@ class RIFEConfig(BasePipelineConfig):
     artifacts = [
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/RIFE",
-            files=["flownet.pkl"],
+            files=["config.json", "flownet.pkl"],
         ),
     ]
     supports_prompts = False

--- a/src/scope/core/pipelines/scribble/schema.py
+++ b/src/scope/core/pipelines/scribble/schema.py
@@ -19,7 +19,7 @@ class ScribbleConfig(BasePipelineConfig):
     artifacts = [
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/VACE-Annotators",
-            files=["scribble/anime_style/netG_A_latest.pth"],
+            files=["config.json", "scribble/anime_style/netG_A_latest.pth"],
         ),
     ]
     supports_prompts = False

--- a/src/scope/core/pipelines/streamdiffusionv2/schema.py
+++ b/src/scope/core/pipelines/streamdiffusionv2/schema.py
@@ -40,7 +40,7 @@ class StreamDiffusionV2Config(BasePipelineConfig):
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/StreamDiffusionV2",
-            files=["wan_causal_dmd_v2v/model.pt"],
+            files=["config.json", "wan_causal_dmd_v2v/model.pt"],
         ),
     ]
 

--- a/src/scope/core/pipelines/video_depth_anything/schema.py
+++ b/src/scope/core/pipelines/video_depth_anything/schema.py
@@ -21,7 +21,7 @@ class VideoDepthAnythingConfig(BasePipelineConfig):
     artifacts = [
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/Video-Depth-Anything-Small",
-            files=["video_depth_anything_vits.pth"],
+            files=["config.json", "video_depth_anything_vits.pth"],
         ),
     ]
     supports_prompts = False

--- a/src/scope/server/pipeline_artifacts.py
+++ b/src/scope/server/pipeline_artifacts.py
@@ -12,7 +12,7 @@ WAN_1_3B_ARTIFACT = HuggingfaceRepoArtifact(
 
 UMT5_ENCODER_ARTIFACT = HuggingfaceRepoArtifact(
     repo_id="daydreamlive/WanVideo_comfy",
-    files=["umt5-xxl-enc-fp8_e4m3fn.safetensors"],
+    files=["config.json", "umt5-xxl-enc-fp8_e4m3fn.safetensors"],
 )
 
 VACE_ARTIFACT = HuggingfaceRepoArtifact(
@@ -29,7 +29,7 @@ VACE_14B_ARTIFACT = HuggingfaceRepoArtifact(
 # Extra VAE artifacts (lightweight/alternative encoders)
 LIGHTVAE_ARTIFACT = HuggingfaceRepoArtifact(
     repo_id="daydreamlive/Autoencoders",
-    files=["lightvaew2_1.pth"],
+    files=["config.json", "lightvaew2_1.pth"],
 )
 
 TAE_ARTIFACT = HuggingfaceRepoArtifact(
@@ -53,7 +53,7 @@ PIPELINE_ARTIFACTS = {
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/StreamDiffusionV2",
-            files=["wan_causal_dmd_v2v/model.pt"],
+            files=["config.json", "wan_causal_dmd_v2v/model.pt"],
         ),
     ],
     "longlive": [
@@ -65,7 +65,7 @@ PIPELINE_ARTIFACTS = {
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/LongLive-1.3B",
-            files=["models/longlive_base.pt", "models/lora.pt"],
+            files=["config.json", "models/longlive_base.pt", "models/lora.pt"],
         ),
     ],
     "krea-realtime-video": [
@@ -81,7 +81,7 @@ PIPELINE_ARTIFACTS = {
         ),
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/krea-realtime-video",
-            files=["krea-realtime-video-14b.safetensors"],
+            files=["config.json", "krea-realtime-video-14b.safetensors"],
         ),
     ],
     "reward-forcing": [
@@ -93,7 +93,7 @@ PIPELINE_ARTIFACTS = {
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/Reward-Forcing-T2V-1.3B",
-            files=["rewardforcing.pt"],
+            files=["config.json", "rewardforcing.pt"],
         ),
     ],
     "memflow": [
@@ -105,7 +105,7 @@ PIPELINE_ARTIFACTS = {
         LIGHTTAE_ARTIFACT,
         HuggingfaceRepoArtifact(
             repo_id="daydreamlive/MemFlow",
-            files=["base.pt", "lora.pt"],
+            files=["config.json", "base.pt", "lora.pt"],
         ),
     ],
 }


### PR DESCRIPTION
## Summary

- Point all artifact `repo_id` strings from upstream HF repos to `daydreamlive`-hosted mirrors
- Enables download tracking via HF's built-in stats as a zero-consent telemetry proxy
- Insulates users from upstream repo changes/deletions
- No logic changes; local directory names are derived from repo name (not org), so existing downloaded models work without re-downloading

## Repos mirrored (11 total)

| Upstream | Mirror |
|---|---|
| `Wan-AI/Wan2.1-T2V-1.3B` | `daydreamlive/Wan2.1-T2V-1.3B` |
| `Wan-AI/Wan2.1-T2V-14B` | `daydreamlive/Wan2.1-T2V-14B` |
| `Kijai/WanVideo_comfy` | `daydreamlive/WanVideo_comfy` |
| `lightx2v/Autoencoders` | `daydreamlive/Autoencoders` |
| `Efficient-Large-Model/LongLive-1.3B` | `daydreamlive/LongLive-1.3B` |
| `jerryfeng/StreamDiffusionV2` | `daydreamlive/StreamDiffusionV2` |
| `KlingTeam/MemFlow` | `daydreamlive/MemFlow` |
| `krea/krea-realtime-video` | `daydreamlive/krea-realtime-video` |
| `JaydenLu666/Reward-Forcing-T2V-1.3B` | `daydreamlive/Reward-Forcing-T2V-1.3B` |
| `depth-anything/Video-Depth-Anything-Small` | `daydreamlive/Video-Depth-Anything-Small` |
| `ali-vilab/VACE-Annotators` | `daydreamlive/VACE-Annotators` |

## Test plan

- [ ] `uv run daydream-scope` starts without errors
- [ ] Delete a model directory, trigger re-download, confirm it pulls from `daydreamlive`
- [ ] Existing users with models already downloaded are unaffected (local paths unchanged)