### PR TITLE
fix: use relative import for lora utils in peft_lora.py

### DIFF
--- a/src/scope/core/pipelines/wan2_1/lora/strategies/peft_lora.py
+++ b/src/scope/core/pipelines/wan2_1/lora/strategies/peft_lora.py
@@ -17,7 +17,9 @@ import torch
 import torch.nn as nn
 
 from ..utils import (
+    find_lora_pair,
     load_lora_weights,
+    normalize_lora_key,
     parse_lora_weights,
     sanitize_adapter_name,
     standardize_lora_for_peft,
@@ -434,8 +436,6 @@ class PeftLoRAStrategy:
         if not lora_mapping:
             logger.warning("load_adapter: No LoRA layers matched model parameters")
             # Get sample normalized LoRA keys
-            from pipelines.wan2_1.lora.utils import find_lora_pair, normalize_lora_key
-
             sample_normalized = []
             for lora_key in list(lora_state.keys())[:5]:
                 pair_result = find_lora_pair(lora_key, lora_state)


### PR DESCRIPTION
## Summary

Fixes #545

The hardcoded absolute import `from pipelines.wan2_1.lora.utils` was causing `ModuleNotFoundError: No module named 'pipelines'` when loading LoRA adapters. This module path doesn't exist - it should be `scope.core.pipelines.wan2_1.lora.utils`.

## Changes

- Moved `find_lora_pair` and `normalize_lora_key` imports to the top-level imports block
- Changed to use relative imports (`from ..utils`) consistent with the rest of the file
- Removed the inline import that was causing the error

## Testing

This fix addresses the error observed in Grafana logs:
```
scope.core.pipelines.wan2_1.lora.strategies.peft_lora - ERROR - StreamDiffusionV2Pipeline.__init__: Failed to load LoRA: No module named 'pipelines'
```

The relative import pattern is already used successfully for other imports from the same `utils` module at the top of the file.