### PR TITLE
Add graceful shutdown to uvicorn.run

### DIFF
--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -2212,6 +2212,7 @@ def run_server(reload: bool, host: str, port: int, no_browser: bool):
             port=port,
             reload=reload,
             log_config=None,  # Use our logging config, don't override it
+            timeout_graceful_shutdown=1,
         )
         server = uvicorn.Server(config)
 
@@ -2239,6 +2240,7 @@ def run_server(reload: bool, host: str, port: int, no_browser: bool):
             port=port,
             reload=reload,
             log_config=None,  # Use our logging config, don't override it
+            timeout_graceful_shutdown=1,
         )
 
 


### PR DESCRIPTION
Without `timeout_graceful_shutdown`, if there is any connection open, then the server never stops. That is that when user opens in the frontend the preview for source from NDI or Syphon.

We don't have any server-side tasks that would need to be completed before the server shutdown, so setting it to a low value solves all the problems.