### PR TITLE
fix: persist input mode settings when pipeline switched

### DIFF
--- a/frontend/src/hooks/useStreamState.ts
+++ b/frontend/src/hooks/useStreamState.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type {
   SystemMetrics,
   StreamStatus,
@@ -212,11 +212,16 @@ export function useStreamState() {
         ) {
           const firstPipelineId = availablePipelines[0] as PipelineId;
           const firstPipelineSchema = schemas.pipelines[firstPipelineId];
+          const nextMode =
+            prev.inputMode &&
+            firstPipelineSchema.supported_modes.includes(prev.inputMode)
+              ? prev.inputMode
+              : firstPipelineSchema.default_mode;
 
           return {
             ...prev,
             pipelineId: firstPipelineId,
-            inputMode: firstPipelineSchema.default_mode,
+            inputMode: nextMode,
           };
         }
         return prev;
@@ -278,7 +283,11 @@ export function useStreamState() {
             setSettings(prev => ({
               ...prev,
               pipelineId: firstPipelineId,
-              inputMode: firstPipelineSchema.default_mode,
+              inputMode:
+                prev.inputMode &&
+                firstPipelineSchema.supported_modes.includes(prev.inputMode)
+                  ? prev.inputMode
+                  : firstPipelineSchema.default_mode,
             }));
           }
         } else {
@@ -319,25 +328,35 @@ export function useStreamState() {
     getInputSources,
   ]);
 
-  // Track previous pipelineId so we only reset inputMode when the pipeline actually changes
-  const prevPipelineIdRef = useRef<string | null>(null);
-
-  // Update inputMode when schemas first load or pipeline changes
+  // Keep input mode stable across pipeline/schema changes.
+  // Only normalize to schema default when the current mode is missing or unsupported.
   useEffect(() => {
-    if (pipelineSchemas) {
-      const schema = pipelineSchemas.pipelines[settings.pipelineId];
-      if (
-        schema?.default_mode &&
-        prevPipelineIdRef.current !== settings.pipelineId
-      ) {
-        setSettings(prev => ({
+    if (!pipelineSchemas) return;
+    const schema = pipelineSchemas.pipelines[settings.pipelineId];
+    if (!schema) return;
+
+    const currentMode = settings.inputMode;
+    const currentModeIsValid =
+      currentMode !== undefined && schema.supported_modes.includes(currentMode);
+
+    if (!currentModeIsValid) {
+      setSettings(prev => {
+        const currentSchema = pipelineSchemas.pipelines[prev.pipelineId];
+        if (!currentSchema) return prev;
+
+        const prevMode = prev.inputMode;
+        const prevModeIsValid =
+          prevMode !== undefined &&
+          currentSchema.supported_modes.includes(prevMode);
+
+        if (prevModeIsValid) return prev;
+        return {
           ...prev,
-          inputMode: schema.default_mode,
-        }));
-      }
-      prevPipelineIdRef.current = settings.pipelineId;
+          inputMode: currentSchema.default_mode,
+        };
+      });
     }
-  }, [pipelineSchemas, settings.pipelineId]);
+  }, [pipelineSchemas, settings.pipelineId, settings.inputMode]);
 
   // Set recommended quantization based on pipeline schema and available VRAM
   useEffect(() => {

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -404,8 +404,10 @@ export function StreamPage() {
     }
 
     const newPipeline = pipelines?.[pipelineId];
-    const modeToUse = newPipeline?.defaultMode || "text";
     const currentMode = settings.inputMode || "text";
+    const modeToUse = newPipeline?.supportedModes?.includes(currentMode)
+      ? currentMode
+      : (newPipeline?.defaultMode ?? "text");
 
     // Trigger video reinitialization if switching to video mode
     if (modeToUse === "video" && currentMode !== "video") {
@@ -438,6 +440,14 @@ export function StreamPage() {
         ? capResolution(customVideoResolution, pipelineId, modeToUse)
         : { height: defaults.height, width: defaults.width };
 
+    // Clear pre/postprocessors that don't support the selected mode
+    const preprocessorStillValid = settings.preprocessorIds?.every(id =>
+      pipelines?.[id]?.supportedModes?.includes(modeToUse)
+    );
+    const postprocessorStillValid = settings.postprocessorIds?.every(id =>
+      pipelines?.[id]?.supportedModes?.includes(modeToUse)
+    );
+
     // Update the pipeline in settings with the appropriate mode and defaults
     updateSettings({
       pipelineId,
@@ -447,8 +457,12 @@ export function StreamPage() {
       noiseScale: defaults.noiseScale,
       noiseController: defaults.noiseController,
       loras: [], // Clear LoRA controls when switching pipelines
-      preprocessorSchemaFieldOverrides: {},
-      postprocessorSchemaFieldOverrides: {},
+      ...(preprocessorStillValid
+        ? {}
+        : { preprocessorIds: [], preprocessorSchemaFieldOverrides: {} }),
+      ...(postprocessorStillValid
+        ? {}
+        : { postprocessorIds: [], postprocessorSchemaFieldOverrides: {} }),
     });
   };
 


### PR DESCRIPTION
## Overview
This PR fixes a regression where switching the selected pipeline/model in the right-side settings panel reset inputMode back to the pipeline default (text). The change preserves the user’s current input mode (text/video) across pipeline switches when that mode is supported, and only falls back to the pipeline default when the current mode is invalid for the newly selected pipeline.
It also updates stream settings normalization so mode is no longer force-reset on every pipeline/schema change, and keeps pre/postprocessor settings consistent by clearing only processors that are incompatible with the resolved mode.

Manual behavior checks covered:
- video mode persists when switching to another pipeline that supports video
- mode safely falls back to text for pipelines that only support text