### PR TITLE
Implement PR deploy cleanup

### DIFF
--- a/.github/workflows/fal-pr-deploy.yml
+++ b/.github/workflows/fal-pr-deploy.yml
@@ -14,5 +14,5 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           echo "Deleting fal app scope-pr-${PR_NUMBER}..."
-          pip install fal-client
+          pip install fal
           fal apps delete scope-pr-${PR_NUMBER}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI behavior to run a real deletion (`fal apps delete`) on PR close using a secret key; misconfiguration or naming mismatches could delete the wrong app or fail cleanup.
> 
> **Overview**
> Adds a GitHub Actions workflow that triggers on `pull_request` *closed* events and **automatically deletes** the corresponding fal preview deployment (`scope-pr-<PR_NUMBER>`) using `fal-client` and `FAL_KEY`.
> 
> Replaces the prior no-op cleanup step with an actual `fal apps delete` command tied to the PR number, aligning with the PR app naming used in the deploy workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4d678a2b1394f540f035ad62d89939c4b642bc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->