### PR TITLE
fix: broken record on/off button, add support for output recording

### DIFF
--- a/frontend/src/components/PromptTimeline.tsx
+++ b/frontend/src/components/PromptTimeline.tsx
@@ -694,10 +694,16 @@ export function PromptTimeline({
             </Button>
             <Button
               onClick={onRecordingToggle}
-              disabled={disabled || isLoading || isDownloading || isStreaming}
+              disabled={disabled || isLoading || isDownloading || !isStreaming}
               size="sm"
               variant="outline"
-              title={isRecording ? "Stop recording" : "Start recording"}
+              title={
+                !isStreaming
+                  ? "Start streaming to enable recording"
+                  : isRecording
+                    ? "Stop recording"
+                    : "Start recording"
+              }
               className={
                 isRecording
                   ? "border-red-500 hover:border-red-400 animate-record-pulse"

--- a/frontend/src/components/VideoOutput.tsx
+++ b/frontend/src/components/VideoOutput.tsx
@@ -21,6 +21,8 @@ interface VideoOutputProps {
   onRequestPointerLock?: () => void;
   /** Ref to expose the video container element for pointer lock */
   videoContainerRef?: React.RefObject<HTMLDivElement | null>;
+  /** Ref to expose the video element for external use (e.g. recording) */
+  videoRef?: React.RefObject<HTMLVideoElement | null>;
   /** Video scale mode: 'fit' fills available space, 'native' shows at actual resolution */
   videoScaleMode?: "fit" | "native";
 }
@@ -41,9 +43,11 @@ export function VideoOutput({
   isPointerLocked = false,
   onRequestPointerLock,
   videoContainerRef,
+  videoRef: externalVideoRef,
   videoScaleMode = "fit",
 }: VideoOutputProps) {
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const internalVideoRef = useRef<HTMLVideoElement>(null);
+  const videoRef = externalVideoRef || internalVideoRef;
   const internalContainerRef = useRef<HTMLDivElement>(null);
   const [showOverlay, setShowOverlay] = useState(false);
   const [isFadingOut, setIsFadingOut] = useState(false);

--- a/frontend/src/hooks/useRecording.ts
+++ b/frontend/src/hooks/useRecording.ts
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  negotiateMimeType,
+  downloadBlob,
+  getSourceDimensions,
+  buildFilename,
+} from "../lib/recordingUtils";
+
+export interface UseRecordingOptions {
+  /** Canvas width in px. Defaults to the source element's intrinsic width. */
+  width?: number;
+  /** Canvas height in px. Defaults to the source element's intrinsic height. */
+  height?: number;
+  /** Frames-per-second passed to `canvas.captureStream()`. Default 30. */
+  fps?: number;
+  /** MediaRecorder timeslice in ms. Default 200. */
+  timeslice?: number;
+  /** Mirror the source horizontally before recording. Default false. */
+  mirror?: boolean;
+  /** Called when an error occurs during recording. */
+  onError?: (err: Error) => void;
+}
+
+export interface RecordingResult {
+  blob: Blob;
+  /** Object URL suitable for `<video src>` preview. Revoked by `cleanup()`. */
+  url: string;
+  mimeType: string;
+  fileExtension: "mp4" | "webm";
+  durationMs: number;
+}
+
+export interface UseRecordingReturn {
+  isRecording: boolean;
+  isInitializing: boolean;
+  result: RecordingResult | null;
+  startRecording: () => void;
+  stopRecording: () => void;
+  /** Download the current result. Optionally override the filename. */
+  download: (filename?: string) => void;
+  /** Revoke any object URLs held by the hook and clear the result. */
+  cleanup: () => void;
+}
+
+function drawFrame(
+  ctx: CanvasRenderingContext2D,
+  source: HTMLVideoElement | HTMLCanvasElement,
+  canvasW: number,
+  canvasH: number,
+  mirror: boolean
+): void {
+  ctx.fillStyle = "#000000";
+  ctx.fillRect(0, 0, canvasW, canvasH);
+
+  if (source instanceof HTMLVideoElement && (source.paused || source.ended)) {
+    return;
+  }
+
+  const { width: srcW, height: srcH } = getSourceDimensions(source);
+  const scale = Math.min(canvasW / srcW, canvasH / srcH);
+  const drawW = srcW * scale;
+  const drawH = srcH * scale;
+  const offsetX = (canvasW - drawW) / 2;
+  const offsetY = (canvasH - drawH) / 2;
+
+  if (mirror) {
+    ctx.save();
+    ctx.translate(canvasW - offsetX, offsetY);
+    ctx.scale(-1, 1);
+    ctx.drawImage(source, 0, 0, drawW, drawH);
+    ctx.restore();
+  } else {
+    ctx.drawImage(source, offsetX, offsetY, drawW, drawH);
+  }
+}
+
+/**
+ * Record any `<video>` or `<canvas>` element to a downloadable Blob.
+ *
+ * Internally creates an offscreen canvas, draws frames via
+ * `requestAnimationFrame`, captures a `MediaStream`, and records with
+ * `MediaRecorder`.
+ */
+export function useRecording(
+  sourceRef: React.RefObject<HTMLVideoElement | HTMLCanvasElement | null>,
+  options: UseRecordingOptions = {}
+): UseRecordingReturn {
+  const { fps = 30, timeslice = 200, mirror = false, onError } = options;
+
+  const [isRecording, setIsRecording] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(false);
+  const [result, setResult] = useState<RecordingResult | null>(null);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const rafRef = useRef<number | null>(null);
+  const recordingRef = useRef(false);
+  const startTimeRef = useRef(0);
+
+  const emitError = useCallback(
+    (err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error("[useRecording]", error);
+      onError?.(error);
+    },
+    [onError]
+  );
+
+  const startRecording = useCallback(() => {
+    try {
+      setIsInitializing(true);
+
+      const source = sourceRef.current;
+      if (!source) {
+        emitError(new Error("Source element ref is null"));
+        setIsInitializing(false);
+        return;
+      }
+
+      const { width: intrinsicW, height: intrinsicH } =
+        getSourceDimensions(source);
+      const canvasW = options.width ?? intrinsicW;
+      const canvasH = options.height ?? intrinsicH;
+
+      if (!canvasRef.current) {
+        canvasRef.current = document.createElement("canvas");
+      }
+      const canvas = canvasRef.current;
+      canvas.width = canvasW;
+      canvas.height = canvasH;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        emitError(new Error("Could not get 2d context from offscreen canvas"));
+        setIsInitializing(false);
+        return;
+      }
+
+      const draw = () => {
+        if (!recordingRef.current) return;
+        try {
+          drawFrame(ctx, source, canvasW, canvasH, mirror);
+        } catch (err) {
+          emitError(err);
+        }
+        if (recordingRef.current) {
+          rafRef.current = requestAnimationFrame(draw);
+        }
+      };
+
+      const stream = canvas.captureStream(fps);
+      const { mimeType } = negotiateMimeType();
+
+      chunksRef.current = [];
+      const recorder = new MediaRecorder(stream, { mimeType });
+      recorderRef.current = recorder;
+
+      recorder.ondataavailable = e => {
+        if (e.data.size > 0) {
+          chunksRef.current.push(e.data);
+        }
+      };
+
+      recorder.start(timeslice);
+      recordingRef.current = true;
+      startTimeRef.current = performance.now();
+      setIsRecording(true);
+
+      draw();
+    } catch (err) {
+      emitError(err);
+    } finally {
+      setIsInitializing(false);
+    }
+  }, [
+    sourceRef,
+    options.width,
+    options.height,
+    fps,
+    timeslice,
+    mirror,
+    emitError,
+  ]);
+
+  const stopRecording = useCallback(() => {
+    recordingRef.current = false;
+
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+
+    const recorder = recorderRef.current;
+    if (!recorder || recorder.state !== "recording") {
+      setIsRecording(false);
+      return;
+    }
+
+    recorder.onstop = () => {
+      const mimeType = recorder.mimeType || "video/webm";
+      const blob = new Blob(chunksRef.current, { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      const { fileExtension } = negotiateMimeType();
+      const durationMs = performance.now() - startTimeRef.current;
+
+      setResult({ blob, url, mimeType, fileExtension, durationMs });
+      setIsRecording(false);
+      chunksRef.current = [];
+    };
+
+    recorder.stop();
+  }, []);
+
+  const download = useCallback(
+    (filename?: string) => {
+      if (!result) return;
+      const name = filename ?? buildFilename("recording", result.fileExtension);
+      downloadBlob(result.blob, name);
+    },
+    [result]
+  );
+
+  const cleanup = useCallback(() => {
+    if (result?.url) {
+      URL.revokeObjectURL(result.url);
+    }
+    setResult(null);
+  }, [result]);
+
+  useEffect(() => {
+    return () => {
+      if (result?.url) {
+        URL.revokeObjectURL(result.url);
+      }
+    };
+  }, [result]);
+
+  return {
+    isRecording,
+    isInitializing,
+    result,
+    startRecording,
+    stopRecording,
+    download,
+    cleanup,
+  };
+}

--- a/frontend/src/lib/recordingUtils.ts
+++ b/frontend/src/lib/recordingUtils.ts
@@ -1,0 +1,70 @@
+/**
+ * Negotiate the best available video MIME type for MediaRecorder.
+ * Prefers mp4 (rare), then vp9, h264, vp8, falling back to plain webm.
+ */
+export function negotiateMimeType(): {
+  mimeType: string;
+  fileExtension: "mp4" | "webm";
+} {
+  if (typeof MediaRecorder === "undefined") {
+    return { mimeType: "video/webm", fileExtension: "webm" };
+  }
+
+  if (MediaRecorder.isTypeSupported("video/mp4")) {
+    return { mimeType: "video/mp4", fileExtension: "mp4" };
+  }
+  if (MediaRecorder.isTypeSupported("video/webm;codecs=vp9")) {
+    return { mimeType: "video/webm;codecs=vp9", fileExtension: "webm" };
+  }
+  if (MediaRecorder.isTypeSupported("video/webm;codecs=h264")) {
+    return { mimeType: "video/webm;codecs=h264", fileExtension: "webm" };
+  }
+  if (MediaRecorder.isTypeSupported("video/webm;codecs=vp8")) {
+    return { mimeType: "video/webm;codecs=vp8", fileExtension: "webm" };
+  }
+
+  return { mimeType: "video/webm", fileExtension: "webm" };
+}
+
+/**
+ * Trigger a browser download for an in-memory Blob.
+ * Creates a temporary anchor element, clicks it, and cleans up.
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Get the intrinsic dimensions of a video or canvas element.
+ * Falls back to 640x480 when dimensions are unavailable.
+ */
+export function getSourceDimensions(el: HTMLVideoElement | HTMLCanvasElement): {
+  width: number;
+  height: number;
+} {
+  if (el instanceof HTMLVideoElement) {
+    return {
+      width: el.videoWidth || 640,
+      height: el.videoHeight || 480,
+    };
+  }
+  return {
+    width: el.width || 640,
+    height: el.height || 480,
+  };
+}
+
+/**
+ * Build a timestamped filename for a recording download.
+ */
+export function buildFilename(prefix: string, extension: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  return `${prefix}-${ts}.${extension}`;
+}

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -11,6 +11,7 @@ import { useUnifiedWebRTC } from "../hooks/useUnifiedWebRTC";
 import { useVideoSource } from "../hooks/useVideoSource";
 import { useWebRTCStats } from "../hooks/useWebRTCStats";
 import { useControllerInput } from "../hooks/useControllerInput";
+import { useRecording } from "../hooks/useRecording";
 import { usePipeline } from "../hooks/usePipeline";
 import { useStreamState } from "../hooks/useStreamState";
 import { usePipelinesContext } from "../contexts/PipelinesContext";
@@ -186,8 +187,8 @@ export function StreamPage() {
   const [timelineCurrentTime, setTimelineCurrentTime] = useState(0);
   const [isTimelinePlaying, setIsTimelinePlaying] = useState(false);
 
-  // Recording toggle state
-  const [isRecording, setIsRecording] = useState(false);
+  // Ref for the output video element (used by client-side recording)
+  const outputVideoRef = useRef<HTMLVideoElement>(null);
 
   // Track when waiting for cloud WebSocket to connect after clicking Play
   const [isCloudConnecting, setIsCloudConnecting] = useState(false);
@@ -260,7 +261,6 @@ export function StreamPage() {
     stopStream,
     updateVideoTrack,
     sendParameterUpdate,
-    sessionId,
   } = useUnifiedWebRTC();
 
   // Computed loading state - true when downloading models, loading pipeline, connecting WebRTC, or waiting for cloud
@@ -272,6 +272,39 @@ export function StreamPage() {
     peerConnectionRef,
     isStreaming,
   });
+
+  // Client-side recording of the output video
+  const {
+    isRecording,
+    result: recordingResult,
+    startRecording,
+    stopRecording: stopClientRecording,
+    download: downloadRecording,
+    cleanup: cleanupRecording,
+  } = useRecording(outputVideoRef, {
+    onError: err => {
+      toast.error("Recording error", {
+        description: err.message,
+        duration: 5000,
+      });
+    },
+  });
+
+  // Auto-download when a recording result becomes available
+  useEffect(() => {
+    if (recordingResult) {
+      downloadRecording();
+      cleanupRecording();
+    }
+  }, [recordingResult, downloadRecording, cleanupRecording]);
+
+  const handleRecordingToggle = useCallback(() => {
+    if (isRecording) {
+      stopClientRecording();
+    } else {
+      startRecording();
+    }
+  }, [isRecording, stopClientRecording, startRecording]);
 
   // Video container ref for controller input pointer lock
   const videoContainerRef = useRef<HTMLDivElement>(null);
@@ -1319,7 +1352,6 @@ export function StreamPage() {
         first_frame_image?: string;
         last_frame_image?: string;
         images?: string[];
-        recording?: boolean;
         input_source?: {
           enabled: boolean;
           source_type: string;
@@ -1407,9 +1439,6 @@ export function StreamPage() {
         initialParameters.input_source = settings.inputSource;
       }
 
-      // Include recording toggle state
-      initialParameters.recording = isRecording;
-
       // Include runtime schema field overrides so they reach __call__ on first frame
       if (
         settings.schemaFieldOverrides &&
@@ -1431,27 +1460,19 @@ export function StreamPage() {
     }
   };
 
-  const handleSaveGeneration = async () => {
-    try {
-      if (!sessionId) {
-        toast.error("No active session", {
-          description: "Please start a stream before downloading the recording",
-          duration: 5000,
-        });
-        return;
-      }
-      await api.downloadRecording(sessionId);
-    } catch (error) {
-      console.error("Error downloading recording:", error);
-      toast.error("Error downloading recording", {
-        description:
-          error instanceof Error
-            ? error.message
-            : "An error occurred while downloading the recording",
+  const handleSaveGeneration = useCallback(() => {
+    if (isRecording) {
+      // Stop recording - the auto-download effect will handle the download
+      stopClientRecording();
+    } else if (recordingResult) {
+      downloadRecording();
+    } else {
+      toast.error("No recording available", {
+        description: "Start and stop a recording first to save a generation",
         duration: 5000,
       });
     }
-  };
+  }, [isRecording, stopClientRecording, recordingResult, downloadRecording]);
 
   return (
     <div className="h-screen flex flex-col bg-background">
@@ -1602,6 +1623,7 @@ export function StreamPage() {
               isPointerLocked={isPointerLocked}
               onRequestPointerLock={requestPointerLock}
               videoContainerRef={videoContainerRef}
+              videoRef={outputVideoRef}
               // Video scale mode
               videoScaleMode={videoScaleMode}
             />
@@ -1715,7 +1737,7 @@ export function StreamPage() {
               isDownloading={isDownloading}
               onSaveGeneration={handleSaveGeneration}
               isRecording={isRecording}
-              onRecordingToggle={() => setIsRecording(prev => !prev)}
+              onRecordingToggle={handleRecordingToggle}
             />
           </div>
         </div>


### PR DESCRIPTION
The recording button was previously disabled during streaming and relied on server-side recording via the backend API. This PR moves recording to the client, allowing users to record the output video directly from the browser during an active stream.

**Changes:**
- Added `useRecording` hook and `recordingUtils` that use an offscreen canvas + MediaRecorder to capture the output video element and auto-download the file on stop
- Flipped the record button to be enabled during streaming (instead of only before), since client-side recording requires an active stream
- Exposed the `<video>` ref from VideoOutput and wired it into StreamPage, removing the server-side recording parameter from the WebRTC initial parameters

https://github.com/user-attachments/assets/3d1db142-9546-4064-be16-eb5304536d35

