### PR TITLE
Revert "fix: use CDN upload for large assets to avoid WebSocket timeout"

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,4 @@
 import type { IceServersResponse, ModelStatusResponse } from "../types";
-import { fetchFalCdnToken } from "./auth";
 
 export interface PromptItem {
   text: string;
@@ -454,22 +453,11 @@ export const uploadAsset = async (file: File): Promise<AssetFileInfo> => {
   const fileContent = await file.arrayBuffer();
   const filename = encodeURIComponent(file.name);
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/octet-stream",
-  };
-
-  try {
-    const cdnToken = await fetchFalCdnToken();
-    headers["X-Fal-CDN-Token"] = cdnToken.token;
-    headers["X-Fal-CDN-Token-Type"] = cdnToken.token_type;
-    headers["X-Fal-CDN-Base-URL"] = cdnToken.base_url;
-  } catch (e) {
-    console.warn("uploadAsset: failed to fetch CDN token, upload may fail:", e);
-  }
-
   const response = await fetch(`/api/v1/assets?filename=${filename}`, {
     method: "POST",
-    headers,
+    headers: {
+      "Content-Type": "application/octet-stream",
+    },
     body: fileContent,
   });
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -264,29 +264,6 @@ export function redirectToSignIn(): void {
   }
 }
 
-export interface FalCdnToken {
-  token: string;
-  token_type: string;
-  base_url: string;
-}
-
-/**
- * Fetch a short-lived fal CDN upload token from the Daydream API
- */
-export async function fetchFalCdnToken(): Promise<FalCdnToken> {
-  const apiKey = getDaydreamAPIKey();
-  if (!apiKey) {
-    throw new Error("Not authenticated: no API key available");
-  }
-  const response = await fetch(`${DAYDREAM_API_BASE}/auth/fal/cdn-token`, {
-    headers: { Authorization: `Bearer ${apiKey}` },
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to fetch fal CDN token: ${response.status}`);
-  }
-  return response.json() as Promise<FalCdnToken>;
-}
-
 /**
  * Exchange a short-lived token for a long-lived API key
  */

--- a/src/scope/cloud/fal_app.py
+++ b/src/scope/cloud/fal_app.py
@@ -625,12 +625,9 @@ class ScopeApp(fal.App, keep_alive=300):
 
             async with httpx.AsyncClient() as client:
                 try:
-                    # Check if this is a file upload (base64 or CDN URL)
-                    is_base64_upload = (
+                    # Check if this is a base64-encoded file upload
+                    is_binary_upload = (
                         body and isinstance(body, dict) and "_base64_content" in body
-                    )
-                    is_cdn_upload = (
-                        body and isinstance(body, dict) and "_cdn_url" in body
                     )
 
                     if method == "GET":
@@ -640,46 +637,8 @@ class ScopeApp(fal.App, keep_alive=300):
                             f"{SCOPE_BASE_URL}{path}", timeout=timeout
                         )
                     elif method == "POST":
-                        if is_cdn_upload:
-                            # Download from CDN URL and forward as binary
-                            # This handles large files that were uploaded directly to fal CDN
-                            cdn_url = body["_cdn_url"]
-                            content_type = body.get(
-                                "_content_type", "application/octet-stream"
-                            )
-                            print(f"[{log_prefix()}] Downloading from CDN: {cdn_url}")
-                            try:
-                                cdn_response = await client.get(
-                                    cdn_url, timeout=120.0, follow_redirects=True
-                                )
-                                if cdn_response.status_code != 200:
-                                    return {
-                                        "type": "api_response",
-                                        "request_id": request_id,
-                                        "status": 502,
-                                        "error": f"CDN download failed: {cdn_response.status_code}",
-                                    }
-                                binary_content = cdn_response.content
-                                print(
-                                    f"[{log_prefix()}] Downloaded {len(binary_content)} bytes from CDN"
-                                )
-                            except Exception as e:
-                                print(f"[{log_prefix()}] CDN download error: {e}")
-                                return {
-                                    "type": "api_response",
-                                    "request_id": request_id,
-                                    "status": 502,
-                                    "error": f"CDN download error: {e}",
-                                }
-
-                            response = await client.post(
-                                f"{SCOPE_BASE_URL}{path}",
-                                content=binary_content,
-                                headers={"Content-Type": content_type},
-                                timeout=60.0,
-                            )
-                        elif is_base64_upload:
-                            # Decode base64 and send as binary (for small files)
+                        if is_binary_upload:
+                            # Decode base64 and send as binary
                             binary_content = base64.b64decode(body["_base64_content"])
                             content_type = body.get(
                                 "_content_type", "application/octet-stream"

--- a/src/scope/core/pipelines/wan2_1/lora/strategies/peft_lora.py
+++ b/src/scope/core/pipelines/wan2_1/lora/strategies/peft_lora.py
@@ -17,9 +17,7 @@ import torch
 import torch.nn as nn
 
 from ..utils import (
-    find_lora_pair,
     load_lora_weights,
-    normalize_lora_key,
     parse_lora_weights,
     sanitize_adapter_name,
     standardize_lora_for_peft,
@@ -436,6 +434,8 @@ class PeftLoRAStrategy:
         if not lora_mapping:
             logger.warning("load_adapter: No LoRA layers matched model parameters")
             # Get sample normalized LoRA keys
+            from pipelines.wan2_1.lora.utils import find_lora_pair, normalize_lora_key
+
             sample_normalized = []
             for lora_key in list(lora_state.keys())[:5]:
                 pair_result = find_lora_pair(lora_key, lora_state)

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -1317,9 +1317,6 @@ async def upload_asset(
                 filename,
                 content_type,
                 asset_type,
-                fal_cdn_token=request.headers.get("X-Fal-CDN-Token"),
-                fal_cdn_token_type=request.headers.get("X-Fal-CDN-Token-Type"),
-                fal_cdn_base_url=request.headers.get("X-Fal-CDN-Base-URL"),
             )
 
         # Local mode: save to local assets directory

--- a/src/scope/server/cloud_proxy.py
+++ b/src/scope/server/cloud_proxy.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from functools import wraps
 from typing import Any
 
-import aiohttp
 from fastapi import HTTPException, Request
 from fastapi.responses import Response
 
@@ -138,105 +137,19 @@ async def get_hardware_info_from_cloud(
     )
 
 
-async def _upload_to_fal_cdn(
-    content: bytes,
-    filename: str,
-    content_type: str,
-    cdn_token: str,
-    token_type: str,
-    base_upload_url: str,
-) -> str:
-    """Upload file directly to fal CDN via REST API.
-
-    This bypasses the WebSocket and uploads directly to fal's storage,
-    returning a CDN URL that can be used by the cloud runner.
-
-    The CDN token must be obtained by the caller (frontend) from the Daydream
-    API at /auth/fal/cdn-token and passed through request headers.
-
-    Args:
-        content: File content as bytes
-        filename: Original filename
-        content_type: MIME type of the file
-        cdn_token: Short-lived CDN upload token from Daydream API
-        token_type: Token type (e.g. "bearer")
-        base_upload_url: Base URL for CDN uploads
-
-    Returns:
-        CDN URL of the uploaded file (https://v3.fal.media/files/...)
-
-    Raises:
-        HTTPException: If upload fails
-    """
-    logger.info(f"upload_to_fal_cdn: Uploading {len(content)} bytes ({filename})")
-
-    try:
-        async with aiohttp.ClientSession() as session:
-            # Upload file to CDN
-            upload_url = f"{base_upload_url}/files/upload"
-            upload_auth = f"{token_type} {cdn_token}"
-
-            async with session.post(
-                upload_url,
-                data=content,
-                headers={
-                    "Authorization": upload_auth,
-                    "Content-Type": content_type,
-                    "X-Fal-File-Name": filename,
-                    "Accept": "application/json",
-                },
-                timeout=aiohttp.ClientTimeout(total=120),
-            ) as upload_response:
-                if upload_response.status != 200:
-                    error_text = await upload_response.text()
-                    logger.error(f"upload_to_fal_cdn: Upload failed: {error_text}")
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"CDN upload failed: {upload_response.status}",
-                    )
-
-                upload_result = await upload_response.json()
-                cdn_url = upload_result.get("access_url") or upload_result.get("url")
-
-                if not cdn_url:
-                    logger.error(
-                        f"upload_to_fal_cdn: No URL in response: {upload_result}"
-                    )
-                    raise HTTPException(
-                        status_code=502,
-                        detail="CDN upload succeeded but no URL returned",
-                    )
-
-                logger.info(f"upload_to_fal_cdn: Success, URL: {cdn_url}")
-                return cdn_url
-
-    except aiohttp.ClientError as e:
-        logger.error(f"upload_to_fal_cdn: Network error: {e}")
-        raise HTTPException(
-            status_code=502,
-            detail=f"CDN upload network error: {e}",
-        ) from e
-
-
 async def upload_asset_to_cloud(
     cloud_manager: CloudConnectionManager,
     content: bytes,
     filename: str,
     content_type: str,
     asset_type: str,
-    fal_cdn_token: str | None = None,
-    fal_cdn_token_type: str | None = None,
-    fal_cdn_base_url: str | None = None,
 ) -> AssetFileInfo:
-    """Upload asset to cloud and save a local copy for thumbnails.
-
-    Uploads directly to fal CDN using a token obtained by the frontend from
-    the Daydream API, then notifies the cloud runner via the WebSocket.
+    """Upload asset to cloud (POST with base64 body) and save a local copy for thumbnails.
 
     Call when cloud_manager.is_connected; raises HTTPException on cloud errors.
     """
     logger.info(
-        f"upload_asset: Uploading {asset_type} to cloud and locally: {filename} ({len(content)} bytes)"
+        f"upload_asset: Uploading {asset_type} to cloud and locally: {filename}"
     )
 
     # Save locally for thumbnail serving
@@ -246,26 +159,12 @@ async def upload_asset_to_cloud(
     local_file_path.write_bytes(content)
     logger.info(f"upload_asset: Saved local copy for thumbnails: {local_file_path}")
 
-    if not fal_cdn_token or not fal_cdn_token_type or not fal_cdn_base_url:
-        raise HTTPException(
-            status_code=400,
-            detail="CDN token required for uploads (provide X-Fal-CDN-Token, X-Fal-CDN-Token-Type, X-Fal-CDN-Base-URL headers)",
-        )
-    cdn_url = await _upload_to_fal_cdn(
-        content,
-        filename,
-        content_type,
-        fal_cdn_token,
-        fal_cdn_token_type,
-        fal_cdn_base_url,
-    )
-
-    # Tell the cloud runner to fetch from CDN URL instead of receiving base64
+    base64_content = base64.b64encode(content).decode("utf-8")
     response = await cloud_manager.api_request(
         method="POST",
         path=f"/api/v1/assets?filename={filename}",
         body={
-            "_cdn_url": cdn_url,
+            "_base64_content": base64_content,
             "_content_type": content_type,
         },
         timeout=60.0,


### PR DESCRIPTION
Reverts daydreamlive/scope#550

I didn't realise this would auto-merge like that, I need to wait for a daydream API change before merging.