### PR TITLE
Harden workflow import: extract hooks, add security guards, fix UI bugs

### DIFF
--- a/frontend/src/components/PromptInputWithTimeline.tsx
+++ b/frontend/src/components/PromptInputWithTimeline.tsx
@@ -164,7 +164,6 @@ export function PromptInputWithTimeline({
     }
   }, [prompts, onPromptSubmit, onPromptItemsSubmit]);
 
-  // Enhanced rewind handler
   // Enhanced disconnect handler
   const handleEnhancedDisconnect = useCallback(() => {
     onDisconnect?.();
@@ -372,7 +371,6 @@ export function PromptInputWithTimeline({
 
       // Check if the new prompt is the same as the current live prompt
       // Compare both text and weights for prompt blending
-      console.log("handleLivePromptSubmit", promptItems);
       const newPromptText = promptItems.map(p => p.text).join(", ");
       const newPromptWeights = promptItems.map(p => p.weight);
       const currentLivePrompt = prompts.find(p => p.isLive);

--- a/frontend/src/components/PromptTimeline.tsx
+++ b/frontend/src/components/PromptTimeline.tsx
@@ -584,7 +584,7 @@ export function PromptTimeline({
               size="sm"
               variant="outline"
             >
-              <Upload className="h-4 w-4 mr-1" />
+              <Download className="h-4 w-4 mr-1" />
               Export
             </Button>
             <ExportDialog
@@ -607,7 +607,7 @@ export function PromptTimeline({
               variant="outline"
               disabled={disabled || isStreaming || isLoading || isDownloading}
             >
-              <Download className="h-4 w-4 mr-1" />
+              <Upload className="h-4 w-4 mr-1" />
               Import
             </Button>
             <Button

--- a/frontend/src/components/WorkflowImportDialog.tsx
+++ b/frontend/src/components/WorkflowImportDialog.tsx
@@ -23,16 +23,9 @@ import type {
   ResolutionItem,
   WorkflowResolutionPlan,
   WorkflowLoRAProvenance,
-  WorkflowLoRA,
-  LoRADownloadRequest,
 } from "../lib/workflowApi";
-import {
-  resolveWorkflow,
-  downloadLoRA,
-  installPlugin,
-  restartServer,
-  waitForServer,
-} from "../lib/api";
+import { resolveWorkflow } from "../lib/api";
+import { useLoRAsContext } from "../contexts/LoRAsContext";
 import type { SettingsState } from "../types";
 import type { TimelinePrompt } from "./PromptTimeline";
 import {
@@ -41,20 +34,16 @@ import {
   workflowToPromptState,
 } from "../lib/workflowSettings";
 import type { WorkflowPromptState } from "../lib/workflowSettings";
+import {
+  useLoRADownloads,
+  usePluginInstalls,
+} from "../hooks/useWorkflowDependencies";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 type ImportStep = "select" | "review";
-
-interface LoRADownloadState {
-  [filename: string]: "idle" | "downloading" | "done" | "error";
-}
-
-interface PluginInstallState {
-  [pluginName: string]: "idle" | "installing" | "done" | "error";
-}
 
 interface WorkflowImportDialogProps {
   open: boolean;
@@ -91,41 +80,6 @@ const kindLabel = (kind: ResolutionItem["kind"]) => {
       return "LoRA";
   }
 };
-
-function buildLoRADownloadRequest(
-  lora: WorkflowLoRA
-): LoRADownloadRequest | null {
-  const prov = lora.provenance;
-  if (!prov || prov.source === "local") return null;
-
-  if (prov.source === "huggingface") {
-    return {
-      source: "huggingface",
-      repo_id: prov.repo_id,
-      hf_filename: prov.hf_filename,
-      expected_sha256: lora.sha256,
-    };
-  }
-
-  if (prov.source === "civitai") {
-    return {
-      source: "civitai",
-      model_id: prov.model_id,
-      version_id: prov.version_id,
-      expected_sha256: lora.sha256,
-    };
-  }
-
-  if (prov.source === "url" && prov.url) {
-    return {
-      source: "url",
-      url: prov.url,
-      expected_sha256: lora.sha256,
-    };
-  }
-
-  return null;
-}
 
 function provenanceLabel(prov: WorkflowLoRAProvenance): string {
   if (prov.source === "huggingface" && prov.repo_id) {
@@ -169,18 +123,6 @@ function LoRAProvenanceLabel({
   );
 }
 
-function findPluginInstallSpec(
-  workflow: ScopeWorkflow,
-  pluginName: string
-): string | null {
-  for (const p of workflow.pipelines) {
-    if (p.source.plugin_name === pluginName) {
-      return p.source.package_spec ?? p.source.plugin_name ?? null;
-    }
-  }
-  return null;
-}
-
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -193,21 +135,23 @@ export function WorkflowImportDialog({
   const [step, setStep] = useState<ImportStep>("select");
   const [workflow, setWorkflow] = useState<ScopeWorkflow | null>(null);
   const [plan, setPlan] = useState<WorkflowResolutionPlan | null>(null);
-  const [loraDownloads, setLoraDownloads] = useState<LoRADownloadState>({});
-  const [pluginInstalls, setPluginInstalls] = useState<PluginInstallState>({});
   const [validating, setValidating] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { loraFiles } = useLoRAsContext();
+
+  const loras = useLoRADownloads(workflow);
+  const plugins = usePluginInstalls(workflow);
 
   // Reset all state when dialog closes
   const handleClose = useCallback(() => {
     setStep("select");
     setWorkflow(null);
     setPlan(null);
-    setLoraDownloads({});
-    setPluginInstalls({});
+    loras.reset();
+    plugins.reset();
     setValidating(false);
     onClose();
-  }, [onClose]);
+  }, [onClose, loras, plugins]);
 
   // -----------------------------------------------------------------------
   // File selection and validation
@@ -234,32 +178,41 @@ export function WorkflowImportDialog({
         return;
       }
 
+      if (
+        !parsed.metadata ||
+        typeof parsed.metadata.name !== "string" ||
+        !Array.isArray(parsed.pipelines) ||
+        parsed.pipelines.length === 0
+      ) {
+        toast.error("Malformed workflow file", {
+          description: "Missing required fields: metadata or pipelines",
+        });
+        setValidating(false);
+        return;
+      }
+
       setWorkflow(parsed);
 
       const resolution = await resolveWorkflow(parsed);
       setPlan(resolution);
 
-      // Initialize LoRA download states
-      const initialDownloads: LoRADownloadState = {};
-      for (const item of resolution.items) {
-        if (item.kind === "lora" && item.status === "missing") {
-          initialDownloads[item.name] = "idle";
-        }
-      }
-      setLoraDownloads(initialDownloads);
+      // Initialize dependency states from resolution items
+      loras.initialize(
+        resolution.items
+          .filter(i => i.kind === "lora" && i.status === "missing")
+          .map(i => i.name)
+      );
+      plugins.initialize(
+        resolution.items
+          .filter(
+            i =>
+              i.kind === "plugin" &&
+              i.status === "missing" &&
+              i.can_auto_resolve
+          )
+          .map(i => i.name)
+      );
 
-      // Initialize plugin install states
-      const initialPlugins: PluginInstallState = {};
-      for (const item of resolution.items) {
-        if (
-          item.kind === "plugin" &&
-          item.status === "missing" &&
-          item.can_auto_resolve
-        ) {
-          initialPlugins[item.name] = "idle";
-        }
-      }
-      setPluginInstalls(initialPlugins);
       setStep("review");
     } catch (err) {
       console.error("Workflow validation failed:", err);
@@ -291,117 +244,21 @@ export function WorkflowImportDialog({
   );
 
   // -----------------------------------------------------------------------
-  // LoRA download
-  // -----------------------------------------------------------------------
-
-  const handleDownloadLoRA = useCallback(
-    async (filename: string) => {
-      if (!workflow) return;
-
-      // Find the LoRA in the workflow
-      const lora = workflow.pipelines
-        .flatMap(p => p.loras)
-        .find(l => l.filename === filename);
-      if (!lora) return;
-
-      const req = buildLoRADownloadRequest(lora);
-      if (!req) {
-        toast.error("No download source available for this LoRA");
-        return;
-      }
-
-      setLoraDownloads(prev => ({ ...prev, [filename]: "downloading" }));
-      try {
-        await downloadLoRA(req);
-        setLoraDownloads(prev => ({ ...prev, [filename]: "done" }));
-        toast.success(`Downloaded ${filename}`);
-      } catch (err) {
-        setLoraDownloads(prev => ({ ...prev, [filename]: "error" }));
-        toast.error(`Failed to download ${filename}`, {
-          description: err instanceof Error ? err.message : String(err),
-        });
-      }
-    },
-    [workflow]
-  );
-
-  const handleDownloadAllLoRAs = useCallback(async () => {
-    if (!workflow) return;
-    const missing = Object.entries(loraDownloads)
-      .filter(([, s]) => s === "idle" || s === "error")
-      .map(([name]) => name);
-
-    await Promise.allSettled(missing.map(f => handleDownloadLoRA(f)));
-  }, [workflow, loraDownloads, handleDownloadLoRA]);
-
-  // -----------------------------------------------------------------------
-  // Plugin install
-  // -----------------------------------------------------------------------
-
-  const doRestartServer = useCallback(async () => {
-    toast.info("Restarting server to load new plugins...");
-    try {
-      const oldStartTime = await restartServer();
-      await waitForServer(oldStartTime);
-      toast.success("Server restarted successfully");
-    } catch {
-      toast.error(
-        "Server did not restart in time. You may need to restart manually."
-      );
-    }
-  }, []);
-
-  const handleInstallPlugin = useCallback(
-    async (pluginName: string, { skipRestart = false } = {}) => {
-      if (!workflow) return;
-
-      const installSpec = findPluginInstallSpec(workflow, pluginName);
-      if (!installSpec) {
-        toast.error("No install source available for this plugin");
-        return;
-      }
-
-      setPluginInstalls(prev => ({ ...prev, [pluginName]: "installing" }));
-      try {
-        const result = await installPlugin({ package: installSpec });
-        if (!result.success) {
-          throw new Error(result.message || "Installation failed");
-        }
-        setPluginInstalls(prev => ({ ...prev, [pluginName]: "done" }));
-        toast.success(`Installed ${pluginName}`);
-        if (!skipRestart) {
-          await doRestartServer();
-        }
-      } catch (err) {
-        setPluginInstalls(prev => ({ ...prev, [pluginName]: "error" }));
-        toast.error(`Failed to install ${pluginName}`, {
-          description: err instanceof Error ? err.message : String(err),
-        });
-      }
-    },
-    [workflow, doRestartServer]
-  );
-
-  const handleInstallAllPlugins = useCallback(async () => {
-    if (!workflow) return;
-    const missing = Object.entries(pluginInstalls)
-      .filter(([, s]) => s === "idle" || s === "error")
-      .map(([name]) => name);
-
-    await Promise.allSettled(
-      missing.map(name => handleInstallPlugin(name, { skipRestart: true }))
-    );
-    await doRestartServer();
-  }, [workflow, pluginInstalls, handleInstallPlugin, doRestartServer]);
-
-  // -----------------------------------------------------------------------
-  // Load workflow into the interface (no pipeline loading)
+  // Load workflow into the interface
   // -----------------------------------------------------------------------
 
   const handleLoad = useCallback(() => {
     if (!workflow) return;
 
-    const importedSettings = workflowToSettings(workflow);
+    if (
+      !window.confirm(
+        "Loading this workflow will replace your current settings and timeline. Continue?"
+      )
+    ) {
+      return;
+    }
+
+    const importedSettings = workflowToSettings(workflow, loraFiles);
     const timelinePrompts = workflowTimelineToPrompts(workflow.timeline);
     const promptState = workflowToPromptState(workflow);
 
@@ -420,17 +277,11 @@ export function WorkflowImportDialog({
     i => i.kind === "lora" && i.status === "missing"
   );
   const downloadableLoRAs = missingLoRAs?.filter(i => i.can_auto_resolve);
-  const someLoRAsDownloading = Object.values(loraDownloads).some(
-    s => s === "downloading"
-  );
 
   const missingPlugins = plan?.items.filter(
     i => i.kind === "plugin" && i.status === "missing"
   );
   const installablePlugins = missingPlugins?.filter(i => i.can_auto_resolve);
-  const somePluginsInstalling = Object.values(pluginInstalls).some(
-    s => s === "installing"
-  );
 
   // -----------------------------------------------------------------------
   // Render
@@ -529,12 +380,12 @@ export function WorkflowImportDialog({
                       item.status === "missing" &&
                       item.can_auto_resolve && (
                         <div className="mt-1">
-                          {loraDownloads[item.name] === "done" ? (
+                          {loras.downloads[item.name] === "done" ? (
                             <span className="text-xs text-green-500 flex items-center gap-1">
                               <CheckCircle2 className="h-3 w-3" />
                               Downloaded
                             </span>
-                          ) : loraDownloads[item.name] === "downloading" ? (
+                          ) : loras.downloads[item.name] === "downloading" ? (
                             <span className="text-xs text-muted-foreground flex items-center gap-1">
                               <Loader2 className="h-3 w-3 animate-spin" />
                               Downloading...
@@ -544,10 +395,10 @@ export function WorkflowImportDialog({
                               variant="ghost"
                               size="sm"
                               className="h-6 text-xs px-2"
-                              onClick={() => handleDownloadLoRA(item.name)}
+                              onClick={() => loras.downloadOne(item.name)}
                             >
                               <Download className="h-3 w-3 mr-1" />
-                              {loraDownloads[item.name] === "error"
+                              {loras.downloads[item.name] === "error"
                                 ? "Retry"
                                 : "Download"}
                             </Button>
@@ -564,12 +415,12 @@ export function WorkflowImportDialog({
                       item.status === "missing" &&
                       item.can_auto_resolve && (
                         <div className="mt-1">
-                          {pluginInstalls[item.name] === "done" ? (
+                          {plugins.installs[item.name] === "done" ? (
                             <span className="text-xs text-green-500 flex items-center gap-1">
                               <CheckCircle2 className="h-3 w-3" />
                               Installed
                             </span>
-                          ) : pluginInstalls[item.name] === "installing" ? (
+                          ) : plugins.installs[item.name] === "installing" ? (
                             <span className="text-xs text-muted-foreground flex items-center gap-1">
                               <Loader2 className="h-3 w-3 animate-spin" />
                               Installing...
@@ -579,10 +430,10 @@ export function WorkflowImportDialog({
                               variant="ghost"
                               size="sm"
                               className="h-6 text-xs px-2"
-                              onClick={() => handleInstallPlugin(item.name)}
+                              onClick={() => plugins.installOne(item.name)}
                             >
                               <Download className="h-3 w-3 mr-1" />
-                              {pluginInstalls[item.name] === "error"
+                              {plugins.installs[item.name] === "error"
                                 ? "Retry"
                                 : "Install"}
                             </Button>
@@ -598,17 +449,17 @@ export function WorkflowImportDialog({
             {downloadableLoRAs &&
               downloadableLoRAs.length > 1 &&
               missingLoRAs &&
-              missingLoRAs.some(l => loraDownloads[l.name] !== "done") && (
+              missingLoRAs.some(l => loras.downloads[l.name] !== "done") && (
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={handleDownloadAllLoRAs}
-                  disabled={someLoRAsDownloading}
+                  onClick={loras.downloadAll}
+                  disabled={loras.someDownloading}
                 >
                   <Download className="h-4 w-4 mr-2" />
-                  {someLoRAsDownloading
+                  {loras.someDownloading
                     ? "Downloading..."
-                    : `Download All Missing LoRAs (${downloadableLoRAs.filter(l => loraDownloads[l.name] !== "done").length})`}
+                    : `Download All Missing LoRAs (${downloadableLoRAs.filter(l => loras.downloads[l.name] !== "done").length})`}
                 </Button>
               )}
 
@@ -616,17 +467,17 @@ export function WorkflowImportDialog({
             {installablePlugins &&
               installablePlugins.length > 1 &&
               missingPlugins &&
-              missingPlugins.some(p => pluginInstalls[p.name] !== "done") && (
+              missingPlugins.some(p => plugins.installs[p.name] !== "done") && (
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={handleInstallAllPlugins}
-                  disabled={somePluginsInstalling}
+                  onClick={plugins.installAll}
+                  disabled={plugins.someInstalling}
                 >
                   <Download className="h-4 w-4 mr-2" />
-                  {somePluginsInstalling
+                  {plugins.someInstalling
                     ? "Installing..."
-                    : `Install All Missing Plugins (${installablePlugins.filter(p => pluginInstalls[p.name] !== "done").length})`}
+                    : `Install All Missing Plugins (${installablePlugins.filter(p => plugins.installs[p.name] !== "done").length})`}
                 </Button>
               )}
 
@@ -654,7 +505,7 @@ export function WorkflowImportDialog({
           {step === "review" && (
             <Button
               onClick={handleLoad}
-              disabled={someLoRAsDownloading || somePluginsInstalling}
+              disabled={loras.someDownloading || plugins.someInstalling}
             >
               Load Workflow
             </Button>

--- a/frontend/src/hooks/useWorkflowDependencies.ts
+++ b/frontend/src/hooks/useWorkflowDependencies.ts
@@ -1,0 +1,237 @@
+/**
+ * Hooks for managing LoRA downloads and plugin installs during workflow import.
+ */
+
+import { useState, useCallback } from "react";
+import { toast } from "sonner";
+import type {
+  ScopeWorkflow,
+  WorkflowLoRA,
+  LoRADownloadRequest,
+} from "../lib/workflowApi";
+import {
+  downloadLoRA,
+  installPlugin,
+  restartServer,
+  waitForServer,
+} from "../lib/api";
+
+// ---------------------------------------------------------------------------
+// LoRA downloads
+// ---------------------------------------------------------------------------
+
+export type LoRADownloadStatus = "idle" | "downloading" | "done" | "error";
+
+function buildLoRADownloadRequest(
+  lora: WorkflowLoRA
+): LoRADownloadRequest | null {
+  const prov = lora.provenance;
+  if (!prov || prov.source === "local") return null;
+
+  if (prov.source === "huggingface") {
+    return {
+      source: "huggingface",
+      repo_id: prov.repo_id,
+      hf_filename: prov.hf_filename,
+      expected_sha256: lora.sha256,
+    };
+  }
+
+  if (prov.source === "civitai") {
+    return {
+      source: "civitai",
+      model_id: prov.model_id,
+      version_id: prov.version_id,
+      expected_sha256: lora.sha256,
+    };
+  }
+
+  if (prov.source === "url" && prov.url) {
+    return {
+      source: "url",
+      url: prov.url,
+      expected_sha256: lora.sha256,
+    };
+  }
+
+  return null;
+}
+
+export function useLoRADownloads(workflow: ScopeWorkflow | null) {
+  const [downloads, setDownloads] = useState<
+    Record<string, LoRADownloadStatus>
+  >({});
+
+  const initialize = useCallback(
+    (missingFilenames: string[]) => {
+      const initial: Record<string, LoRADownloadStatus> = {};
+      for (const name of missingFilenames) {
+        initial[name] = "idle";
+      }
+      setDownloads(initial);
+    },
+    [setDownloads]
+  );
+
+  const downloadOne = useCallback(
+    async (filename: string) => {
+      if (!workflow) return;
+
+      const lora = workflow.pipelines
+        .flatMap(p => p.loras)
+        .find(l => l.filename === filename);
+      if (!lora) return;
+
+      const req = buildLoRADownloadRequest(lora);
+      if (!req) {
+        toast.error("No download source available for this LoRA");
+        return;
+      }
+
+      setDownloads(prev => ({ ...prev, [filename]: "downloading" }));
+      try {
+        await downloadLoRA(req);
+        setDownloads(prev => ({ ...prev, [filename]: "done" }));
+        toast.success(`Downloaded ${filename}`);
+      } catch (err) {
+        setDownloads(prev => ({ ...prev, [filename]: "error" }));
+        toast.error(`Failed to download ${filename}`, {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [workflow]
+  );
+
+  const downloadAll = useCallback(async () => {
+    const pending = Object.entries(downloads)
+      .filter(([, s]) => s === "idle" || s === "error")
+      .map(([name]) => name);
+    await Promise.allSettled(pending.map(f => downloadOne(f)));
+  }, [downloads, downloadOne]);
+
+  const reset = useCallback(() => setDownloads({}), []);
+
+  const someDownloading = Object.values(downloads).some(
+    s => s === "downloading"
+  );
+
+  return {
+    downloads,
+    initialize,
+    downloadOne,
+    downloadAll,
+    reset,
+    someDownloading,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin installs
+// ---------------------------------------------------------------------------
+
+export type PluginInstallStatus = "idle" | "installing" | "done" | "error";
+
+function findPluginInstallSpec(
+  workflow: ScopeWorkflow,
+  pluginName: string
+): string | null {
+  for (const p of workflow.pipelines) {
+    if (p.source.plugin_name === pluginName) {
+      return p.source.package_spec ?? p.source.plugin_name ?? null;
+    }
+  }
+  return null;
+}
+
+export function usePluginInstalls(workflow: ScopeWorkflow | null) {
+  const [installs, setInstalls] = useState<Record<string, PluginInstallStatus>>(
+    {}
+  );
+
+  const initialize = useCallback(
+    (pluginNames: string[]) => {
+      const initial: Record<string, PluginInstallStatus> = {};
+      for (const name of pluginNames) {
+        initial[name] = "idle";
+      }
+      setInstalls(initial);
+    },
+    [setInstalls]
+  );
+
+  const doRestartServer = useCallback(async () => {
+    toast.info("Restarting server to load new plugins...");
+    try {
+      const oldStartTime = await restartServer();
+      await waitForServer(oldStartTime);
+      toast.success("Server restarted successfully");
+    } catch {
+      toast.error(
+        "Server did not restart in time. You may need to restart manually."
+      );
+    }
+  }, []);
+
+  const installOne = useCallback(
+    async (pluginName: string, { skipRestart = false } = {}) => {
+      if (!workflow) return;
+
+      const installSpec = findPluginInstallSpec(workflow, pluginName);
+      if (!installSpec) {
+        toast.error("No install source available for this plugin");
+        return;
+      }
+
+      if (
+        !window.confirm(
+          `This will install the package "${installSpec}" via pip. Only proceed if you trust the workflow source.\n\nContinue?`
+        )
+      ) {
+        return;
+      }
+
+      setInstalls(prev => ({ ...prev, [pluginName]: "installing" }));
+      try {
+        const result = await installPlugin({ package: installSpec });
+        if (!result.success) {
+          throw new Error(result.message || "Installation failed");
+        }
+        setInstalls(prev => ({ ...prev, [pluginName]: "done" }));
+        toast.success(`Installed ${pluginName}`);
+        if (!skipRestart) {
+          await doRestartServer();
+        }
+      } catch (err) {
+        setInstalls(prev => ({ ...prev, [pluginName]: "error" }));
+        toast.error(`Failed to install ${pluginName}`, {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [workflow, doRestartServer]
+  );
+
+  const installAll = useCallback(async () => {
+    const pending = Object.entries(installs)
+      .filter(([, s]) => s === "idle" || s === "error")
+      .map(([name]) => name);
+    await Promise.allSettled(
+      pending.map(name => installOne(name, { skipRestart: true }))
+    );
+    await doRestartServer();
+  }, [installs, installOne, doRestartServer]);
+
+  const reset = useCallback(() => setInstalls({}), []);
+
+  const someInstalling = Object.values(installs).some(s => s === "installing");
+
+  return {
+    installs,
+    initialize,
+    installOne,
+    installAll,
+    reset,
+    someInstalling,
+  };
+}

--- a/frontend/src/lib/workflowApi.ts
+++ b/frontend/src/lib/workflowApi.ts
@@ -124,4 +124,3 @@ export interface LoRADownloadResult {
   sha256: string;
   size_bytes: number;
 }
-

--- a/frontend/src/lib/workflowSettings.ts
+++ b/frontend/src/lib/workflowSettings.ts
@@ -101,6 +101,17 @@ function extractFilename(path: string): string {
   return parts[parts.length - 1] || path;
 }
 
+/** Resolve a LoRA filename to the full path from the available files list. */
+function resolveLoRAPath(
+  filename: string,
+  availableLoRAs: LoRAFileInfo[]
+): string {
+  const match = availableLoRAs.find(
+    f => extractFilename(f.path).toLowerCase() === filename.toLowerCase()
+  );
+  return match?.path ?? filename;
+}
+
 /** Determine the pipeline source (builtin vs plugin). */
 function buildPipelineSource(
   pipelineId: string,
@@ -375,7 +386,8 @@ function extractProcessorSettings(pipelines: WorkflowPipeline[]): {
  * resolve full paths after the workflow is applied and LoRAs are present.
  */
 export function workflowToSettings(
-  workflow: ScopeWorkflow
+  workflow: ScopeWorkflow,
+  availableLoRAs: LoRAFileInfo[] = []
 ): Partial<SettingsState> {
   if (workflow.pipelines.length === 0) return {};
 
@@ -421,12 +433,18 @@ export function workflowToSettings(
 
   // LoRAs
   if (mainPipeline.loras.length > 0) {
+    const VALID_MERGE_MODES: LoraMergeStrategy[] = [
+      "permanent_merge",
+      "runtime_peft",
+    ];
     partial.loras = mainPipeline.loras.map(
       (l): LoRAConfig => ({
         id: l.id ?? l.filename,
-        path: l.filename, // filename-only; resolved after apply
+        path: resolveLoRAPath(l.filename, availableLoRAs),
         scale: l.weight,
-        mergeMode: l.merge_mode as LoraMergeStrategy | undefined,
+        mergeMode: VALID_MERGE_MODES.includes(l.merge_mode as LoraMergeStrategy)
+          ? (l.merge_mode as LoraMergeStrategy)
+          : undefined,
       })
     );
     // Use the first LoRA's merge_mode as the global strategy

--- a/src/scope/core/workflows/resolve.py
+++ b/src/scope/core/workflows/resolve.py
@@ -9,18 +9,21 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from scope.core.pipelines.registry import PipelineRegistry
+
+if TYPE_CHECKING:
+    from scope.core.plugins.manager import PluginManager
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Minimal request models — only the fields the backend actually accesses.
+# Minimal request models -- only the fields the backend actually accesses.
 # All models use extra="ignore" so the frontend can send the full workflow
 # JSON and the backend silently drops fields it doesn't care about.
 # ---------------------------------------------------------------------------
@@ -36,7 +39,7 @@ class WorkflowLoRAProvenance(BaseModel, extra="ignore"):
 
 
 class WorkflowLoRA(BaseModel, extra="ignore"):
-    filename: str
+    filename: str = Field(max_length=255)
     provenance: WorkflowLoRAProvenance | None = None
 
 
@@ -50,11 +53,11 @@ class WorkflowPipelineSource(BaseModel, extra="ignore"):
 class WorkflowPipeline(BaseModel, extra="ignore"):
     pipeline_id: str
     source: WorkflowPipelineSource
-    loras: list[WorkflowLoRA] = []
+    loras: list[WorkflowLoRA] = Field(default=[], max_length=100)
 
 
 class WorkflowRequest(BaseModel, extra="ignore"):
-    pipelines: list[WorkflowPipeline]
+    pipelines: list[WorkflowPipeline] = Field(max_length=50)
     min_scope_version: str | None = None
 
 
@@ -175,7 +178,17 @@ def _check_plugin_version(
 
 
 def _resolve_lora(lora: WorkflowLoRA, lora_dir: Path) -> ResolutionItem:
-    if (lora_dir / lora.filename).exists():
+    # Guard against path traversal: ensure the resolved path stays within lora_dir
+    target = (lora_dir / lora.filename).resolve()
+    if not target.is_relative_to(lora_dir.resolve()):
+        return ResolutionItem(
+            kind="lora",
+            name=lora.filename,
+            status="missing",
+            detail="Invalid LoRA filename",
+        )
+
+    if target.exists():
         return ResolutionItem(kind="lora", name=lora.filename, status="ok")
 
     prov = lora.provenance
@@ -228,12 +241,12 @@ def _check_min_scope_version(
 
 def resolve_workflow(
     workflow: WorkflowRequest,
-    plugin_manager: Any,
+    plugin_manager: PluginManager,
     models_dir: Path,
 ) -> WorkflowResolutionPlan:
     """Resolve all dependencies for *workflow*.
 
-    This is a **read-only** operation — no downloads, no installs.
+    This is a **read-only** operation -- no downloads, no installs.
     """
     items: list[ResolutionItem] = []
     warnings: list[str] = []
@@ -249,7 +262,7 @@ def resolve_workflow(
             item = _resolve_plugin(wp, plugins)
 
         items.append(item)
-        if item.status == "missing":
+        if item.status in ("missing", "version_mismatch"):
             all_pipelines_ok = False
 
         for lora in wp.loras:

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -39,7 +39,12 @@ from scope.core.lora.manifest import (
     load_manifest,
     save_manifest,
 )
-from scope.core.workflows.resolve import WorkflowRequest
+from scope.core.workflows.resolve import (
+    WorkflowRequest,
+    WorkflowResolutionPlan,
+    resolve_workflow,
+)
+from scope.server.models_config import get_models_dir
 
 from .cloud_proxy import (
     cloud_proxy,
@@ -1205,7 +1210,7 @@ async def tag_lora_provenance(
 # ---------------------------------------------------------------------------
 
 
-@app.post("/api/v1/workflow/resolve")
+@app.post("/api/v1/workflow/resolve", response_model=WorkflowResolutionPlan)
 def resolve_workflow_endpoint(
     workflow: WorkflowRequest,
 ):
@@ -1213,15 +1218,17 @@ def resolve_workflow_endpoint(
 
     This is side-effect-free: no installs, no downloads.  The request
     body uses ``extra="ignore"`` so the frontend can send the full
-    workflow JSON — the backend only reads the fields it needs.
+    workflow JSON; the backend only reads the fields it needs.
     """
     from scope.core.plugins import get_plugin_manager
-    from scope.core.workflows.resolve import resolve_workflow
-    from scope.server.models_config import get_models_dir
 
-    plugin_manager = get_plugin_manager()
-    models_dir = get_models_dir()
-    return resolve_workflow(workflow, plugin_manager, models_dir)
+    try:
+        plugin_manager = get_plugin_manager()
+        models_dir = get_models_dir()
+        return resolve_workflow(workflow, plugin_manager, models_dir)
+    except Exception as e:
+        logger.error("Error resolving workflow: %s", e)
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @app.get("/api/v1/assets", response_model=AssetsResponse)

--- a/tests/test_workflow_resolve.py
+++ b/tests/test_workflow_resolve.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from scope.core.workflows.resolve import (
     WorkflowLoRA,
     WorkflowLoRAProvenance,
@@ -613,3 +615,163 @@ class TestMinScopeVersion:
         plan = resolve_workflow(wf, mock_plugin_manager(), tmp_path)
 
         assert not any("Scope >=" in w for w in plan.warnings)
+
+    @patch("scope.core.workflows.resolve.PipelineRegistry")
+    @patch("importlib.metadata.version")
+    def test_resolve_warns_when_package_not_found(
+        self, mock_version, mock_registry, tmp_path
+    ):
+        """PackageNotFoundError produces a warning."""
+        import importlib.metadata
+
+        mock_registry.is_registered.return_value = True
+        mock_version.side_effect = importlib.metadata.PackageNotFoundError(
+            "daydream-scope"
+        )
+
+        wf = make_workflow(min_scope_version="1.0.0")
+        plan = resolve_workflow(wf, mock_plugin_manager(), tmp_path)
+
+        assert any("Could not verify" in w for w in plan.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Path traversal tests
+# ---------------------------------------------------------------------------
+
+
+class TestPathTraversal:
+    @patch("scope.core.workflows.resolve.PipelineRegistry")
+    def test_lora_path_traversal_rejected(self, mock_registry, tmp_path):
+        """LoRA filenames with path traversal components are rejected."""
+        mock_registry.is_registered.return_value = True
+
+        lora_dir = tmp_path / "lora"
+        lora_dir.mkdir()
+
+        wf = make_workflow(
+            pipelines=[
+                WorkflowPipeline(
+                    pipeline_id="test_pipe",
+                    source=WorkflowPipelineSource(type="builtin"),
+                    loras=[WorkflowLoRA(filename="../../etc/passwd")],
+                )
+            ]
+        )
+
+        plan = resolve_workflow(wf, mock_plugin_manager(), tmp_path)
+
+        lora_items = [i for i in plan.items if i.kind == "lora"]
+        assert lora_items[0].status == "missing"
+        assert lora_items[0].detail == "Invalid LoRA filename"
+        assert lora_items[0].can_auto_resolve is False
+
+    @patch("scope.core.workflows.resolve.PipelineRegistry")
+    def test_lora_normal_filename_ok(self, mock_registry, tmp_path):
+        """Normal filenames still work after path traversal guard."""
+        mock_registry.is_registered.return_value = True
+
+        lora_dir = tmp_path / "lora"
+        lora_dir.mkdir()
+        (lora_dir / "valid.safetensors").write_bytes(b"data")
+
+        wf = make_workflow(
+            pipelines=[
+                WorkflowPipeline(
+                    pipeline_id="test_pipe",
+                    source=WorkflowPipelineSource(type="builtin"),
+                    loras=[WorkflowLoRA(filename="valid.safetensors")],
+                )
+            ]
+        )
+
+        plan = resolve_workflow(wf, mock_plugin_manager(), tmp_path)
+
+        lora_items = [i for i in plan.items if i.kind == "lora"]
+        assert lora_items[0].status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Empty pipelines + version_mismatch can_apply tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    @patch("scope.core.workflows.resolve.PipelineRegistry")
+    def test_empty_pipelines(self, mock_registry, tmp_path):
+        """Empty pipelines list resolves with can_apply=True and no items."""
+        wf = WorkflowRequest(pipelines=[])
+        plan = resolve_workflow(wf, mock_plugin_manager(), tmp_path)
+
+        assert plan.can_apply is True
+        assert plan.items == []
+
+    @patch("scope.core.workflows.resolve.PipelineRegistry")
+    def test_version_mismatch_blocks_can_apply(self, mock_registry, tmp_path):
+        """Plugin version_mismatch sets can_apply=False."""
+        mock_registry.is_registered.return_value = True
+
+        wf = make_workflow(
+            pipelines=[
+                WorkflowPipeline(
+                    pipeline_id="face-swap",
+                    source=WorkflowPipelineSource(
+                        type="pypi",
+                        plugin_name="scope-deeplivecam",
+                        plugin_version="2.0.0",
+                    ),
+                )
+            ]
+        )
+        pm = mock_plugin_manager([{"name": "scope-deeplivecam", "version": "0.1.0"}])
+
+        plan = resolve_workflow(wf, pm, tmp_path)
+
+        plugin_items = [i for i in plan.items if i.kind == "plugin"]
+        assert plugin_items[0].status == "version_mismatch"
+        assert plan.can_apply is False
+
+
+# ---------------------------------------------------------------------------
+# Input validation (Field constraints)
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_lora_filename_max_length(self):
+        """LoRA filename exceeding max_length is rejected."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            WorkflowLoRA(filename="a" * 256)
+
+    def test_lora_filename_at_max_length(self):
+        """LoRA filename at max_length is accepted."""
+        lora = WorkflowLoRA(filename="a" * 255)
+        assert len(lora.filename) == 255
+
+    def test_too_many_pipelines_rejected(self):
+        """WorkflowRequest with >50 pipelines is rejected."""
+        from pydantic import ValidationError
+
+        pipelines = [
+            WorkflowPipeline(
+                pipeline_id=f"pipe_{i}",
+                source=WorkflowPipelineSource(type="builtin"),
+            )
+            for i in range(51)
+        ]
+        with pytest.raises(ValidationError):
+            WorkflowRequest(pipelines=pipelines)
+
+    def test_too_many_loras_rejected(self):
+        """WorkflowPipeline with >100 LoRAs is rejected."""
+        from pydantic import ValidationError
+
+        loras = [WorkflowLoRA(filename=f"lora_{i}.safetensors") for i in range(101)]
+        with pytest.raises(ValidationError):
+            WorkflowPipeline(
+                pipeline_id="test",
+                source=WorkflowPipelineSource(type="builtin"),
+                loras=loras,
+            )


### PR DESCRIPTION
- Extract LoRA download and plugin install logic from WorkflowImportDialog into useLoRADownloads/usePluginInstalls hooks
  - Add path traversal guard on LoRA filename resolution (backend)
  - Add Field constraints (max_length) on workflow request models
  - Add frontend validation of workflow structure before resolution
  - Add confirmation dialogs for plugin installs and workflow loading
  - Fix swapped Upload/Download icons on Export/Import buttons
  - Fix version_mismatch not blocking can_apply in resolution plan
  - Resolve LoRA paths at import time using available files list
  - Fix misplaced function definition between import blocks
  - Remove stale console.log and duplicate comment
  - Add tests for path traversal, input validation, and edge cases