### PR TITLE
WebRTC ICE server fix

### DIFF
--- a/src/scope/server/cloud_webrtc_client.py
+++ b/src/scope/server/cloud_webrtc_client.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
-from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc import RTCConfiguration, RTCPeerConnection, RTCSessionDescription
 from aiortc.mediastreams import VIDEO_TIME_BASE, MediaStreamTrack
 from av import VideoFrame
 
@@ -201,10 +201,15 @@ class CloudWebRTCClient:
 
         # Get ICE servers from cloud
         ice_response = await self.cloud_manager.webrtc_get_ice_servers()
-        ice_servers = ice_response.get("data", {}).get("iceServers", [])
 
-        # Create peer connection
-        config = {"iceServers": ice_servers} if ice_servers else {}
+        from .webrtc import credentials_to_rtc_ice_servers
+
+        rtc_ice_servers = credentials_to_rtc_ice_servers(ice_response)
+        config = (
+            RTCConfiguration(iceServers=rtc_ice_servers)
+            if rtc_ice_servers
+            else RTCConfiguration()
+        )
         self.pc = RTCPeerConnection(config)
 
         # Create input track for sending frames to cloud


### PR DESCRIPTION
The client-to-cloud WebRTC connection was being created with no ICE/TURN servers, causing it to fail ICE negotiation and time out after 30s.
Two bugs in CloudWebRTCClient.connect():
1. Double data extraction — webrtc_get_ice_servers() already unwraps response["data"] and returns {"iceServers": [...]}. But the client then called .get("data", {}).get("iceServers", []), looking for a non-existent nested "data" key. Result: empty list, TURN servers silently dropped.
2. Wrong config type — Even if the servers were extracted, a raw dict was passed to RTCPeerConnection() instead of a proper RTCConfiguration with RTCIceServer objects (which is what the local WebRTC path does correctly via create_rtc_config()).

The fix reuses the existing credentials_to_rtc_ice_servers() helper from webrtc.py to properly parse the ICE server response into RTCIceServer objects, and wraps them in an RTCConfiguration — matching how the local WebRTC path works.