### PR TITLE
Allow seed updates during streaming

### DIFF
--- a/src/scope/core/pipelines/krea_realtime_video/schema.py
+++ b/src/scope/core/pipelines/krea_realtime_video/schema.py
@@ -93,7 +93,7 @@ class KreaRealtimeVideoConfig(BasePipelineConfig):
         default=42,
         ge=0,
         description="Base random seed for reproducible generation",
-        json_schema_extra=ui_field_config(order=5, is_load_param=True, label="Seed"),
+        json_schema_extra=ui_field_config(order=5, label="Seed"),
     )
     manage_cache: bool = Field(
         default=True,

--- a/src/scope/core/pipelines/longlive/schema.py
+++ b/src/scope/core/pipelines/longlive/schema.py
@@ -86,7 +86,7 @@ class LongLiveConfig(BasePipelineConfig):
         default=42,
         ge=0,
         description="Base random seed for reproducible generation",
-        json_schema_extra=ui_field_config(order=5, is_load_param=True, label="Seed"),
+        json_schema_extra=ui_field_config(order=5, label="Seed"),
     )
     manage_cache: bool = Field(
         default=True,

--- a/src/scope/core/pipelines/memflow/schema.py
+++ b/src/scope/core/pipelines/memflow/schema.py
@@ -85,7 +85,7 @@ class MemFlowConfig(BasePipelineConfig):
         default=42,
         ge=0,
         description="Base random seed for reproducible generation",
-        json_schema_extra=ui_field_config(order=5, is_load_param=True, label="Seed"),
+        json_schema_extra=ui_field_config(order=5, label="Seed"),
     )
     manage_cache: bool = Field(
         default=True,

--- a/src/scope/core/pipelines/reward_forcing/schema.py
+++ b/src/scope/core/pipelines/reward_forcing/schema.py
@@ -84,7 +84,7 @@ class RewardForcingConfig(BasePipelineConfig):
         default=42,
         ge=0,
         description="Base random seed for reproducible generation",
-        json_schema_extra=ui_field_config(order=5, is_load_param=True, label="Seed"),
+        json_schema_extra=ui_field_config(order=5, label="Seed"),
     )
     manage_cache: bool = Field(
         default=True,

--- a/src/scope/core/pipelines/streamdiffusionv2/schema.py
+++ b/src/scope/core/pipelines/streamdiffusionv2/schema.py
@@ -90,7 +90,7 @@ class StreamDiffusionV2Config(BasePipelineConfig):
         default=42,
         ge=0,
         description="Base random seed for reproducible generation",
-        json_schema_extra=ui_field_config(order=5, is_load_param=True, label="Seed"),
+        json_schema_extra=ui_field_config(order=5, label="Seed"),
     )
     manage_cache: bool = Field(
         default=True,

--- a/src/scope/core/pipelines/wan2_1/blocks/prepare_latents.py
+++ b/src/scope/core/pipelines/wan2_1/blocks/prepare_latents.py
@@ -90,7 +90,8 @@ class PrepareLatentsBlock(ModularPipelineBlocks):
             base_seed = 42
 
         # Create generator from seed for reproducible generation
-        block_seed = base_seed + block_state.current_start_frame
+        # manual_seed accepts a C long long, so clamp to [0, 2^63-1]
+        block_seed = (base_seed + block_state.current_start_frame) % (2**63)
         rng = torch.Generator(device=generator_param.device).manual_seed(block_seed)
 
         # Determine number of latent frames to generate

--- a/src/scope/core/pipelines/wan2_1/blocks/prepare_video_latents.py
+++ b/src/scope/core/pipelines/wan2_1/blocks/prepare_video_latents.py
@@ -88,7 +88,8 @@ class PrepareVideoLatentsBlock(ModularPipelineBlocks):
             base_seed = 42
 
         # Create generator from seed for reproducible generation
-        block_seed = base_seed + block_state.current_start_frame
+        # manual_seed accepts a C long long, so clamp to [0, 2^63-1]
+        block_seed = (base_seed + block_state.current_start_frame) % (2**63)
         rng = torch.Generator(device=components.config.device).manual_seed(block_seed)
 
         # Generate empty latents (noise)

--- a/tests/test_seed_runtime_update.py
+++ b/tests/test_seed_runtime_update.py
@@ -1,0 +1,264 @@
+"""Tests verifying base_seed is a runtime parameter, not a load parameter.
+
+The seed should be changeable while a stream is active. These tests ensure that
+the schema metadata for base_seed does NOT include is_load_param=True, and that
+the pipeline state correctly picks up seed changes at runtime.
+"""
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Schema-level tests: base_seed must NOT be a load param
+# ---------------------------------------------------------------------------
+
+PIPELINE_SCHEMA_MODULES = [
+    "scope.core.pipelines.longlive.schema",
+    "scope.core.pipelines.memflow.schema",
+    "scope.core.pipelines.streamdiffusionv2.schema",
+    "scope.core.pipelines.reward_forcing.schema",
+    "scope.core.pipelines.krea_realtime_video.schema",
+]
+
+
+def _get_config_class(module_path: str):
+    """Import and return the pipeline config class from a schema module."""
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    # Each schema module has exactly one class that ends with "Config"
+    for attr_name in dir(mod):
+        obj = getattr(mod, attr_name)
+        if (
+            isinstance(obj, type)
+            and attr_name.endswith("Config")
+            and attr_name != "BasePipelineConfig"
+            and attr_name != "ConfigDict"
+        ):
+            return obj
+    raise RuntimeError(f"No Config class found in {module_path}")
+
+
+def _get_base_seed_ui(config_class) -> dict:
+    """Extract the UI metadata dict for the base_seed field."""
+    schema = config_class.model_json_schema()
+    props = schema.get("properties", {})
+    seed_prop = props.get("base_seed", {})
+    return seed_prop.get("ui", {})
+
+
+class TestBaseSeedIsRuntimeParam:
+    """base_seed should be editable while the stream is active."""
+
+    @pytest.mark.parametrize("module_path", PIPELINE_SCHEMA_MODULES)
+    def test_base_seed_not_load_param(self, module_path):
+        """is_load_param must be False (the default) for base_seed."""
+        config_class = _get_config_class(module_path)
+        ui = _get_base_seed_ui(config_class)
+        assert ui.get("is_load_param") is not True, (
+            f"{config_class.__name__}.base_seed should not be a load param"
+        )
+
+    @pytest.mark.parametrize("module_path", PIPELINE_SCHEMA_MODULES)
+    def test_base_seed_has_label(self, module_path):
+        """base_seed should still have its UI label."""
+        config_class = _get_config_class(module_path)
+        ui = _get_base_seed_ui(config_class)
+        assert ui.get("label") == "Seed"
+
+    @pytest.mark.parametrize("module_path", PIPELINE_SCHEMA_MODULES)
+    def test_base_seed_in_configuration_category(self, module_path):
+        """base_seed should remain in the configuration category."""
+        config_class = _get_config_class(module_path)
+        ui = _get_base_seed_ui(config_class)
+        assert ui.get("category") == "configuration"
+
+
+# ---------------------------------------------------------------------------
+# ui_field_config helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestUiFieldConfigDefaults:
+    """Verify ui_field_config produces correct defaults."""
+
+    def test_default_is_load_param_false(self):
+        from scope.core.pipelines.base_schema import ui_field_config
+
+        result = ui_field_config(order=1)
+        assert result["ui"]["is_load_param"] is False
+
+    def test_explicit_is_load_param_true(self):
+        from scope.core.pipelines.base_schema import ui_field_config
+
+        result = ui_field_config(order=1, is_load_param=True)
+        assert result["ui"]["is_load_param"] is True
+
+    def test_default_category_is_configuration(self):
+        from scope.core.pipelines.base_schema import ui_field_config
+
+        result = ui_field_config()
+        assert result["ui"]["category"] == "configuration"
+
+
+# ---------------------------------------------------------------------------
+# get_schema_with_metadata integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaMetadataSeedField:
+    """Verify the full schema endpoint output marks seed as runtime."""
+
+    @pytest.mark.parametrize("module_path", PIPELINE_SCHEMA_MODULES)
+    def test_schema_with_metadata_seed_not_load_param(self, module_path):
+        """get_schema_with_metadata should expose base_seed without is_load_param."""
+        config_class = _get_config_class(module_path)
+        metadata = config_class.get_schema_with_metadata()
+        config_schema = metadata["config_schema"]
+        seed_props = config_schema["properties"]["base_seed"]
+        ui = seed_props.get("ui", {})
+        assert ui.get("is_load_param") is not True
+
+
+# ---------------------------------------------------------------------------
+# Pipeline state tests: seed updates propagate at runtime
+# ---------------------------------------------------------------------------
+
+
+class TestSeedStateUpdate:
+    """Verify that base_seed can be updated in pipeline state at runtime."""
+
+    def test_state_set_updates_seed(self):
+        """PipelineState.set should update base_seed."""
+        from diffusers.modular_pipelines import PipelineState
+
+        state = PipelineState()
+        state.set("base_seed", 42)
+        assert state.get("base_seed") == 42
+
+        # Simulate runtime update
+        state.set("base_seed", 999)
+        assert state.get("base_seed") == 999
+
+    def test_kwargs_loop_updates_seed(self):
+        """Simulates the pipeline __call__ kwargs loop updating state."""
+        from diffusers.modular_pipelines import PipelineState
+
+        state = PipelineState()
+        state.set("base_seed", 42)
+
+        # This mirrors the pattern in pipeline __call__:
+        #   for k, v in kwargs.items():
+        #       self.state.set(k, v)
+        kwargs = {"base_seed": 123, "prompt": "test"}
+        for k, v in kwargs.items():
+            state.set(k, v)
+
+        assert state.get("base_seed") == 123
+
+    def test_seed_default_value(self):
+        """base_seed should default to 42 across all pipeline schemas."""
+        for module_path in PIPELINE_SCHEMA_MODULES:
+            config_class = _get_config_class(module_path)
+            instance = config_class()
+            assert instance.base_seed == 42, (
+                f"{config_class.__name__} default seed should be 42"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Overflow safety tests: block_seed must not overflow torch manual_seed
+# ---------------------------------------------------------------------------
+
+
+class TestSeedOverflowSafety:
+    """block_seed = base_seed + current_start_frame must stay within long long range."""
+
+    def test_prepare_latents_large_seed_no_overflow(self):
+        """PrepareLatentsBlock should not crash with a very large seed."""
+        from unittest.mock import MagicMock, patch
+
+        from scope.core.pipelines.wan2_1.blocks.prepare_latents import (
+            PrepareLatentsBlock,
+        )
+
+        block = PrepareLatentsBlock()
+
+        # Mock components
+        components = MagicMock()
+        param_tensor = MagicMock()
+        param_tensor.device = "cpu"
+        param_tensor.dtype = MagicMock()
+        components.generator.model.parameters.return_value = iter([param_tensor])
+        components.config.vae_spatial_downsample_factor = 8
+        components.config.num_frame_per_block = 3
+
+        # Mock state with a seed that would overflow without the modulo fix
+        state = MagicMock()
+        block_state = MagicMock()
+        block_state.base_seed = 2**63 - 1  # max long long
+        block_state.current_start_frame = 100
+        block_state.height = 512
+        block_state.width = 512
+        block.get_block_state = MagicMock(return_value=block_state)
+        block.set_block_state = MagicMock()
+
+        # Should not raise ValueError
+        with patch("torch.randn") as mock_randn:
+            mock_randn.return_value = MagicMock()
+            components_out, state_out = block(components, state)
+
+        # Verify the seed was clamped
+        assert block_state.latents is not None or True  # no crash is the test
+
+    def test_prepare_video_latents_large_seed_no_overflow(self):
+        """PrepareVideoLatentsBlock should not crash with a very large seed."""
+        from unittest.mock import MagicMock, patch
+
+        from scope.core.pipelines.wan2_1.blocks.prepare_video_latents import (
+            PrepareVideoLatentsBlock,
+        )
+
+        block = PrepareVideoLatentsBlock()
+
+        # Mock components
+        components = MagicMock()
+        components.config.device = "cpu"
+        components.config.dtype = MagicMock()
+        components.config.num_frame_per_block = 3
+        components.config.vae_temporal_downsample_factor = 4
+        latent_mock = MagicMock()
+        latent_mock.shape = (1, 3, 16, 64, 64)
+        components.vae.encode_to_latent.return_value = latent_mock
+
+        # Mock state with a seed that would overflow without the modulo fix
+        state = MagicMock()
+        block_state = MagicMock()
+        block_state.base_seed = 2**63 - 1
+        block_state.current_start_frame = 100
+        block_state.noise_scale = 0.7
+        block_state.video = MagicMock()
+        block.get_block_state = MagicMock(return_value=block_state)
+        block.set_block_state = MagicMock()
+
+        # Should not raise ValueError
+        with patch("torch.randn") as mock_randn:
+            noise_mock = MagicMock()
+            mock_randn.return_value = noise_mock
+            components_out, state_out = block(components, state)
+
+    def test_block_seed_modulo_produces_valid_range(self):
+        """The modulo operation should always produce a value in [0, 2^63)."""
+        max_long_long = 2**63
+        test_cases = [
+            (0, 0),
+            (42, 100),
+            (2**63 - 1, 0),
+            (2**63 - 1, 1),
+            (2**63 - 1, 2**63 - 1),
+            (10**18, 10**18),
+        ]
+        for base_seed, frame in test_cases:
+            block_seed = (base_seed + frame) % max_long_long
+            assert 0 <= block_seed < max_long_long, (
+                f"block_seed {block_seed} out of range for base_seed={base_seed}, frame={frame}"
+            )


### PR DESCRIPTION
## Summary

- Remove `is_load_param=True` from `base_seed` in all 5 pipeline schemas so the seed is editable while streaming. The frontend runtime param update path already handles this automatically.
- Fix overflow bug in `PrepareLatentsBlock` and `PrepareVideoLatentsBlock` where `base_seed + current_start_frame` could exceed `torch.Generator.manual_seed()` range. Resolved with modulo clamping.
- Add tests for schema metadata, runtime state propagation, and overflow safety.