### PR TITLE
Fix log panel not auto-scrolling to bottom

### DIFF
--- a/frontend/src/components/LogPanel.tsx
+++ b/frontend/src/components/LogPanel.tsx
@@ -21,17 +21,18 @@ const levelColor: Record<LogLevel, string> = {
 };
 
 export function LogPanel({ logs, isOpen, onClose, onClear }: LogPanelProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [filter, setFilter] = useState<LogFilter>("all");
   const [copied, setCopied] = useState(false);
 
-  // Auto-scroll to bottom when new logs arrive
+  // Auto-scroll to bottom when new logs arrive or panel opens
   useEffect(() => {
-    if (autoScroll && scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    if (isOpen && autoScroll && bottomRef.current) {
+      bottomRef.current.scrollIntoView({ block: "end" });
     }
-  }, [logs, autoScroll]);
+  }, [logs, filter, autoScroll, isOpen]);
 
   if (!isOpen) return null;
 
@@ -142,6 +143,7 @@ export function LogPanel({ logs, isOpen, onClose, onClear }: LogPanelProps) {
             </div>
           ))
         )}
+        <div ref={bottomRef} />
       </div>
     </div>
   );


### PR DESCRIPTION
Log panel now auto-scrolls to the latest log entry when opened and when new logs arrive.
Uses a sentinel element with scrollIntoView for reliable scrolling behavior.