### PR TITLE
Fix download UI blocking on empty model files

### DIFF
--- a/src/scope/server/models_config.py
+++ b/src/scope/server/models_config.py
@@ -203,13 +203,13 @@ def get_required_model_files(pipeline_id: str | None = None) -> list[Path]:
 
 def models_are_downloaded(pipeline_id: str) -> bool:
     """
-    Check if all required model files are downloaded and non-empty.
+    Check if all required model files are downloaded.
 
     Args:
         pipeline_id: The pipeline ID to check models for.
 
     Returns:
-        bool: True if all required models are present and non-empty, False otherwise
+        bool: True if all required models are present, False otherwise
     """
     required_files = get_required_model_files(pipeline_id)
 
@@ -218,13 +218,8 @@ def models_are_downloaded(pipeline_id: str) -> bool:
         if not file_path.exists():
             return False
 
-        # If it's a file, check it's non-empty
-        if file_path.is_file():
-            if file_path.stat().st_size == 0:
-                return False
-
         # If it's a directory, check it's non-empty
-        elif file_path.is_dir():
+        if file_path.is_dir():
             if not any(file_path.iterdir()):
                 return False
 


### PR DESCRIPTION
## Summary

- HuggingFace repos can contain legitimate 0-byte files (config stubs, etc.). The `models_are_downloaded` check treated these as missing, causing the download status to never report completion and trapping the user in the download dialog.
- Removed the file size check so that file existence alone is sufficient. The empty-directory check is preserved since that genuinely indicates a failed/incomplete download.

## Test plan

- [x] Select a pipeline whose HF model repo contains a 0-byte file
- [x] Trigger model download and confirm the download dialog completes and dismisses normally
- [x] Confirm pipelines with no 0-byte files still download and verify correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified model validation to check for file presence only, removing redundant file size verification during model checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->