### PR TITLE
Fix WebRTC VP8 decode errors and PLI keyframe requests

### DIFF
--- a/src/scope/server/cloud_track.py
+++ b/src/scope/server/cloud_track.py
@@ -122,12 +122,15 @@ class CloudTrack(MediaStreamTrack):
     async def _input_loop(self) -> None:
         """Background loop that receives frames from source and sends to cloud."""
         logger.info("Input loop started")
+        consecutive_errors = 0
+        max_consecutive_errors = 10
 
         try:
             while self._input_running and self._source_track is not None:
                 try:
                     # Get frame from browser
                     frame = await self._source_track.recv()
+                    consecutive_errors = 0
 
                     # Send through FrameProcessor (which relays to cloud)
                     if self.frame_processor:
@@ -137,8 +140,18 @@ class CloudTrack(MediaStreamTrack):
                     logger.info("Source track ended")
                     break
                 except Exception as e:
-                    logger.error(f"Error in input loop: {e}")
-                    break
+                    consecutive_errors += 1
+                    if consecutive_errors >= max_consecutive_errors:
+                        logger.error(
+                            f"Error in input loop, stopping after "
+                            f"{consecutive_errors} consecutive errors: {e}"
+                        )
+                        break
+                    logger.warning(
+                        f"Transient error in input loop "
+                        f"({consecutive_errors}/{max_consecutive_errors}): {e}"
+                    )
+                    await asyncio.sleep(0.01)
 
         except asyncio.CancelledError:
             pass

--- a/src/scope/server/cloud_webrtc_client.py
+++ b/src/scope/server/cloud_webrtc_client.py
@@ -308,15 +308,25 @@ class CloudWebRTCClient:
 
     async def _receive_frames(self, track: MediaStreamTrack):
         """Background task to receive frames from cloud."""
+        from aiortc.mediastreams import MediaStreamError
+
         logger.info("Starting frame receive loop")
+        consecutive_errors = 0
+        max_consecutive_errors = 10
 
         try:
             while True:
                 try:
                     frame = await track.recv()
+                    consecutive_errors = 0
                     self._stats["frames_received"] += 1
 
-                    if self._stats["frames_received"] % 100 == 0:
+                    if self._stats["frames_received"] == 1:
+                        logger.info(
+                            "First frame received from cloud "
+                            "(keyframe decoded successfully)"
+                        )
+                    elif self._stats["frames_received"] % 100 == 0:
                         logger.debug(
                             f"Received {self._stats['frames_received']} frames"
                         )
@@ -324,12 +334,22 @@ class CloudWebRTCClient:
                     # Pass to output handler
                     self.output_handler.handle_frame(frame)
 
-                except Exception as e:
-                    if "MediaStreamError" in str(type(e)):
-                        logger.info("Track ended")
-                        break
-                    logger.error(f"Error receiving frame: {e}")
+                except MediaStreamError:
+                    logger.info("Track ended")
                     break
+                except Exception as e:
+                    consecutive_errors += 1
+                    if consecutive_errors >= max_consecutive_errors:
+                        logger.error(
+                            f"Error receiving frame, stopping after "
+                            f"{consecutive_errors} consecutive errors: {e}"
+                        )
+                        break
+                    logger.warning(
+                        f"Transient error receiving frame "
+                        f"({consecutive_errors}/{max_consecutive_errors}): {e}"
+                    )
+                    await asyncio.sleep(0.01)
 
         except asyncio.CancelledError:
             logger.info("Frame receive loop cancelled")
@@ -340,22 +360,43 @@ class CloudWebRTCClient:
             )
 
     async def _request_keyframe(self):
-        """Request a keyframe via PLI after short delay for receiver setup.
+        """Request a keyframe via PLI once the receiver has remote streams.
 
         VP8/VP9 decoders need a keyframe (I-frame) to start decoding.
         After a new WebRTC connection, we may receive P-frames first,
         causing decode errors. Sending PLI (Picture Loss Indication)
         requests the remote end to send a keyframe.
         """
-        await asyncio.sleep(0.1)  # Allow receiver to initialize
-        for receiver in self.pc.getReceivers():
-            if receiver.track and receiver.track.kind == "video":
-                try:
-                    # Access internal PLI method from aiortc
-                    await receiver._send_rtcp_pli()
-                    logger.info("Sent PLI (keyframe request)")
-                except Exception as e:
-                    logger.debug(f"Could not send PLI: {e}")
+        # Poll until remote_streams is populated (RTP packets have arrived)
+        timeout = 5.0
+        poll_interval = 0.1
+        elapsed = 0.0
+        receiver = None
+        remote_streams = None
+
+        while elapsed < timeout:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            for r in self.pc.getReceivers():
+                if r.track and r.track.kind == "video":
+                    streams = r._RTCRtpReceiver__remote_streams
+                    if streams:
+                        receiver = r
+                        remote_streams = streams
+                        break
+            if remote_streams:
+                break
+
+        if not remote_streams or not receiver:
+            logger.debug("No remote streams after %.1fs, skipping PLI", timeout)
+            return
+
+        try:
+            media_ssrc = next(iter(remote_streams))
+            await receiver._send_rtcp_pli(media_ssrc)
+            logger.info(f"Sent PLI keyframe request (media_ssrc={media_ssrc})")
+        except Exception as e:
+            logger.debug(f"Could not send PLI: {e}")
 
     def send_frame(self, frame: VideoFrame | np.ndarray) -> bool:
         """Send a frame to cloud for processing.

--- a/src/scope/server/tracks.py
+++ b/src/scope/server/tracks.py
@@ -60,20 +60,36 @@ class VideoProcessingTrack(MediaStreamTrack):
 
     async def input_loop(self):
         """Background loop that continuously feeds frames to the processor"""
+        consecutive_errors = 0
+        max_consecutive_errors = 10
         while self.input_task_running:
             try:
                 input_frame = await self.track.recv()
+                consecutive_errors = 0
 
                 # Store raw VideoFrame for later processing (tracks input FPS internally)
                 self.frame_processor.put(input_frame)
 
             except asyncio.CancelledError:
                 break
-            except Exception as e:
-                # Stop the input loop on connection errors to avoid spam
-                logger.error(f"Error in input loop, stopping: {e}")
+            except MediaStreamError:
+                logger.info("Source track ended")
                 self.input_task_running = False
                 break
+            except Exception as e:
+                consecutive_errors += 1
+                if consecutive_errors >= max_consecutive_errors:
+                    logger.error(
+                        f"Error in input loop, stopping after "
+                        f"{consecutive_errors} consecutive errors: {e}"
+                    )
+                    self.input_task_running = False
+                    break
+                logger.warning(
+                    f"Transient error in input loop "
+                    f"({consecutive_errors}/{max_consecutive_errors}): {e}"
+                )
+                await asyncio.sleep(0.01)
 
     # Copied from https://github.com/livepeer/fastworld/blob/e649ef788cd33d78af6d8e1da915cd933761535e/backend/track.py#L267
     async def next_timestamp(self) -> tuple[int, fractions.Fraction]:


### PR DESCRIPTION
## Problem

Cloud relay WebRTC connections would permanently die from transient VP8 decode errors. When a decoder receives P-frames before a keyframe (common at connection start), the exception killed the frame receive loop with no recovery.

Additionally, aiortc 1.14.0 changed `_send_rtcp_pli()` to require a `media_ssrc` argument, causing PLI keyframe requests to fail with warnings on every cloud connection.

## Two fixes

### 1. VP8 decode error retry (`tracks.py`, `cloud_track.py`, `cloud_webrtc_client.py`)

All three frame input loops now tolerate transient errors instead of dying on the first one:

- Track 10 consecutive errors with a 10ms sleep between each
- Any successful frame resets the counter to 0
- Only bail after 10 consecutive failures (~400ms at 25fps)
- Covers the window between connection start and first keyframe arrival

### 2. PLI keyframe request fix (`cloud_webrtc_client.py`)

Requests a keyframe from the cloud encoder to speed up decoder startup:

- Polls every 100ms until aiortc's `remote_streams` dict is populated (up to 5s)
- Sends a single PLI with the correct `media_ssrc` (required by aiortc >= 1.14.0)
- Logs the SSRC on success for verification
- Logs first frame receipt to confirm the keyframe roundtrip

### How they work together

```
Connection established
  ├─ PLI task starts polling for remote_streams
  ├─ Frame receive loop starts
  │   ├─ P-frame arrives → decode error → retry (counter=1)
  │   ├─ P-frame arrives → decode error → retry (counter=2)
  │   ├─ PLI sent once remote_streams populated
  │   ├─ Keyframe arrives → decoded successfully → counter=0
  │   └─ Normal operation continues
  └─ "First frame received from cloud (keyframe decoded successfully)"
```

In practice, the cloud encoder sends a keyframe on its own at connection start, so the first frame usually arrives before the PLI is even sent. The PLI is a safety net, and the retry logic is a safety net for the safety net.

## Expected logs

```
INFO - Sent PLI keyframe request (media_ssrc=2642438216)
INFO - First frame received from cloud (keyframe decoded successfully)
INFO - [FRAME-PROCESSOR] First frame produced, playback ready (ttff=1312ms)
```

## Test plan

- [x] Verify server starts without errors (`uv run daydream-scope`)
- [x] Test cloud relay mode — no PLI warnings in logs
- [x] Verify "Sent PLI keyframe request" and "First frame received" appear in logs
- [x] VP8 decode warnings should be logged but not kill the session
- [x] Clean disconnects still work (MediaStreamError path)