### PR TITLE
fix: cast block_seed to int before manual_seed() call

### DIFF
--- a/src/scope/core/pipelines/wan2_1/blocks/prepare_latents.py
+++ b/src/scope/core/pipelines/wan2_1/blocks/prepare_latents.py
@@ -91,7 +91,7 @@ class PrepareLatentsBlock(ModularPipelineBlocks):
 
         # Create generator from seed for reproducible generation
         block_seed = base_seed + block_state.current_start_frame
-        rng = torch.Generator(device=generator_param.device).manual_seed(block_seed)
+        rng = torch.Generator(device=generator_param.device).manual_seed(int(block_seed))
 
         # Determine number of latent frames to generate
         num_latent_frames = components.config.num_frame_per_block

--- a/src/scope/core/pipelines/wan2_1/blocks/prepare_video_latents.py
+++ b/src/scope/core/pipelines/wan2_1/blocks/prepare_video_latents.py
@@ -89,7 +89,7 @@ class PrepareVideoLatentsBlock(ModularPipelineBlocks):
 
         # Create generator from seed for reproducible generation
         block_seed = base_seed + block_state.current_start_frame
-        rng = torch.Generator(device=components.config.device).manual_seed(block_seed)
+        rng = torch.Generator(device=components.config.device).manual_seed(int(block_seed))
 
         # Generate empty latents (noise)
         noise = torch.randn(


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: manual_seed expected a long, but got float` in both `PrepareVideoLatentsBlock` and `PrepareLatentsBlock`.

## Problem

`torch.Generator.manual_seed()` requires an integer argument, but `block_seed` (computed as `base_seed + current_start_frame`) can be a float when `base_seed` is deserialized from JSON (where all numbers may be represented as floats).

This was observed on fal.ai (March 5, 2026) in the `longlive` pipeline:
```
scope.server.pipeline_processor - ERROR - Error processing chunk for longlive: 
manual_seed expected a long, but got float
```

## Fix

Wrap `block_seed` with `int()` at the `manual_seed()` call site in both:
- `src/scope/core/pipelines/wan2_1/blocks/prepare_video_latents.py`
- `src/scope/core/pipelines/wan2_1/blocks/prepare_latents.py`

This is safe because seeds are inherently integer values — truncating a float seed to int preserves the intended behavior.

## Closes

Fixes #618

_Filed automatically by scope-monitor._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed seed initialization to ensure consistent and reproducible random number generation during latent preparation operations. This improves reliability of generated results across multiple processing runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->