### PR TITLE
fix: cast block_seed to int before manual_seed()

### DIFF
--- a/src/scope/core/pipelines/wan2_1/blocks/prepare_latents.py
+++ b/src/scope/core/pipelines/wan2_1/blocks/prepare_latents.py
@@ -90,7 +90,7 @@ class PrepareLatentsBlock(ModularPipelineBlocks):
             base_seed = 42
 
         # Create generator from seed for reproducible generation
-        block_seed = base_seed + block_state.current_start_frame
+        block_seed = int(base_seed + block_state.current_start_frame)
         rng = torch.Generator(device=generator_param.device).manual_seed(block_seed)
 
         # Determine number of latent frames to generate

--- a/src/scope/core/pipelines/wan2_1/blocks/prepare_video_latents.py
+++ b/src/scope/core/pipelines/wan2_1/blocks/prepare_video_latents.py
@@ -88,7 +88,7 @@ class PrepareVideoLatentsBlock(ModularPipelineBlocks):
             base_seed = 42
 
         # Create generator from seed for reproducible generation
-        block_seed = base_seed + block_state.current_start_frame
+        block_seed = int(base_seed + block_state.current_start_frame)
         rng = torch.Generator(device=components.config.device).manual_seed(block_seed)
 
         # Generate empty latents (noise)


### PR DESCRIPTION
## Summary

Cast `block_seed` to `int` before passing to `torch.Generator.manual_seed()` in both `PrepareVideoLatentsBlock` and `PrepareLatentsBlock`.

## Problem

`manual_seed()` requires a `long`/`int`, but `base_seed` can arrive as a `float` when deserialized from JSON, causing:
```
RuntimeError: manual_seed expected a long, but got float
```

## Fix

One-line change in each block: `int(base_seed + block_state.current_start_frame)`

Fixes #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed seed calculation in video latent generation to ensure proper type handling, improving reliability and consistency in random number generation for video processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->