### PR TITLE
fix: guard against None frame_processor in OSC broadcast

### DIFF
--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -652,7 +652,10 @@ class WebRTCManager:
                 continue
             if "paused" in parameters and session.video_track:
                 session.video_track.pause(parameters["paused"])
-            if session.video_track and hasattr(session.video_track, "frame_processor"):
+            if (
+                session.video_track
+                and getattr(session.video_track, "frame_processor", None) is not None
+            ):
                 session.video_track.frame_processor.update_parameters(parameters)
 
     async def stop(self):


### PR DESCRIPTION
## Problem

When a cloud WebRTC connection times out or fails, sessions remain in the `sessions` dict with `frame_processor` set to `None`. The existing `hasattr()` check on line 656 passes (the attribute exists as `None`), causing an `AttributeError` that crashes the asyncio UDP callback handler. This kills **all** subsequent OSC message processing until the server is restarted.

The user reports that OSC works fine in local mode but breaks permanently after connecting to remote inference, which aligns — the cloud WebRTC timeout leaves a zombie session with a null frame processor.

## Fix

Replace `hasattr(session.video_track, "frame_processor")` with `getattr(session.video_track, "frame_processor", None) is not None` to properly guard against the attribute being present but set to `None`.

## Root Cause

`webrtc.py:656` — `broadcast_parameter_update()` iterates all sessions and calls `frame_processor.update_parameters()` without checking if `frame_processor` is actually a live object vs `None`.

Fixes #623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing errors when updating video stream parameters in certain conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->