### PR TITLE
feat: refactor logs rendering to use virtual lists

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-virtual": "^3.13.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.544.0",
@@ -2640,6 +2641,33 @@
         "@tailwindcss/oxide": "4.1.13",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.13"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.21.tgz",
+      "integrity": "sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.21"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.21.tgz",
+      "integrity": "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/babel__core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-virtual": "^3.13.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",

--- a/frontend/src/components/LogPanel.tsx
+++ b/frontend/src/components/LogPanel.tsx
@@ -1,4 +1,11 @@
-import { useRef, useEffect, useState } from "react";
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+} from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Terminal, Copy, Trash2, X, Check } from "lucide-react";
 import { Button } from "./ui/button";
 import type { LogLine, LogLevel } from "../hooks/useLogStream";
@@ -20,41 +27,61 @@ const levelColor: Record<LogLevel, string> = {
   UNKNOWN: "text-neutral-400",
 };
 
+const LogRow = React.memo(function LogRow({ log }: { log: LogLine }) {
+  return (
+    <div
+      className={`${levelColor[log.level]} whitespace-pre-wrap leading-5${log.isCloud ? " border-l-2 border-blue-500/50 bg-blue-950/20 pl-2" : ""}`}
+    >
+      {log.isCloud && (
+        <span className="bg-blue-900/40 text-blue-300 text-[10px] px-1 rounded mr-1 inline-block">
+          CLOUD
+        </span>
+      )}
+      {log.text}
+    </div>
+  );
+});
+
 export function LogPanel({ logs, isOpen, onClose, onClear }: LogPanelProps) {
-  const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [autoScroll, setAutoScroll] = useState(true);
+  const autoScrollRef = useRef(true);
   const [filter, setFilter] = useState<LogFilter>("all");
   const [copied, setCopied] = useState(false);
 
-  // Auto-scroll to bottom when new logs arrive or panel opens
-  useEffect(() => {
-    if (isOpen && autoScroll && bottomRef.current) {
-      bottomRef.current.scrollIntoView({ block: "end" });
-    }
-  }, [logs, filter, autoScroll, isOpen]);
-
-  if (!isOpen) return null;
-
-  const filteredLogs = logs.filter(log => {
+  const filteredLogs = useMemo(() => {
     if (filter === "errors")
-      return log.level === "ERROR" || log.level === "WARNING";
-    if (filter === "cloud") return log.isCloud;
-    return true;
+      return logs.filter(l => l.level === "ERROR" || l.level === "WARNING");
+    if (filter === "cloud") return logs.filter(l => l.isCloud);
+    return logs;
+  }, [logs, filter]);
+
+  const virtualizer = useVirtualizer({
+    count: filteredLogs.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 20,
+    overscan: 20,
   });
 
-  const handleCopy = async () => {
+  useEffect(() => {
+    if (isOpen && autoScrollRef.current && filteredLogs.length > 0) {
+      virtualizer.scrollToIndex(filteredLogs.length - 1, { align: "end" });
+    }
+  }, [filteredLogs.length, isOpen, virtualizer]);
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+    autoScrollRef.current = isAtBottom;
+  }, []);
+
+  const handleCopy = useCallback(async () => {
     const text = filteredLogs.map(l => l.text).join("\n");
     await navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
-  };
+  }, [filteredLogs]);
 
-  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-    const el = e.currentTarget;
-    const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
-    setAutoScroll(isAtBottom);
-  };
+  if (!isOpen) return null;
 
   return (
     <div
@@ -68,7 +95,6 @@ export function LogPanel({ logs, isOpen, onClose, onClear }: LogPanelProps) {
 
         <div className="flex-1" />
 
-        {/* Filter buttons */}
         {(["all", "errors", "cloud"] as const).map(f => (
           <button
             key={f}
@@ -129,21 +155,34 @@ export function LogPanel({ logs, isOpen, onClose, onClear }: LogPanelProps) {
             No logs yet
           </div>
         ) : (
-          filteredLogs.map((log, i) => (
-            <div
-              key={i}
-              className={`${levelColor[log.level]} whitespace-pre-wrap leading-5${log.isCloud ? " border-l-2 border-blue-500/50 bg-blue-950/20 pl-2" : ""}`}
-            >
-              {log.isCloud && (
-                <span className="bg-blue-900/40 text-blue-300 text-[10px] px-1 rounded mr-1 inline-block">
-                  CLOUD
-                </span>
-              )}
-              {log.text}
-            </div>
-          ))
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map(virtualRow => {
+              const log = filteredLogs[virtualRow.index];
+              return (
+                <div
+                  key={log.id}
+                  ref={virtualizer.measureElement}
+                  data-index={virtualRow.index}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <LogRow log={log} />
+                </div>
+              );
+            })}
+          </div>
         )}
-        <div ref={bottomRef} />
       </div>
     </div>
   );

--- a/frontend/src/hooks/useLogStream.ts
+++ b/frontend/src/hooks/useLogStream.ts
@@ -7,10 +7,13 @@ const LOCAL_POLL_INTERVAL_MS = 2000;
 export type LogLevel = "ERROR" | "WARNING" | "INFO" | "DEBUG" | "UNKNOWN";
 
 export interface LogLine {
+  id: number;
   text: string;
   level: LogLevel;
   isCloud: boolean;
 }
+
+let nextLogId = 0;
 
 function parseLogLine(raw: string): LogLine {
   const isCloud = raw.includes("- scope.cloud -");
@@ -20,7 +23,7 @@ function parseLogLine(raw: string): LogLine {
   else if (raw.includes(" - INFO - ")) level = "INFO";
   else if (raw.includes(" - DEBUG - ")) level = "DEBUG";
 
-  return { text: raw, level, isCloud };
+  return { id: nextLogId++, text: raw, level, isCloud };
 }
 
 export function useLogStream() {


### PR DESCRIPTION
## Log Panel Improvements

With the way the current log panel is implemented there is scope for improvement in how logs are rendered given they are accumulated over time and increase the DOM nodes that are rendered. Virtual lists are a way to help with this and in this PR we are:
1. **Virtualized log rendering** — Replaced the naive `.map()` over up to 2,000 log lines with `@tanstack/react-virtual`
[tiny 2Kb package]. Only visible rows (plus an overscan buffer) are now in the DOM. Auto-scroll uses the virtualizer's native `scrollToIndex` instead of `scrollIntoView` on a sentinel div.

3. **Stable log line IDs** — Each `LogLine` now carries a monotonically increasing `id`, giving React stable keys that survive array trimming when the 2,000-line cap kicks in (previously used array index as key).

4. **Memoized filtering and row rendering** — `filteredLogs` is wrapped in `useMemo`; individual rows are extracted into a `React.memo`-wrapped `LogRow` component so unchanged lines skip re-rendering entirely.

5. **Eliminated scroll-triggered re-renders** — Converted `autoScroll` from `useState` to `useRef` and stabilized handlers with `useCallback`, so scrolling no longer causes the entire log panel to re-render.

<img width="1512" height="290" alt="image" src="https://github.com/user-attachments/assets/147a68d5-7e76-4c75-816f-35701cd60215" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual confirmation indicator that temporarily displays when copying logs to clipboard, providing feedback that the action was successful.

* **Refactor**
  * Optimized log panel rendering to improve performance when handling large volumes of log output.
  * Enhanced auto-scroll detection to better recognize when users manually scroll and adjusted scrolling behavior accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->