### PR TITLE
Add native Workflow export to daydream.live

### DIFF
--- a/frontend/src/components/ExportDialog.tsx
+++ b/frontend/src/components/ExportDialog.tsx
@@ -1,4 +1,4 @@
-import { Download, Share2 } from "lucide-react";
+import { Download, ExternalLink, LogIn, Share2 } from "lucide-react";
 import { Button } from "./ui/button";
 import {
   Dialog,
@@ -14,7 +14,10 @@ interface ExportDialogProps {
   onClose: () => void;
   onSaveGeneration: () => void;
   onSaveTimeline: () => void;
+  onExportToDaydream: () => void;
   isRecording?: boolean;
+  isAuthenticated?: boolean;
+  isExportingToDaydream?: boolean;
 }
 
 export function ExportDialog({
@@ -22,7 +25,10 @@ export function ExportDialog({
   onClose,
   onSaveGeneration,
   onSaveTimeline,
+  onExportToDaydream,
   isRecording = false,
+  isAuthenticated = false,
+  isExportingToDaydream = false,
 }: ExportDialogProps) {
   return (
     <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
@@ -67,6 +73,36 @@ export function ExportDialog({
               <span className="font-semibold">Export Workflow</span>
               <span className="text-xs text-muted-foreground">
                 Save pipeline settings, LoRAs, and timeline as a shareable file
+              </span>
+            </div>
+          </Button>
+
+          <Button
+            onClick={() => {
+              onExportToDaydream();
+              if (!isAuthenticated) {
+                onClose();
+              }
+            }}
+            variant="outline"
+            className="w-full justify-start gap-3 px-4 py-6"
+            disabled={isExportingToDaydream}
+          >
+            {isAuthenticated ? (
+              <ExternalLink className="h-4 w-4" />
+            ) : (
+              <LogIn className="h-4 w-4" />
+            )}
+            <div className="flex flex-col items-start">
+              <span className="font-semibold">
+                {isAuthenticated
+                  ? "Export to daydream.live"
+                  : "Log in to export to daydream.live"}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {isAuthenticated
+                  ? "Publish your workflow on daydream.live"
+                  : "Sign in to your Daydream account to publish"}
               </span>
             </div>
           </Button>

--- a/frontend/src/components/PromptInputWithTimeline.tsx
+++ b/frontend/src/components/PromptInputWithTimeline.tsx
@@ -48,6 +48,9 @@ interface PromptInputWithTimelineProps {
   onRecordingToggle?: () => void;
   onWorkflowExport?: () => void;
   onWorkflowImport?: () => void;
+  onExportToDaydream?: () => void;
+  isAuthenticated?: boolean;
+  isExportingToDaydream?: boolean;
 }
 
 export function PromptInputWithTimeline({
@@ -86,6 +89,9 @@ export function PromptInputWithTimeline({
   onRecordingToggle,
   onWorkflowExport,
   onWorkflowImport,
+  onExportToDaydream,
+  isAuthenticated = false,
+  isExportingToDaydream = false,
 }: PromptInputWithTimelineProps) {
   const [isLive, setIsLive] = useState(false);
   const [selectedPromptId, setSelectedPromptId] = useState<string | null>(null);
@@ -558,6 +564,9 @@ export function PromptInputWithTimeline({
         onRecordingToggle={onRecordingToggle}
         onWorkflowExport={onWorkflowExport}
         onWorkflowImport={onWorkflowImport}
+        onExportToDaydream={onExportToDaydream}
+        isAuthenticated={isAuthenticated}
+        isExportingToDaydream={isExportingToDaydream}
       />
     </div>
   );

--- a/frontend/src/components/PromptTimeline.tsx
+++ b/frontend/src/components/PromptTimeline.tsx
@@ -151,6 +151,9 @@ interface PromptTimelineProps {
   onRecordingToggle?: () => void;
   onWorkflowExport?: () => void;
   onWorkflowImport?: () => void;
+  onExportToDaydream?: () => void;
+  isAuthenticated?: boolean;
+  isExportingToDaydream?: boolean;
 }
 
 export function PromptTimeline({
@@ -182,6 +185,9 @@ export function PromptTimeline({
   onRecordingToggle,
   onWorkflowExport,
   onWorkflowImport,
+  onExportToDaydream,
+  isAuthenticated = false,
+  isExportingToDaydream = false,
 }: PromptTimelineProps) {
   const timelineRef = useRef<HTMLDivElement>(null);
   const [timelineWidth, setTimelineWidth] = useState(800);
@@ -599,7 +605,12 @@ export function PromptTimeline({
                 setShowExportDialog(false);
                 onWorkflowExport?.();
               }}
+              onExportToDaydream={() => {
+                onExportToDaydream?.();
+              }}
               isRecording={isRecording}
+              isAuthenticated={isAuthenticated}
+              isExportingToDaydream={isExportingToDaydream}
             />
             <Button
               onClick={() => onWorkflowImport?.()}

--- a/frontend/src/lib/daydreamExport.ts
+++ b/frontend/src/lib/daydreamExport.ts
@@ -1,0 +1,40 @@
+const DAYDREAM_API_BASE =
+  (import.meta.env.VITE_DAYDREAM_API_BASE as string | undefined) ||
+  "https://api.daydream.live";
+
+interface ImportSessionResponse {
+  token: string;
+  createUrl: string;
+}
+
+export async function createDaydreamImportSession(
+  apiKey: string,
+  workflowData: unknown,
+  suggestedName?: string
+): Promise<ImportSessionResponse> {
+  const body: Record<string, unknown> = { workflowData };
+  if (suggestedName) {
+    body.suggestedName = suggestedName;
+  }
+
+  const response = await fetch(
+    `${DAYDREAM_API_BASE}/v1/workflows/import-sessions`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Failed to create import session: ${response.status} ${text}`
+    );
+  }
+
+  return response.json() as Promise<ImportSessionResponse>;
+}

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -8,7 +8,10 @@ import { PromptInputWithTimeline } from "../components/PromptInputWithTimeline";
 import { DownloadDialog } from "../components/DownloadDialog";
 import { WorkflowExportDialog } from "../components/WorkflowExportDialog";
 import { WorkflowImportDialog } from "../components/WorkflowImportDialog";
-import type { WorkflowPromptState } from "../lib/workflowSettings";
+import {
+  buildScopeWorkflow,
+  type WorkflowPromptState,
+} from "../lib/workflowSettings";
 import type { TimelinePrompt } from "../components/PromptTimeline";
 import { StatusBar } from "../components/StatusBar";
 import { LogPanel } from "../components/LogPanel";
@@ -37,11 +40,21 @@ import type {
   LoraMergeStrategy,
   DownloadProgress,
 } from "../types";
-import type { PromptItem, PromptTransition } from "../lib/api";
+import type { PromptItem, PromptTransition, PluginInfo } from "../lib/api";
 import { getInputSourceResolution, fetchDaydreamWorkflow } from "../lib/api";
+import { useLoRAsContext } from "../contexts/LoRAsContext";
+import { usePluginsContext } from "../contexts/PluginsContext";
+import { useServerInfoContext } from "../contexts/ServerInfoContext";
 import type { ScopeWorkflow } from "../lib/workflowApi";
 import { sendLoRAScaleUpdates } from "../utils/loraHelpers";
 import { toast } from "sonner";
+import {
+  isAuthenticated as checkIsAuthenticated,
+  getDaydreamAPIKey,
+  redirectToSignIn,
+} from "../lib/auth";
+import { createDaydreamImportSession } from "../lib/daydreamExport";
+import { openExternalUrl } from "../lib/openExternal";
 
 interface OscCommand {
   key: string;
@@ -259,6 +272,92 @@ export function StreamPage() {
   const [showWorkflowImport, setShowWorkflowImport] = useState(false);
   const [preloadedWorkflow, setPreloadedWorkflow] =
     useState<ScopeWorkflow | null>(null);
+
+  // Daydream export state
+  const [isExportingToDaydream, setIsExportingToDaydream] = useState(false);
+  const [isDaydreamAuthenticated, setIsDaydreamAuthenticated] = useState(
+    checkIsAuthenticated()
+  );
+  const { loraFiles } = useLoRAsContext();
+  const { plugins } = usePluginsContext();
+  const { version: scopeVersion } = useServerInfoContext();
+
+  useEffect(() => {
+    const handleAuthChange = () => {
+      setIsDaydreamAuthenticated(checkIsAuthenticated());
+    };
+    window.addEventListener("daydream-auth-change", handleAuthChange);
+    return () => {
+      window.removeEventListener("daydream-auth-change", handleAuthChange);
+    };
+  }, []);
+
+  const handleExportToDaydream = useCallback(async () => {
+    if (!isDaydreamAuthenticated) {
+      redirectToSignIn();
+      return;
+    }
+
+    const apiKey = getDaydreamAPIKey();
+    if (!apiKey) {
+      toast.error("Not authenticated with Daydream");
+      return;
+    }
+
+    setIsExportingToDaydream(true);
+    try {
+      const pluginInfoMap = new Map<string, PluginInfo>(
+        plugins.map(p => [p.name, p])
+      );
+
+      const workflow = buildScopeWorkflow({
+        name: "Untitled Workflow",
+        settings,
+        timelinePrompts,
+        promptState: {
+          promptItems,
+          interpolationMethod,
+          transitionSteps,
+          temporalInterpolationMethod,
+        },
+        pipelineInfoMap: pipelines ?? {},
+        loraFiles,
+        pluginInfoMap,
+        scopeVersion: scopeVersion ?? "unknown",
+      });
+
+      const result = await createDaydreamImportSession(
+        apiKey,
+        workflow,
+        workflow.metadata.name
+      );
+
+      openExternalUrl(result.createUrl);
+      toast.success("Opening daydream.live...", {
+        description:
+          "Your workflow has been sent to daydream.live for publishing.",
+      });
+    } catch (err) {
+      console.error("Export to daydream.live failed:", err);
+      toast.error("Export failed", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsExportingToDaydream(false);
+    }
+  }, [
+    isDaydreamAuthenticated,
+    plugins,
+    settings,
+    timelinePrompts,
+    promptItems,
+    interpolationMethod,
+    transitionSteps,
+    temporalInterpolationMethod,
+    pipelines,
+    loraFiles,
+    scopeVersion,
+  ]);
 
   // Handle install-workflow deep links from Electron
   useEffect(() => {
@@ -2003,6 +2102,9 @@ export function StreamPage() {
               onRecordingToggle={() => setIsRecording(prev => !prev)}
               onWorkflowExport={() => setShowWorkflowExport(true)}
               onWorkflowImport={() => setShowWorkflowImport(true)}
+              onExportToDaydream={handleExportToDaydream}
+              isAuthenticated={isDaydreamAuthenticated}
+              isExportingToDaydream={isExportingToDaydream}
             />
           </div>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Daydream export functionality enabling users to publish workflows to daydream.live
  * Export dialog now provides authentication-aware options, displaying sign-in prompts for unauthenticated users
  * Real-time loading indicators during export operations
  * Seamless workflow publishing with automatic redirect to the Daydream platform upon successful export
  * Conditional UI guidance based on authentication status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->