### PR TITLE
Close WebRTC session when cloud WebSocket disconnects

### DIFF
--- a/src/scope/cloud/fal_app.py
+++ b/src/scope/cloud/fal_app.py
@@ -1151,6 +1151,33 @@ class ScopeApp(fal.App, keep_alive=300):
                         "session_end_time_ms": int(end_time * 1000),
                     },
                 )
+            # Close the WebRTC session on the local Scope backend.
+            # The WebRTC peer connection (UDP) is independent of this WebSocket,
+            # so it must be explicitly torn down to stop video streaming.
+            if session_id:
+                import httpx
+
+                try:
+                    async with httpx.AsyncClient() as client:
+                        resp = await client.delete(
+                            f"{SCOPE_LOCAL_URL}/api/v1/webrtc/offer/{session_id}",
+                            timeout=10.0,
+                        )
+                        if resp.status_code == 204:
+                            print(
+                                f"[{log_prefix()}] Closed WebRTC session {session_id}"
+                            )
+                        else:
+                            print(
+                                f"[{log_prefix()}] Warning: Failed to close WebRTC "
+                                f"session {session_id}: {resp.status_code}"
+                            )
+                except Exception as e:
+                    print(
+                        f"[{log_prefix()}] Warning: Failed to close WebRTC "
+                        f"session {session_id}: {e}"
+                    )
+
             # Clean up session data to prevent data leakage between users.
             # Block the next connection's "ready" message until cleanup finishes.
             event = _get_cleanup_event()

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -881,6 +881,26 @@ async def add_ice_candidate(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+@app.delete(
+    "/api/v1/webrtc/offer/{session_id}", status_code=204, response_class=Response
+)
+async def close_webrtc_session(
+    session_id: str,
+    webrtc_manager: "WebRTCManager" = Depends(get_webrtc_manager),
+):
+    """Close and remove a WebRTC session.
+
+    Used by the cloud proxy (fal_app) to tear down the WebRTC peer connection
+    when the signaling WebSocket closes (e.g. MAX_DURATION_EXCEEDED).
+    """
+    try:
+        await webrtc_manager.remove_session(session_id)
+        return Response(status_code=204)
+    except Exception as e:
+        logger.error(f"Error closing WebRTC session {session_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
 @app.get("/api/v1/recordings/{session_id}")
 @cloud_proxy(recording_download_cloud_path, timeout=120.0)
 async def download_recording(


### PR DESCRIPTION
## Problem

When the fal WebSocket closes (e.g. `MAX_DURATION_EXCEEDED` after 60 minutes), the video stream keeps playing indefinitely instead of stopping.

### Why this happens

There are 3 actors on the fal machine:

1. **fal_app.py** — WebSocket proxy, owns the 60-minute timer
2. **Scope backend** — runs the pipeline, owns the WebRTC peer connection
3. **Client** — browser (direct mode) or local backend (relay mode)

The WebRTC peer connection uses **UDP** and is completely independent of the WebSocket (TCP). When fal_app.py closes the WebSocket, the scope backend has no idea — nobody tells it to stop. The pipeline keeps running and frames keep flowing over UDP.

### Current (broken) sequence

```
           Client                    fal_app.py                Scope backend (on fal)
           (browser or               (WebSocket proxy)         (runs pipeline, owns
            local backend)                                      WebRTC peer connection)
               │                          │                          │
               │◄─── WebRTC (UDP) ────────┼──────────────────────────►│
               │     video frames flowing both directions             │
               │                          │                          │
               │◄──── WebSocket ─────────►│                          │
               │     signaling channel    │                          │
               │                          │                          │
          ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │ ─ ─  60 min timer ─ ─ ─│─ ─ ─
               │                          │                          │
               │    {"type":"error",      │                          │
               │◄────"MAX_DURATION_       │                          │
               │      EXCEEDED"}          │                          │
               │                          │                          │
               │     WebSocket CLOSED     │                          │
               │◄─────────────────────────│                          │
               │                          │                          │
               │  (client detects close)  │   finally block:         │
               │  sets _connected=False   │   - cancel log forwarder │
               │  publishes kafka event   │   - publish kafka event  │
               │                          │   - cleanup files/plugins│
               │  ┌─────────────────┐     │                          │
               │  │ BUT: does NOT   │     │  ┌─────────────────────┐ │
               │  │ close WebRTC    │     │  │ KNOWS NOTHING about │ │
               │  │ connection      │     │  │ WebSocket closing.  │ │
               │  └─────────────────┘     │  │ Pipeline keeps      │ │
               │                          │  │ running, frames     │ │
               │◄─── WebRTC (UDP) ────────┼──┤ keep processing.    │ │
               │     STILL FLOWING        │  └─────────────────────┘ │
               │                          │                          │
               ▼                          ▼                          ▼
         Video continues              Handler exits           Happily running
         indefinitely              (awaits next conn)         with no idea
```

## Fix

### Fixed sequence

```
           Client                    fal_app.py                Scope backend (on fal)
               │                          │                          │
          ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │ ─ ─  60 min timer ─ ─ ─│─ ─ ─
               │                          │                          │
               │◄── error: MAX_DURATION ──│                          │
               │◄── WebSocket CLOSED ─────│                          │
               │                          │                          │
               │                          │  DELETE /webrtc/offer/   │
               │                          │───── {session_id} ──────►│
               │                          │                          │
               │                          │                    closes RTCPeerConnection
               │                          │                    stops pipeline
               │                          │                          │
               │   WebRTC track ends      │                          │
               │◄─────────────────────────┼──────────────────────────│
               │   (MediaStreamError)     │                          │
               │                          │                          │
         Stream stops cleanly         Cleanup done             Session removed
```

### Changes

1. **`DELETE /api/v1/webrtc/offer/{session_id}`** — new endpoint on the scope backend that closes and removes a WebRTC session via `webrtc_manager.remove_session()`

2. **fal_app.py `finally` block** — calls the DELETE endpoint with the session ID before cleaning up files/plugins, so the WebRTC peer connection is torn down when the WebSocket closes for any reason (MAX_DURATION_EXCEEDED, client disconnect, errors)

## Test plan

- [ ] Stream for 60+ minutes (or temporarily lower `MAX_CONNECTION_DURATION_SECONDS`) and verify the stream stops when the timer fires
- [ ] Verify logs show `Closed WebRTC session <id>` in fal output
- [ ] Verify normal disconnect (user closes browser) still cleans up properly
- [ ] Verify reconnection works after session cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of WebRTC sessions when connections disconnect
  * Added new HTTP API endpoint for closing WebRTC sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->