### PR TITLE
feat: audio-only pipeline support, decouple FrameProcessor from VideoProcessingTrack

### DIFF
--- a/frontend/src/components/VideoOutput.tsx
+++ b/frontend/src/components/VideoOutput.tsx
@@ -54,6 +54,7 @@ export function VideoOutput({
   // User can click the speaker icon to unmute once the stream is playing.
   const [isMuted, setIsMuted] = useState(true);
   const [hasAudioTrack, setHasAudioTrack] = useState(false);
+  const [hasVideoTrack, setHasVideoTrack] = useState(false);
 
   // Use external ref if provided, otherwise use internal
   const containerRef = videoContainerRef || internalContainerRef;
@@ -62,14 +63,14 @@ export function VideoOutput({
     if (videoRef.current && remoteStream) {
       videoRef.current.srcObject = remoteStream;
 
-      // Check if the stream contains an audio track
-      const audioTracks = remoteStream.getAudioTracks();
-      setHasAudioTrack(audioTracks.length > 0);
+      // Check if the stream contains audio/video tracks
+      setHasAudioTrack(remoteStream.getAudioTracks().length > 0);
+      setHasVideoTrack(remoteStream.getVideoTracks().length > 0);
 
       // Listen for tracks being added later (audio may arrive after video)
       const handleTrackAdded = () => {
-        const tracks = remoteStream.getAudioTracks();
-        setHasAudioTrack(tracks.length > 0);
+        setHasAudioTrack(remoteStream.getAudioTracks().length > 0);
+        setHasVideoTrack(remoteStream.getVideoTracks().length > 0);
       };
       remoteStream.addEventListener("addtrack", handleTrackAdded);
 
@@ -199,17 +200,28 @@ export function VideoOutput({
             className="relative w-full h-full cursor-pointer flex items-center justify-center"
             onClick={handleVideoClick}
           >
+            {/* Always render the video element (browsers won't play display:none media).
+                For audio-only streams it acts as an invisible audio sink. */}
             <video
               ref={videoRef}
               className={
-                videoScaleMode === "fit"
-                  ? "w-full h-full object-contain"
-                  : "max-w-full max-h-full object-contain"
+                hasVideoTrack
+                  ? videoScaleMode === "fit"
+                    ? "w-full h-full object-contain"
+                    : "max-w-full max-h-full object-contain"
+                  : "absolute w-0 h-0 overflow-hidden"
               }
               autoPlay
               muted={isMuted}
               playsInline
             />
+            {/* Audio-only visual indicator */}
+            {!hasVideoTrack && (
+              <div className="flex flex-col items-center gap-3 text-muted-foreground">
+                <Volume2 className="w-12 h-12" />
+                <p className="text-lg">Audio Only</p>
+              </div>
+            )}
             {/* Audio mute/unmute toggle - only shown when stream has audio */}
             {hasAudioTrack && (
               <button

--- a/src/scope/core/pipelines/base_schema.py
+++ b/src/scope/core/pipelines/base_schema.py
@@ -229,6 +229,12 @@ class BasePipelineConfig(BaseModel):
     supports_vace: ClassVar[bool] = False
 
     # UI capability metadata - tells frontend what controls to show
+    # Whether this pipeline produces video output. Audio-only pipelines set this
+    # to False so the server can skip creating a video track.
+    produces_video: ClassVar[bool] = True
+    # Whether this pipeline expects audio input from the browser (microphone).
+    requires_audio_input: ClassVar[bool] = False
+
     supports_cache_management: ClassVar[bool] = False
     supports_kv_cache_bias: ClassVar[bool] = False
     supports_quantization: ClassVar[bool] = False
@@ -380,6 +386,8 @@ class BasePipelineConfig(BaseModel):
             cls.recommended_quantization_vram_threshold
         )
         metadata["modified"] = cls.modified
+        metadata["produces_video"] = cls.produces_video
+        metadata["requires_audio_input"] = cls.requires_audio_input
         # Convert UsageType enum values to strings for JSON serialization
         metadata["usage"] = [usage.value for usage in cls.usage] if cls.usage else []
         metadata["config_schema"] = cls.model_json_schema()

--- a/src/scope/core/pipelines/registry.py
+++ b/src/scope/core/pipelines/registry.py
@@ -159,6 +159,7 @@ def _register_pipelines():
         ),
         ("memflow", ".memflow.pipeline", "MemFlowPipeline"),
         ("passthrough", ".passthrough.pipeline", "PassthroughPipeline"),
+        ("test_tone", ".test_tone.pipeline", "TestTonePipeline"),
         (
             "video_depth_anything",
             ".video_depth_anything.pipeline",

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -457,9 +457,29 @@ class PipelineProcessor:
             output_dict = self.pipeline(**call_params)
             processing_time = time.time() - processing_start
 
+            # Pass audio to callback regardless of whether video exists.
+            # This ensures audio-only pipelines can deliver audio.
+            audio_output = output_dict.get("audio")
+            audio_sample_rate = output_dict.get("audio_sample_rate")
+            if (
+                audio_output is not None
+                and audio_sample_rate is not None
+                and self.audio_callback
+            ):
+                try:
+                    audio_cpu = audio_output.detach().cpu()
+                    self.audio_callback(audio_cpu, audio_sample_rate)
+                except Exception as e:
+                    logger.error(f"Error in audio callback: {e}")
+
             # Extract video from the returned dictionary
             output = output_dict.get("video")
             if output is None:
+                # No video produced. If the pipeline also has no input
+                # requirements (audio-only), sleep to prevent CPU spinning.
+                # 20ms matches WebRTC audio frame cadence.
+                if requirements is None:
+                    self.shutdown_event.wait(0.02)
                 return
 
             # Forward extra params to downstream pipeline (dual-output pattern)
@@ -533,20 +553,6 @@ class PipelineProcessor:
                         f"Output queue full for {self.pipeline_id}, dropping processed frame"
                     )
                     continue
-
-            # Pass audio to callback if available
-            audio_output = output_dict.get("audio")
-            audio_sample_rate = output_dict.get("audio_sample_rate")
-            if (
-                audio_output is not None
-                and audio_sample_rate is not None
-                and self.audio_callback
-            ):
-                try:
-                    audio_cpu = audio_output.detach().cpu()
-                    self.audio_callback(audio_cpu, audio_sample_rate)
-                except Exception as e:
-                    logger.error(f"Error in audio callback: {e}")
 
             # Latch native frame rate for stable playback speed.
             # Check output dict first, then pipeline config as fallback.

--- a/src/scope/server/tracks.py
+++ b/src/scope/server/tracks.py
@@ -35,6 +35,7 @@ class VideoProcessingTrack(MediaStreamTrack):
         user_id: str | None = None,
         connection_id: str | None = None,
         connection_info: dict | None = None,
+        frame_processor: "FrameProcessor | None" = None,
     ):
         super().__init__()
         self.pipeline_manager = pipeline_manager
@@ -49,7 +50,7 @@ class VideoProcessingTrack(MediaStreamTrack):
         self.fps = fps
         self.frame_ptime = 1.0 / fps
 
-        self.frame_processor = None
+        self.frame_processor = frame_processor
         self.input_task = None
         self.input_task_running = False
         self._paused = False
@@ -120,17 +121,12 @@ class VideoProcessingTrack(MediaStreamTrack):
         return self._fallback_pts, VIDEO_TIME_BASE
 
     def initialize_output_processing(self):
+        """No-op guard; FrameProcessor is injected via constructor."""
         if not self.frame_processor:
-            self.frame_processor = FrameProcessor(
-                pipeline_manager=self.pipeline_manager,
-                initial_parameters=self.initial_parameters,
-                notification_callback=self.notification_callback,
-                session_id=self.session_id,
-                user_id=self.user_id,
-                connection_id=self.connection_id,
-                connection_info=self.connection_info,
+            raise RuntimeError(
+                "VideoProcessingTrack requires a FrameProcessor. "
+                "Pass one via the constructor."
             )
-            self.frame_processor.start()
 
     def initialize_input_processing(self, track: MediaStreamTrack):
         self.track = track
@@ -205,8 +201,8 @@ class VideoProcessingTrack(MediaStreamTrack):
             except asyncio.CancelledError:
                 pass
 
-        if self.frame_processor is not None:
-            self.frame_processor.stop()
+        # Note: frame_processor.stop() is handled by Session.close(),
+        # not here, because the FrameProcessor is shared with AudioProcessingTrack.
 
         super().stop()
 

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -19,8 +19,11 @@ from aiortc.codecs import h264, vpx
 from aiortc.contrib.media import MediaRelay
 from aiortc.sdp import candidate_from_sdp
 
+from scope.core.pipelines.registry import PipelineRegistry
+
 from .cloud_track import CloudTrack
 from .credentials import get_turn_credentials
+from .frame_processor import FrameProcessor
 from .kafka_publisher import publish_event
 from .media_clock import MediaClock
 from .pipeline_manager import PipelineManager
@@ -56,6 +59,7 @@ class Session:
         pc: RTCPeerConnection,
         video_track: MediaStreamTrack | None = None,
         audio_track: "AudioProcessingTrack | None" = None,
+        frame_processor: "FrameProcessor | None" = None,
         media_clock: "MediaClock | None" = None,
         data_channel: RTCDataChannel | None = None,
         relay: MediaRelay | None = None,
@@ -68,6 +72,7 @@ class Session:
         self.pc = pc
         self.video_track = video_track
         self.audio_track = audio_track
+        self.frame_processor = frame_processor
         self.media_clock = media_clock
         self.data_channel = data_channel
         self.relay = relay
@@ -79,9 +84,13 @@ class Session:
     async def close(self):
         """Close this session and cleanup resources."""
         try:
-            # Stop video track first to properly cleanup FrameProcessor
+            # Stop video track first
             if self.video_track is not None:
                 await self.video_track.stop()
+
+            # Stop frame processor (owned by session, shared between tracks)
+            if self.frame_processor is not None:
+                self.frame_processor.stop()
 
             if self.pc is not None and self.pc.connectionState not in [
                 "closed",
@@ -185,6 +194,24 @@ def _publish_connection_error(
     )
 
 
+def _pipelines_produce_video(pipeline_ids: list[str]) -> bool:
+    """Check whether the pipeline chain produces video output.
+
+    Returns True (the default) unless the *last* pipeline in the chain
+    explicitly declares ``produces_video = False`` in its config.
+    """
+
+    if not pipeline_ids:
+        return True
+
+    # The last pipeline in the chain determines the final output modality
+    last_id = pipeline_ids[-1]
+    config_cls = PipelineRegistry.get_config_class(last_id)
+    if config_cls is None:
+        return True
+    return getattr(config_cls, "produces_video", True)
+
+
 class WebRTCManager:
     """
     Manages multiple WebRTC peer connections using sessions.
@@ -233,81 +260,99 @@ class WebRTCManager:
 
             # Create shared media clock for A/V synchronization
             media_clock = MediaClock()
+            session.media_clock = media_clock
 
-            video_track = VideoProcessingTrack(
-                pipeline_manager,
+            # Determine whether the pipeline produces video.
+            # If all pipelines in the chain are audio-only, skip video track creation.
+            pipeline_ids = initial_parameters.get("pipeline_ids", [])
+            produces_video = _pipelines_produce_video(pipeline_ids)
+
+            # Create FrameProcessor (owned by session, shared between tracks)
+            frame_processor = FrameProcessor(
+                pipeline_manager=pipeline_manager,
                 initial_parameters=initial_parameters,
                 notification_callback=notification_sender.call,
-                media_clock=media_clock,
                 session_id=session.id,
                 user_id=request.user_id,
                 connection_id=request.connection_id,
                 connection_info=request.connection_info,
             )
-            session.video_track = video_track
-            session.media_clock = media_clock
+            frame_processor.start()
+            session.frame_processor = frame_processor
 
-            # Eagerly initialize the FrameProcessor so the AudioProcessingTrack
-            # can share it. VideoProcessingTrack.recv() normally does this lazily,
-            # but we need the reference now to wire audio.
-            video_track.initialize_output_processing()
+            video_track = None
+            relay = None
+
+            if produces_video:
+                video_track = VideoProcessingTrack(
+                    pipeline_manager,
+                    initial_parameters=initial_parameters,
+                    notification_callback=notification_sender.call,
+                    media_clock=media_clock,
+                    session_id=session.id,
+                    user_id=request.user_id,
+                    connection_id=request.connection_id,
+                    connection_info=request.connection_info,
+                    frame_processor=frame_processor,
+                )
+                session.video_track = video_track
+
+                # Create a MediaRelay to allow multiple consumers (WebRTC and recording)
+                relay = MediaRelay()
+                relayed_track = relay.subscribe(video_track)
+
+                # Only create RecordingManager if recording is enabled for this session
+                # WebRTC initial params take precedence; if absent, fall back to env var
+                from .recording import RECORDING_ENABLED
+
+                recording_param = initial_parameters.get("recording")
+                recording_enabled = (
+                    recording_param
+                    if recording_param is not None
+                    else RECORDING_ENABLED
+                )
+                if recording_enabled:
+                    recording_manager = RecordingManager(video_track=video_track)
+                    session.recording_manager = recording_manager
+                    recording_manager.set_relay(relay)
+                else:
+                    session.recording_manager = None
+
+                # Add the relayed video track to WebRTC connection
+                pc.addTrack(relayed_track)
+
+                # Store relay for cleanup
+                session.relay = relay
+
+                # Start recording when ready (only if recording is enabled)
+                if recording_enabled and session.recording_manager:
+                    recording_manager = session.recording_manager
+
+                    async def start_recording_when_ready():
+                        """Start recording when frames start flowing."""
+                        try:
+                            await asyncio.sleep(0.1)
+                            await recording_manager.start_recording()
+                        except Exception as e:
+                            logger.debug(f"Could not start recording yet: {e}")
+
+                    asyncio.create_task(start_recording_when_ready())
+            else:
+                logger.info(
+                    f"Audio-only pipeline(s) {pipeline_ids}, skipping video track"
+                )
 
             audio_track = AudioProcessingTrack(
-                frame_processor=video_track.frame_processor,
+                frame_processor=frame_processor,
             )
             session.audio_track = audio_track
-
-            # Create a MediaRelay to allow multiple consumers (WebRTC and recording)
-            relay = MediaRelay()
-            relayed_track = relay.subscribe(video_track)
-
-            # Only create RecordingManager if recording is enabled for this session
-            # WebRTC initial params take precedence; if absent, fall back to env var
-            from .recording import RECORDING_ENABLED
-
-            recording_param = initial_parameters.get("recording")
-            recording_enabled = (
-                recording_param if recording_param is not None else RECORDING_ENABLED
-            )
-            if recording_enabled:
-                # Create RecordingManager and store it in the session
-                # Pass the original video_track - RecordingManager will subscribe to relay itself
-                recording_manager = RecordingManager(video_track=video_track)
-                session.recording_manager = recording_manager
-
-                # Set the relay on the recording manager so it can create a recording track
-                recording_manager.set_relay(relay)
-            else:
-                session.recording_manager = None
-
-            # Add the relayed video track to WebRTC connection
-            pc.addTrack(relayed_track)
-
-            # Store relay for cleanup
-            session.relay = relay
-
-            # Start recording when ready (only if recording is enabled)
-            if recording_enabled and session.recording_manager:
-                recording_manager = session.recording_manager
-
-                async def start_recording_when_ready():
-                    """Start recording when frames start flowing."""
-                    try:
-                        # Wait a bit for the connection to establish and frames to start flowing
-                        await asyncio.sleep(0.1)
-                        # Try to start recording
-                        await recording_manager.start_recording()
-                    except Exception as e:
-                        logger.debug(f"Could not start recording yet: {e}")
-
-                asyncio.create_task(start_recording_when_ready())
 
             logger.info(f"Created new session: {session}")
 
             @pc.on("track")
             def on_track(track: MediaStreamTrack):
                 logger.info(f"Track received: {track.kind} for session {session.id}")
-                if track.kind == "video":
+                if track.kind == "video" and video_track is not None:
                     video_track.initialize_input_processing(track)
 
             @pc.on("connectionstatechange")
@@ -371,10 +416,8 @@ class WebRTCManager:
                             session.video_track.pause(data["paused"])
 
                         # Send parameters to the frame processor
-                        if session.video_track and hasattr(
-                            session.video_track, "frame_processor"
-                        ):
-                            session.video_track.frame_processor.update_parameters(data)
+                        if session.frame_processor:
+                            session.frame_processor.update_parameters(data)
                         else:
                             logger.warning(
                                 "No frame processor available for parameter update"


### PR DESCRIPTION
## Summary

- **Decouple FrameProcessor from VideoProcessingTrack**: Session now owns the FrameProcessor lifecycle and injects it into both VideoProcessingTrack and AudioProcessingTrack. This removes the awkward coupling where audio had to route through the video track to reach the shared processor.
- **Conditional video track creation**: Pipelines can declare `produces_video = False` in their config. When the last pipeline in a chain is audio-only, the server skips VideoProcessingTrack, MediaRelay, and RecordingManager entirely.
- **Fix audio delivery for audio-only pipelines**: Audio callback now fires before the video early-return in PipelineProcessor, so pipelines that return only `{"audio": ..., "audio_sample_rate": ...}` actually deliver audio.
- **Add `requires_audio_input` ClassVar**: Forward-looking flag on BasePipelineConfig for pipelines that expect browser audio input (microphone). Not wired yet; placeholder for the audio input workstream.
- **Frontend audio-only indicator**: VideoOutput component detects absence of video tracks and shows an audio-only UI with a hidden media element for playback.

## Depends on

- #534 (Audio Support for Scope Rework)

## Test plan

- [ ] Video+audio pipeline (e.g. LTX-2) still works as before
- [ ] Audio-only pipeline (e.g. test_tone with `produces_video = False`) delivers audio without creating a video track
- [ ] Frontend shows "Audio Only" indicator when no video track is present
- [ ] Session cleanup properly stops FrameProcessor
- [ ] Parameter updates route through `session.frame_processor` correctly
- [ ] Pipeline schema metadata includes `produces_video` and `requires_audio_input`