### PR TITLE
Use daydream API to check if plugin is allowed

### DIFF
--- a/src/scope/cloud/fal_app.py
+++ b/src/scope/cloud/fal_app.py
@@ -824,7 +824,7 @@ class ScopeApp(fal.App, keep_alive=300):
                 )
 
                 # Check if the requested plugin is allowed via the Daydream API
-                async def is_plugin_allowed(package: str) -> bool:
+                async def is_plugin_allowed(package: str) -> bool | None:
                     import re
 
                     def normalize_plugin_url(url: str) -> str:
@@ -869,11 +869,19 @@ class ScopeApp(fal.App, keep_alive=300):
                         print(
                             f"[{log_prefix()}] Failed to fetch allowed plugins from {base_url}: {e}"
                         )
-                        return False
+                        return None
 
                     return False
 
-                if not await is_plugin_allowed(requested_package):
+                allowed = await is_plugin_allowed(requested_package)
+                if allowed is None:
+                    return {
+                        "type": "api_response",
+                        "request_id": request_id,
+                        "status": 503,
+                        "error": "Unable to verify plugin allowlist — the Daydream API is currently unavailable. Please try again later.",
+                    }
+                if not allowed:
                     return {
                         "type": "api_response",
                         "request_id": request_id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Plugin access now uses remote API checks so allowlists stay up-to-date; plugins not permitted will be blocked.
  * Validation now handles API pagination and network errors more robustly, reducing false allow/block outcomes.
  * Service base URL handling improved with a sensible default to ensure validation continues when configuration is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

We can approve/revoke plugins in the daydream [admin pages](https://app.daydream.live/dashboard/admin/nodes) now and this will be automatically reflected in the front end as well as this back end check. 
Screenshot of admin page:
<img width="1479" height="603" alt="Screenshot 2026-03-10 at 13 17 09" src="https://github.com/user-attachments/assets/105b3c6a-994d-43a5-8a3a-603d441b8348" />
