### PR TITLE
feat: improve cloud button discoverability and header icon visibility

### DIFF
--- a/e2e/tests/cloud-streaming.spec.ts
+++ b/e2e/tests/cloud-streaming.spec.ts
@@ -57,7 +57,7 @@ async function enableCloudMode(page: Page) {
   console.log("Enabling cloud mode...");
 
   // Open settings dialog via the cloud icon in the header
-  const cloudIcon = page.locator('button[title*="cloud" i]');
+  const cloudIcon = page.locator('button[title*="cloud" i], button[title*="remote inference" i]');
   await expect(cloudIcon).toBeVisible({ timeout: 10000 });
   await cloudIcon.click();
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -138,17 +138,17 @@ export function Header({
             onClick={handleCloudIconClick}
             className={`hover:opacity-80 transition-opacity h-8 gap-1.5 px-2 ${
               isConnected
-                ? "text-green-500 opacity-80"
+                ? "text-green-500 opacity-100"
                 : isConnecting
-                  ? "text-amber-400 opacity-80"
-                  : "text-muted-foreground opacity-60"
+                  ? "text-amber-400 opacity-100"
+                  : "text-muted-foreground opacity-80"
             }`}
             title={
               isConnected
                 ? "Cloud connected"
                 : isConnecting
                   ? "Connecting to cloud..."
-                  : "Cloud disconnected"
+                  : "Enable remote inference"
             }
           >
             {isConnected ? (
@@ -163,14 +163,14 @@ export function Header({
                 ? "Connected"
                 : isConnecting
                   ? "Connecting..."
-                  : "Disconnected"}
+                  : "Enable Remote Inference"}
             </span>
           </Button>
           <Button
             variant="ghost"
             size="icon"
             onClick={() => setPluginsOpen(true)}
-            className="hover:opacity-80 transition-opacity text-muted-foreground opacity-60 h-8 w-8"
+            className="hover:opacity-80 transition-opacity text-muted-foreground opacity-80 h-8 w-8"
             title="Plugins"
           >
             <Plug className="h-5 w-5" />
@@ -179,7 +179,7 @@ export function Header({
             variant="ghost"
             size="icon"
             onClick={() => setSettingsOpen(true)}
-            className="hover:opacity-80 transition-opacity text-muted-foreground opacity-60 h-8 w-8"
+            className="hover:opacity-80 transition-opacity text-muted-foreground opacity-80 h-8 w-8"
             title="Settings"
           >
             <Settings className="h-5 w-5" />


### PR DESCRIPTION
Change disconnected state text from "Disconnected" to "Enable Remote Inference" so new users understand the feature is available. Bump opacity on all three header icons (cloud, plugins, settings) for better visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated cloud status indicator labels, tooltips, and styling for improved clarity and guidance
  * Adjusted opacity of cloud, plugins, and settings icons for better visibility

* **Tests**
  * Broadened end-to-end cloud activation checks to cover both cloud and remote inference entry points for more reliable test coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->