### PR TITLE
fix: kill entire process group on quit to prevent stale server processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ notes/
 .cursor/
 .specstory/
 *.local*
+
+*.tsbuildinfo

--- a/app/src/services/pythonProcess.ts
+++ b/app/src/services/pythonProcess.ts
@@ -94,6 +94,9 @@ export class ScopePythonProcessService implements PythonProcessService {
       cwd: projectRoot,
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: false,
+      // On Unix, create a new process group so we can kill the entire tree
+      // (uv + Python server + any children) with a single signal
+      detached: process.platform !== 'win32',
       env: {
         ...process.env,
         PATH: pathEnv,
@@ -192,29 +195,32 @@ export class ScopePythonProcessService implements PythonProcessService {
 
   stopServer(): void {
     this.intentionalStop = true;  // Mark as intentional to prevent respawn on exit code 42
-    if (this.serverProcess) {
-      logger.info('Stopping server...');
-      const pid = this.serverProcess.pid;
 
-      if (process.platform === 'win32' && pid) {
-        // On Windows, kill the entire process tree using taskkill
-        // This ensures child processes (like the Python server spawned by uv) are also terminated
-        try {
-          execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
-          logger.info(`Killed process tree for PID ${pid}`);
-        } catch (err) {
-          logger.warn(`Failed to kill process tree: ${err}`);
-          // Fallback to regular kill
-          this.serverProcess.kill('SIGINT');
-        }
-      } else {
-        // On Unix-like systems, SIGINT should propagate to child processes
-        this.serverProcess.kill('SIGINT');
+    if (!this.serverProcess?.pid) return;
+
+    logger.info('Stopping server...');
+    const pid = this.serverProcess.pid;
+    this.serverProcess = null;
+
+    if (process.platform === 'win32') {
+      // On Windows, kill the entire process tree using taskkill
+      try {
+        execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
+        logger.info(`Killed process tree for PID ${pid}`);
+      } catch (err) {
+        logger.warn(`Failed to kill process tree: ${err}`);
       }
-
-      this.serverProcess = null;
+    } else {
+      // On Unix, kill the entire process group (negative PID) since we spawned with detached: true
+      try {
+        process.kill(-pid, 'SIGKILL');
+        logger.info(`Killed process group ${pid}`);
+      } catch (err) {
+        logger.warn(`Failed to kill process group: ${err}`);
+      }
     }
   }
+
 
   isServerRunning(): boolean {
     return this.serverProcess !== null && !this.serverProcess.killed;


### PR DESCRIPTION
## Summary
- Spawn Python server with `detached: true` on Unix to create a dedicated process group
- `stopServer()` now kills the entire process group (`process.kill(-pid, 'SIGKILL')`) instead of just sending SIGINT to the direct child (`uv`), ensuring the Python server is also terminated
- Adds `*.tsbuildinfo` to `.gitignore`

## Problem
Users were seeing "No available ports found after 5 attempts starting from 52178" because `stopServer()` only sent SIGINT to the `uv` process, leaving the Python server orphaned and holding the port across app restarts.

## Test plan
- [ ] Launch the Electron app, verify server starts normally
- [ ] Quit the app (Cmd+Q on macOS, Alt+F4 on Windows), verify no stale Python processes remain (`lsof -i :52178`)
- [ ] Relaunch the app, verify it starts without port errors
- [ ] Test on Windows to verify `taskkill /T /F` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform process termination reliability to ensure complete cleanup of background processes on both Windows and Unix systems.

* **Chores**
  * Updated build configuration to exclude TypeScript incremental build files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->