### PR TITLE
Remove local filesize limits

### DIFF
--- a/frontend/src/components/MediaPicker.tsx
+++ b/frontend/src/components/MediaPicker.tsx
@@ -106,10 +106,10 @@ export function MediaPicker({
       return;
     }
 
-    const maxSize = 50 * 1024 * 1024;
-    if (file.size > maxSize) {
+    const maxCloudUploadSize = 50 * 1024 * 1024;
+    if (isCloudConnected && file.size > maxCloudUploadSize) {
       console.error(
-        `handleFileUpload: File size exceeds maximum of ${maxSize / (1024 * 1024)}MB`
+        `handleFileUpload: File size exceeds maximum of ${maxCloudUploadSize / (1024 * 1024)}MB while connected to cloud`
       );
       return;
     }

--- a/frontend/src/hooks/useVideoSource.ts
+++ b/frontend/src/hooks/useVideoSource.ts
@@ -263,13 +263,6 @@ export function useVideoSource(props?: UseVideoSourceProps) {
 
   const handleVideoFileUpload = useCallback(
     async (file: File) => {
-      // Validate file size (10MB limit)
-      const maxSize = 10 * 1024 * 1024; // 10MB in bytes
-      if (file.size > maxSize) {
-        setError("File size must be less than 10MB");
-        return false;
-      }
-
       // Validate file type
       if (!file.type.startsWith("video/")) {
         setError("Please select a video file");

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -1570,13 +1570,15 @@ async def upload_asset(
         # Read file content from request body
         content = await request.body()
 
-        # Validate file size (50MB limit)
-        max_size = 50 * 1024 * 1024  # 50MB
-        if len(content) > max_size:
-            raise HTTPException(
-                status_code=400,
-                detail=f"File size exceeds maximum of {max_size / (1024 * 1024):.0f}MB",
-            )
+        # Apply upload size validation only for cloud uploads.
+        # Local mode keeps files on the same machine, so no explicit cap is enforced.
+        if cloud_manager.is_connected:
+            max_size = 50 * 1024 * 1024  # 50MB
+            if len(content) > max_size:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"File size exceeds maximum of {max_size / (1024 * 1024):.0f}MB",
+                )
 
         # If cloud mode is active, upload to cloud AND save locally for thumbnails
         if cloud_manager.is_connected:


### PR DESCRIPTION
There's no reason to constrain filesizes for input videos given they never leave the device. For images, only check the size for remote inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Cloud uploads retain a 50MB size limit; local uploads are no longer capped by file size.
  * Video uploads now validate only the file type, removing the prior size-based rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->