### PR TITLE
fix: displaying new loading text

### DIFF
--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -109,6 +109,7 @@ export function StreamPage() {
   const {
     isConnected: isBackendCloudConnected,
     isConnecting: isBackendCloudConnecting,
+    connectStage: cloudConnectStage,
   } = useCloudStatus();
 
   // Combined cloud mode: either frontend direct-to-cloud or backend relay to cloud
@@ -417,6 +418,7 @@ export function StreamPage() {
     error: pipelineError,
     loadPipeline,
     pipelineInfo,
+    loadingStage: pipelineLoadingStage,
   } = usePipeline();
 
   // WebRTC for streaming (unified hook works in both local and cloud modes)
@@ -2132,6 +2134,8 @@ export function StreamPage() {
                 isCloudConnecting={isCloudConnecting}
                 isConnecting={isConnecting}
                 pipelineError={pipelineError}
+                pipelineLoadingStage={pipelineLoadingStage}
+                cloudConnectStage={cloudConnectStage}
                 isPlaying={!settings.paused}
                 isDownloading={isDownloading}
                 onPlayPauseToggle={() => {


### PR DESCRIPTION
When backend progress updates were introduced [here](https://github.com/daydreamlive/scope/pull/581) it seems we missed passing the properties through to the VideoOutput component, maybe something got messed up in a merge or something.

Verified working:
<img width="364" height="188" alt="Screenshot 2026-03-11 at 11 08 46" src="https://github.com/user-attachments/assets/cf3dbd88-034e-41d3-925f-4c7599fa5042" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced visibility into cloud connection and pipeline loading stages within the video interface, enabling better real-time status feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->