### PR TITLE
Make Settings dialog box size match Plugins

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -115,7 +115,7 @@ export function SettingsDialog({
 
   return (
     <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-[600px] p-0 gap-0">
+      <DialogContent className="sm:max-w-[600px] lg:max-w-[800px] xl:max-w-[960px] p-0 gap-0">
         <Tabs
           value={activeTab}
           onValueChange={setActiveTab}
@@ -155,7 +155,7 @@ export function SettingsDialog({
             </TabsTrigger>
           </TabsList>
           <div className="w-px bg-border self-stretch" />
-          <div className="flex-1 min-w-0 p-4 pt-10 h-[40vh] overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:transition-colors [&::-webkit-scrollbar-thumb:hover]:bg-gray-400">
+          <div className="flex-1 min-w-0 p-4 pt-10 h-[80vh] lg:h-[80vh] xl:h-[80vh] overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:transition-colors [&::-webkit-scrollbar-thumb:hover]:bg-gray-400">
             <TabsContent value="general" className="mt-0">
               <GeneralTab
                 version={version}


### PR DESCRIPTION
It's getting cramped as we add more things in. This change makes it match the Plugins box in size and take more advantage of screen size on larger screens.

On my Macbook Air:

<img width="1470" height="956" alt="Screenshot 2026-03-11 at 11 38 51" src="https://github.com/user-attachments/assets/1097cf1f-49d2-472d-b626-1a677538bfad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Settings dialog layout updated to better utilize larger screens with expanded maximum widths for desktop and wide displays.
  * Scrollable content area height increased for improved visibility and reduced need for nested scrolling, preserving existing overflow and scrollbar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->