### PR TITLE
fix: krea FP8 + torch.compile incompatibility on H100 (#669)

### DIFF
--- a/src/scope/core/pipelines/krea_realtime_video/pipeline.py
+++ b/src/scope/core/pipelines/krea_realtime_video/pipeline.py
@@ -137,14 +137,27 @@ class KreaRealtimeVideoPipeline(Pipeline, LoRAEnabledPipeline, VACEEnabledPipeli
             )
 
             print(f"Quantized diffusion model to fp8 in {time.time() - start:.3f}s")
+
+            if compile:
+                # Float8DynamicActivationFloat8WeightConfig is incompatible with
+                # torch.compile(fullgraph=False): AOT autograd's gen_alias_from_base
+                # calls aten.as_strided on Float8Tensor outputs, which is not
+                # implemented. Skip block compilation when FP8 is active.
+                # See: https://github.com/daydreamlive/scope/issues/669
+                logger.warning(
+                    "Skipping torch.compile for attention blocks: "
+                    "Float8DynamicActivationFloat8WeightConfig is not compatible "
+                    "with fullgraph=False compilation (aten.as_strided unsupported "
+                    "on Float8Tensor). FP8 quantization is still active."
+                )
         else:
             generator = generator.to(device=device, dtype=dtype)
 
-        if compile:
-            # Only compile the attention blocks
-            for block in generator.model.blocks:
-                # Disable fullgraph right now due to issues with RoPE
-                block.compile(fullgraph=False)
+            if compile:
+                # Only compile the attention blocks
+                for block in generator.model.blocks:
+                    # Disable fullgraph right now due to issues with RoPE
+                    block.compile(fullgraph=False)
 
         # Load VAE using create_vae factory (supports multiple VAE types)
         # Note: VAE is shared across all Wan model sizes, stored in Wan2.1-T2V-1.3B

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -691,6 +691,16 @@ class PipelineManager:
             except Exception as e:
                 logger.warning(f"CUDA cleanup failed: {e}")
 
+        # Reset torch.compile compilation cache to prevent stale compiled graphs
+        # (especially those specialized for Float8Tensor weights) from leaking into
+        # subsequently loaded pipelines. Without this, longlive's FP8-compiled graph
+        # cache can corrupt Krea's compile attempt, causing as_strided dispatch errors.
+        try:
+            torch._dynamo.reset()
+            logger.info("torch._dynamo cache reset")
+        except Exception as e:
+            logger.warning(f"torch._dynamo reset failed: {e}")
+
         # Publish pipeline_unloaded event
         publish_event(
             event_type="pipeline_unloaded",


### PR DESCRIPTION
## Problem

**Issue #669** — Krea fails to load on remote inference after using longlive.

```
NotImplementedError: Float8Tensor dispatch: attempting to run unimplemented
operator/function: func=<OpOverload(op='aten.as_strided', overload='default')>
```

### Root cause

On H100/Hopper, Krea loads with `compile=True`. If FP8 quantization is also active, `Float8DynamicActivationFloat8WeightConfig` + `torch.compile(fullgraph=False)` crash during warmup.

**Why it happens**: With `fullgraph=False`, graph breaks split the compiled function into sub-graphs. At the boundary between sub-graphs, AOT autograd's `gen_alias_from_base` calls `aten.as_strided` on the Float8Tensor output of a compiled linear layer to create an output alias — but `as_strided` is not implemented for `Float8Tensor` in torchao.

**Why specifically after longlive**: `torch._dynamo.reset()` is never called between pipeline switches. After longlive runs with FP8 (no compile), its Float8Tensor dispatch state persists in the global dynamo compilation cache. When Krea then loads with FP8 + compile, the residual cache state triggers the AOT autograd aliasing code path that would otherwise be avoided on a fresh worker.

### Traceback path
```
wan2_1/blocks/denoise.py → wan2_1/components/generator.py
  → krea_realtime_video/modules/causal_model.py (torch.compiled block)
    → torch/nn/modules/linear.py: F.linear(input, self.weight, self.bias)
      → torchao Float8Tensor __torch_function__ dispatch (aten.linear)
        → aot_autograd runtime_wrappers: gen_alias_from_base
          → aliased_base_tensor.as_strided(...)  ← CRASH
```

## Fix

**1. `krea_realtime_video/pipeline.py`** — When FP8 quantization is active, skip `block.compile()`. The two optimisations are currently mutually exclusive under `fullgraph=False`. FP8 alone still provides meaningful memory/compute savings on H100.

**2. `pipeline_manager.py`** — Call `torch._dynamo.reset()` on every pipeline unload to flush stale compiled graphs and Float8 dispatch state, preventing cross-pipeline cache pollution.

## Testing

Reproduce with:
1. Load longlive with FP8 quantization on H100
2. Unload longlive
3. Load krea-realtime-video — should now succeed instead of crashing during warmup

Closes #669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 quantization handling by skipping block-wide compilation when active to prevent incompatibilities.
  * Fixed pipeline unloading to properly clear compilation cache, preventing stale compiled graphs from affecting subsequently loaded pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->