### PR TITLE
fix(frame_processor): surface empty pipeline_ids error to client + fallback to loaded pipelines

### DIFF
--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -167,9 +167,35 @@ class FrameProcessor:
 
         # Local mode: setup pipeline graph
         if not self.pipeline_ids:
+            # Fallback: if no pipeline_ids were specified in initial parameters,
+            # use whatever pipelines are currently loaded in the manager.
+            # This matches the schema description: "If not provided, uses the
+            # currently loaded pipeline."
+            if self.pipeline_manager:
+                loaded_ids = self.pipeline_manager.get_loaded_pipeline_ids()
+                if loaded_ids:
+                    logger.info(
+                        f"[FRAME-PROCESSOR] No pipeline_ids in initial parameters; "
+                        f"falling back to loaded pipelines: {loaded_ids}"
+                    )
+                    self.pipeline_ids = loaded_ids
+
+        if not self.pipeline_ids:
             error_msg = "No pipeline IDs provided, cannot start"
             logger.error(error_msg)
             self.running = False
+            # Surface the error to the frontend via data channel so the client
+            # knows why the stream did not start (instead of silently hanging).
+            if self.notification_callback:
+                try:
+                    self.notification_callback(
+                        {
+                            "type": "stream_stopped",
+                            "error_message": error_msg,
+                        }
+                    )
+                except Exception as cb_err:
+                    logger.error(f"Error in notification callback: {cb_err}")
             # Publish error for startup failure
             publish_event(
                 event_type="error",


### PR DESCRIPTION
## Problem

Issue #680: `frame_processor` silently fails when started with no `pipeline_ids`, logging an ERROR server-side but never notifying the client. This left the frontend with no video output and no explanation — causing a retry/reconnect loop (3 hits on the same fal job in issue #680).

## Root cause

In `FrameProcessor.start()`, the early-exit path for missing `pipeline_ids` published a Kafka error event and set `running = False`, but **never called `notification_callback`**. The client's data channel received no signal, so it retried.

## Changes

**1. Graceful fallback — use loaded pipelines when none specified (new behaviour)**

If `pipeline_ids` is absent/empty in `initial_parameters`, the processor now queries `pipeline_manager.get_loaded_pipeline_ids()` and uses whatever is already loaded. This matches the documented schema behaviour:

> _"If not provided, uses the currently loaded pipeline."_

This prevents the error entirely for sessions that legitimately omit `pipeline_ids`.

**2. Surface error to client via data channel (bug fix)**

If the fallback also yields nothing, the existing error path now calls `notification_callback` with `{"type": "stream_stopped", "error_message": "No pipeline IDs provided, cannot start"}` before returning. The frontend receives this on the data channel and can show a user-visible error instead of retrying blindly.

## Testing

- Existing behaviour unchanged when `pipeline_ids` is provided
- No regressions to the Kafka error event (still published)
- Fallback path requires the pipeline manager to have loaded pipelines; if not, error path fires as before (now with client notification)

Closes #680
