### PR TITLE
fix: check is_available() before creating Spout/unavailable sinks and sources (#688)

### DIFF
--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -679,6 +679,12 @@ class FrameProcessor:
             if sink_class is None:
                 logger.error(f"Unknown output sink type: {sink_type}")
                 return
+            if not sink_class.is_available():
+                logger.warning(
+                    "Output sink '%s' is not available on this platform, skipping",
+                    sink_type,
+                )
+                return
             try:
                 sink = sink_class()
                 if sink.create(sink_name, width, height):
@@ -825,8 +831,9 @@ class FrameProcessor:
             return
 
         if not source_class.is_available():
-            logger.error(
-                f"Input source '{source_type}' is not available on this platform"
+            logger.warning(
+                "Input source '%s' is not available on this platform, skipping",
+                source_type,
             )
             return
 


### PR DESCRIPTION
## Summary

Fixes #688 — same availability-guard pattern as #644 (NDI), now applied to output sinks generally and the input source path.

## Changes

### `src/scope/server/frame_processor.py`

**`_update_output_sink()`** — add `is_available()` guard before attempting to create:
```python
if not sink_class.is_available():
    logger.warning(
        "Output sink '%s' is not available on this platform, skipping",
        sink_type,
    )
    return
```

**`_create_and_connect_input_source()`** — downgrade existing `is_available()` failure from `ERROR` to `WARNING` for consistency.

## Why

SpoutGL is a Windows-only DirectX texture sharing library. On Linux fal.ai workers, enabling the Spout sink/source produced ERROR-level log noise even though the outcome was benign. This cluttered the error monitoring dashboard alongside real errors.

## Test

- On Linux: enabling Spout output sink/input source should produce a `WARNING` and no further errors (no `create()` attempt)
- On Windows: no behaviour change — `is_available()` returns `True`, sink creates as normal

## Related

- #644 — identical fix for NDI output sink (the template for this change)