### PR TITLE
fix: suppress VaceEncodingBlock per-chunk crash storm for stale asset paths (#689)

### DIFF
--- a/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
+++ b/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
@@ -16,6 +16,7 @@ For conditioning inputs (depth, flow, etc.), follows original VACE architecture:
 """
 
 import logging
+import os
 from typing import Any
 
 import torch
@@ -71,12 +72,47 @@ class VaceEncodingBlock(ModularPipelineBlocks):
         self._inactive_cache = None
         self._reactive_cache = None
         self._caches_initialized = False
+        # Track asset paths that have already been logged as missing to suppress
+        # per-chunk log storms (see #689: 150+ ERROR lines from a single stale path).
+        self._logged_missing_assets: set[str] = set()
 
     def clear_encoder_caches(self):
         """Clear encoder caches for a new video sequence."""
         self._inactive_cache = None
         self._reactive_cache = None
         self._caches_initialized = False
+
+    def _validate_image_paths(self, paths: list[str | None]) -> bool:
+        """
+        Validate that all provided image paths exist on disk.
+
+        Logs ERROR once per unique missing path; subsequent calls for the same missing
+        path are silent. This prevents per-chunk log storms when a saved workflow
+        references an asset that no longer exists on the current ephemeral worker
+        (e.g. fal.ai H100 workers that do not persist /home/rio/.daydream-scope/assets/).
+
+        Returns True if all paths are valid (or None), False if any are missing.
+
+        See: #689 — VaceEncodingBlock crashes on fal.ai: stale asset path not present on worker
+        See: #524 — VaceEncodingBlock failing on Windows-style asset paths
+        """
+        all_valid = True
+        for path in paths:
+            if path is None:
+                continue
+            if not os.path.exists(path):
+                all_valid = False
+                if path not in self._logged_missing_assets:
+                    self._logged_missing_assets.add(path)
+                    logger.error(
+                        f"VaceEncodingBlock: Asset not found: '{path}'. "
+                        f"This path may reference an asset from a previous fal.ai worker "
+                        f"session that is no longer available. Please re-upload the asset "
+                        f"or update the workflow configuration. "
+                        f"Skipping VACE conditioning for this stream. "
+                        f"(Subsequent missing-asset errors for this path will be suppressed.)"
+                    )
+        return all_valid
 
     @property
     def expected_components(self) -> list[ComponentSpec]:
@@ -179,6 +215,26 @@ class VaceEncodingBlock(ModularPipelineBlocks):
         has_extension = has_first_frame or has_last_frame
 
         if not has_ref_images and not has_input_frames and not has_extension:
+            block_state.vace_context = None
+            block_state.vace_ref_images = None
+            self.set_block_state(state, block_state)
+            return components, state
+
+        # Validate that all referenced image paths exist on disk before attempting
+        # to encode. Stale paths (e.g. from a previous fal.ai worker session) will
+        # cause FileNotFoundError on every chunk — log once and skip gracefully
+        # rather than crashing 150+ times per session. See #689.
+        image_paths_to_check: list[str | None] = []
+        if has_ref_images:
+            image_paths_to_check.extend(vace_ref_images)
+        if has_first_frame:
+            image_paths_to_check.append(first_frame_image)
+        if has_last_frame:
+            image_paths_to_check.append(last_frame_image)
+
+        if not self._validate_image_paths(image_paths_to_check):
+            # One or more asset paths are missing — error already logged once above.
+            # Skip VACE conditioning for this chunk to avoid per-chunk crash storm.
             block_state.vace_context = None
             block_state.vace_ref_images = None
             self.set_block_state(state, block_state)

--- a/tests/test_vace_encoding_block_missing_asset.py
+++ b/tests/test_vace_encoding_block_missing_asset.py
@@ -1,0 +1,171 @@
+"""
+Tests for VaceEncodingBlock stale/missing asset path handling.
+
+Regression test for #689: VaceEncodingBlock crashes on fal.ai when a saved
+workflow references an asset path from a previous ephemeral worker session.
+The block must log an ERROR exactly once per missing path and then skip
+VACE conditioning gracefully instead of crashing on every chunk.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestValidateImagePaths:
+    """Unit tests for VaceEncodingBlock._validate_image_paths."""
+
+    def _make_block(self):
+        from scope.core.pipelines.wan2_1.vace.blocks.vace_encoding import (
+            VaceEncodingBlock,
+        )
+
+        return VaceEncodingBlock()
+
+    def test_returns_true_for_existing_paths(self, tmp_path):
+        """Returns True when all paths exist."""
+        img = tmp_path / "img.jpg"
+        img.write_bytes(b"fake")
+
+        block = self._make_block()
+        assert block._validate_image_paths([str(img)]) is True
+
+    def test_returns_true_for_none_paths(self):
+        """None entries are skipped — returns True."""
+        block = self._make_block()
+        assert block._validate_image_paths([None, None]) is True
+
+    def test_returns_false_for_missing_path(self, tmp_path):
+        """Returns False when a path does not exist."""
+        block = self._make_block()
+        missing = str(tmp_path / "nonexistent.jpg")
+        assert block._validate_image_paths([missing]) is False
+
+    def test_logs_error_on_first_missing_occurrence(self, tmp_path, caplog):
+        """Logs ERROR exactly once when a path is first detected as missing."""
+        block = self._make_block()
+        missing = str(tmp_path / "stale_screenshot.jpg")
+
+        with caplog.at_level(logging.ERROR, logger="scope"):
+            block._validate_image_paths([missing])
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert missing in errors[0].message
+
+    def test_suppresses_error_on_subsequent_missing_occurrences(self, tmp_path, caplog):
+        """Logs ERROR only once for the same missing path (no per-chunk log storm)."""
+        block = self._make_block()
+        missing = str(tmp_path / "stale_screenshot.jpg")
+
+        with caplog.at_level(logging.ERROR, logger="scope"):
+            for _ in range(150):  # simulate 150 chunks
+                block._validate_image_paths([missing])
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1, (
+            f"Expected 1 ERROR log, got {len(errors)} — log storm not suppressed"
+        )
+
+    def test_mixed_valid_and_missing_paths(self, tmp_path):
+        """Returns False when at least one path is missing."""
+        existing = tmp_path / "good.jpg"
+        existing.write_bytes(b"fake")
+        missing = str(tmp_path / "stale.jpg")
+
+        block = self._make_block()
+        assert block._validate_image_paths([str(existing), missing]) is False
+
+    def test_multiple_distinct_missing_paths_each_logged_once(self, tmp_path, caplog):
+        """Each unique missing path is logged once."""
+        block = self._make_block()
+        missing_a = str(tmp_path / "a.jpg")
+        missing_b = str(tmp_path / "b.jpg")
+
+        with caplog.at_level(logging.ERROR, logger="scope"):
+            for _ in range(10):
+                block._validate_image_paths([missing_a, missing_b])
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 2
+        messages = " ".join(e.message for e in errors)
+        assert missing_a in messages
+        assert missing_b in messages
+
+
+class TestCallWithMissingAssets:
+    """Integration-style tests for VaceEncodingBlock.__call__ with missing assets."""
+
+    def _make_block(self):
+        from scope.core.pipelines.wan2_1.vace.blocks.vace_encoding import (
+            VaceEncodingBlock,
+        )
+
+        return VaceEncodingBlock()
+
+    def _make_state(self, **kwargs):
+        """Build a minimal PipelineState-like mock."""
+        block_state = MagicMock()
+        block_state.vace_ref_images = kwargs.get("vace_ref_images", None)
+        block_state.vace_input_frames = kwargs.get("vace_input_frames", None)
+        block_state.first_frame_image = kwargs.get("first_frame_image", None)
+        block_state.last_frame_image = kwargs.get("last_frame_image", None)
+        block_state.current_start_frame = kwargs.get("current_start_frame", 0)
+
+        state = MagicMock()
+        return block_state, state
+
+    def test_skips_encoding_when_ref_image_missing(self, tmp_path, caplog):
+        """
+        When vace_ref_images contains a stale path, __call__ should skip encoding
+        and set vace_context=None / vace_ref_images=None instead of crashing.
+        """
+        from scope.core.pipelines.wan2_1.vace.blocks.vace_encoding import (
+            VaceEncodingBlock,
+        )
+
+        block = VaceEncodingBlock()
+        missing = str(tmp_path / "stale.jpg")
+        block_state, state = self._make_state(vace_ref_images=[missing])
+
+        components = MagicMock()
+
+        with patch.object(block, "get_block_state", return_value=block_state):
+            with patch.object(block, "set_block_state") as mock_set:
+                with caplog.at_level(logging.ERROR, logger="scope"):
+                    result_components, result_state = block(components, state)
+
+        # Should have returned early without crashing
+        assert block_state.vace_context is None
+        assert block_state.vace_ref_images is None
+        mock_set.assert_called_once()
+
+        # Exactly one ERROR for this path
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert missing in errors[0].message
+
+    def test_no_log_storm_across_chunks_with_missing_ref(self, tmp_path, caplog):
+        """
+        Simulates 50 chunks with a stale ref image. Should produce exactly 1 ERROR.
+        """
+        from scope.core.pipelines.wan2_1.vace.blocks.vace_encoding import (
+            VaceEncodingBlock,
+        )
+
+        block = VaceEncodingBlock()
+        missing = str(tmp_path / "stale.jpg")
+        components = MagicMock()
+
+        with caplog.at_level(logging.ERROR, logger="scope"):
+            for _ in range(50):
+                block_state, state = self._make_state(vace_ref_images=[missing])
+                with patch.object(block, "get_block_state", return_value=block_state):
+                    with patch.object(block, "set_block_state"):
+                        block(components, state)
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1, (
+            f"Expected 1 ERROR across 50 chunks, got {len(errors)}"
+        )


### PR DESCRIPTION
## Summary

Fixes #689.

When a saved workflow references an image path that no longer exists on the current fal.ai worker (ephemeral workers don't persist `/home/rio/.daydream-scope/assets/`), `VaceEncodingBlock` was crashing on every processed chunk, producing **150+ identical ERROR lines** in a single session.

**Root cause:** `Image.open(ref_path)` in `load_and_prepare_reference_images` throws `FileNotFoundError` unconditionally. The pipeline processor catches the exception per-chunk and keeps running — so a single stale asset floods logs for the entire session.

## Changes

### `vace_encoding.py`
- Add `_logged_missing_assets: set[str]` to `__init__` — tracks which missing paths have already been reported
- Add `_validate_image_paths(paths)` — checks `os.path.exists()` for every referenced image before encoding; logs **ERROR once** per unique missing path, then silently suppresses repeats
- In `__call__`, call `_validate_image_paths` before any encoding attempt; short-circuit with `vace_context=None` if any path is missing (same behaviour as the existing no-inputs skip path)

### `tests/test_vace_encoding_block_missing_asset.py` (new)
9 tests covering:
- Valid / None / missing path return values
- Log-once suppression (150-chunk storm simulation asserts exactly 1 ERROR)
- Mixed valid + missing paths
- Multiple distinct missing paths each logged once
- Full `__call__` integration: skips encoding, sets `vace_context=None`, logs once

## Behaviour after this fix

| Situation | Before | After |
|-----------|--------|-------|
| Stale asset path | `FileNotFoundError` × N chunks | 1× ERROR, N-1 silent skips |
| Valid path | Encodes normally | Encodes normally (unchanged) |
| No images provided | Skips (no change) | Skips (no change) |

## Related
- #524 — Windows client paths to cloud backend (different cause, same block)
- #685 — firstlastframe log storm (same per-chunk flood pattern)
- #673 — temporal kernel underflow (same per-chunk flood pattern)