### PR TITLE
fix: check is_available() before creating Syphon output sink (#692)

### DIFF
--- a/src/scope/core/inputs/syphon.py
+++ b/src/scope/core/inputs/syphon.py
@@ -96,7 +96,7 @@ class SyphonInputSource(InputSource):
                 self._receiver = None
                 return False
         except ImportError:
-            logger.error("syphon-python not available")
+            logger.warning("syphon-python not available (macOS only)")
             return False
         except Exception as e:
             logger.error(f"Error connecting SyphonInputSource: {e}")

--- a/src/scope/core/outputs/syphon.py
+++ b/src/scope/core/outputs/syphon.py
@@ -70,7 +70,7 @@ class SyphonOutputSink(OutputSink):
             self._sender = None
             return False
         except ImportError:
-            logger.error("syphon-python not available")
+            logger.warning("syphon-python not available (macOS only)")
             return False
         except Exception as e:
             logger.error(f"Error creating SyphonOutputSink: {e}")

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -679,6 +679,11 @@ class FrameProcessor:
             if sink_class is None:
                 logger.error(f"Unknown output sink type: {sink_type}")
                 return
+            if not sink_class.is_available():
+                logger.warning(
+                    f"Output sink '{sink_type}' is not available on this platform"
+                )
+                return
             try:
                 sink = sink_class()
                 if sink.create(sink_name, width, height):

--- a/src/scope/server/syphon/sender.py
+++ b/src/scope/server/syphon/sender.py
@@ -43,7 +43,7 @@ class SyphonSender:
             )
             return True
         except ImportError:
-            logger.error("syphon-python not available")
+            logger.warning("syphon-python not available (macOS only)")
             return False
         except Exception as e:
             logger.error(f"Failed to create SyphonSender: {e}", exc_info=True)


### PR DESCRIPTION
## Summary

Adds the missing `is_available()` guard for the Syphon output sink in `_update_output_sink()`, matching the existing guard already in place for input sources (added in #644/NDI).

On fal.ai Linux workers, `syphon-python` is not installed. Without the guard, every connection attempt from a user with a Syphon workflow saved from their Mac produced four ERROR log lines, flooding Grafana.

## Changes

- **`frame_processor._update_output_sink()`** — add `sink_class.is_available()` check before instantiating the sink, identical pattern to the input source guard at line 827
- **`SyphonOutputSink.create()`** — downgrade `ImportError` log from `ERROR` → `WARNING` (macOS-only unavailability is expected, not an error)
- **`SyphonSender.create()`** — same downgrade
- **`SyphonInputSource.connect()`** — same downgrade (already gated by `is_available()` but ImportError path still reachable in edge cases)

## Related

- Fixes #692
- Same pattern as #644 (NDI) and #688 (SpoutGL)