### PR TITLE
fix: auto-delete stale checkpoint on tensor shape mismatch (#693)

### DIFF
--- a/src/scope/core/pipelines/wan2_1/components/generator.py
+++ b/src/scope/core/pipelines/wan2_1/components/generator.py
@@ -1,6 +1,7 @@
 # Modified from https://github.com/guandeh17/Self-Forcing
 import inspect
 import json
+import logging
 import os
 import types
 
@@ -9,6 +10,8 @@ import torch
 from scope.core.pipelines.utils import load_state_dict
 
 from .scheduler import FlowMatchScheduler, SchedulerInterface
+
+logger = logging.getLogger(__name__)
 
 
 def filter_causal_model_cls_config(causal_model_cls, config):
@@ -73,7 +76,33 @@ class WanDiffusionWrapper(torch.nn.Module):
             self.model = self.model.to_empty(device="cpu")
             # Then load the state dict weights
             # Use strict=False to allow partial loading (e.g., VACE model with non-VACE checkpoint)
-            self.model.load_state_dict(state_dict, assign=True, strict=False)
+            try:
+                self.model.load_state_dict(state_dict, assign=True, strict=False)
+            except RuntimeError as e:
+                err_str = str(e)
+                # Detect tensor shape/size mismatch — symptom of a stale or corrupt
+                # model checkpoint whose weights no longer match the current model
+                # architecture (e.g. old 1.3B weights cached on a worker that now
+                # expects 14B shapes).
+                if "size of tensor" in err_str or "size mismatch" in err_str:
+                    logger.error(
+                        f"Checkpoint shape mismatch loading '{generator_path}': {e}. "
+                        "This indicates a stale or incompatible cached model file. "
+                        "Deleting the checkpoint so it will be re-downloaded on next startup."
+                    )
+                    try:
+                        os.remove(generator_path)
+                        logger.info(f"Deleted stale checkpoint: {generator_path}")
+                    except OSError as rm_err:
+                        logger.warning(
+                            f"Could not delete stale checkpoint '{generator_path}': {rm_err}"
+                        )
+                    raise RuntimeError(
+                        f"Checkpoint '{generator_path}' has incompatible tensor shapes "
+                        f"and has been deleted ({e}). "
+                        "Please retry — the model will be re-downloaded automatically."
+                    ) from e
+                raise
 
             # HACK!
             # Reinitialize self.freqs properly on CPU (it's not in state_dict)


### PR DESCRIPTION
## Problem

`krea-realtime-video` fails to load on fal.ai workers with:

```
The size of tensor a (5120) must match the size of tensor b (1536) at non-singleton dimension 1.
If this error persists, consider removing the models directory '/data/models' and re-downloading models.
```

This is a stale/incompatible checkpoint cached on the worker — likely downloaded against an older model version where the hidden dim was different. Because the file persists on disk, every subsequent job hits the same error (4 occurrences across 2 jobs before this was caught).

## Root Cause

In `WanDiffusionWrapper.__init__`, `load_state_dict(..., assign=True, strict=False)` ignores missing/unexpected keys but still raises `RuntimeError` when tensor shapes don't match. The error is logged and surfaced, but the stale file is left on disk — so re-tries always fail the same way.

## Fix

Catch `RuntimeError` from `load_state_dict`, detect shape-mismatch phrasing (`"size of tensor"` / `"size mismatch"`), **delete the stale checkpoint file**, then re-raise with a clear actionable message. On the next job attempt fal.ai will re-download the checkpoint fresh and the load will succeed.

This fix applies to all pipelines that use `WanDiffusionWrapper` (krea-realtime-video, streamdiffusionv2, longlive, memflow, reward-forcing).

## Testing

- Shape-mismatch `RuntimeError` → stale file deleted, clear message re-raised ✓
- Other `RuntimeError` (e.g. CUDA OOM) → re-raised unchanged ✓
- File deletion failure (permissions) → warning logged, original error still re-raised ✓

Fixes #693