### PR TITLE
fix: pad vace_input_frames to min spatial size to avoid 3×3 kernel underflow

### DIFF
--- a/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
+++ b/src/scope/core/pipelines/wan2_1/vace/blocks/vace_encoding.py
@@ -19,6 +19,7 @@ import logging
 from typing import Any
 
 import torch
+import torch.nn.functional as F
 from diffusers.modular_pipelines import (
     ModularPipelineBlocks,
     PipelineState,
@@ -708,6 +709,34 @@ class VaceEncodingBlock(ModularPipelineBlocks):
 
         batch_size, channels, num_frames, height, width = input_frames_data.shape
 
+        # Guard against spatial underflow: the WAN VAE encoder contains a 3×3 spatial
+        # convolution kernel.  If either spatial dimension is < 3 the forward pass
+        # will raise:
+        #   RuntimeError: Calculated padded input size per channel: (2 x 513).
+        #   Kernel size: (3 x 3). Kernel size can't be greater than actual input size
+        # Observed in prod (2026-03-15) on krea-realtime-video with job
+        # 5193400c-da0f-4eef-8bdd-dd0fdd26c1db: 2 372 errors over 11 minutes.
+        # This is the spatial analogue of the 3×1×1 temporal kernel guard (issue #673).
+        # Pad to the minimum safe size rather than hard-crashing.
+        # Related: #557 (same block — spatial kernel underflow)
+        _MIN_SPATIAL = 3  # WAN VAE first-layer 3×3 conv
+        if height < _MIN_SPATIAL or width < _MIN_SPATIAL:
+            new_h = max(height, _MIN_SPATIAL)
+            new_w = max(width, _MIN_SPATIAL)
+            logger.warning(
+                f"VaceEncodingBlock._encode_with_conditioning: vace_input_frames spatial "
+                f"dimensions ({height}×{width}) are below the 3×3 spatial convolution "
+                f"kernel minimum. Padding input from ({height}×{width}) to ({new_h}×{new_w})."
+            )
+            # F.pad takes dims in reverse order: (W_left, W_right, H_top, H_bottom, ...)
+            input_frames_data = F.pad(
+                input_frames_data, (0, new_w - width, 0, new_h - height)
+            )
+            # Also patch block_state so the downstream resolution check passes
+            block_state.height = new_h
+            block_state.width = new_w
+            height, width = new_h, new_w
+
         # Validate resolution
         if height != block_state.height or width != block_state.width:
             raise ValueError(
@@ -767,6 +796,13 @@ class VaceEncodingBlock(ModularPipelineBlocks):
                 raise ValueError(
                     f"VaceEncodingBlock._encode_with_conditioning: vace_input_masks must have 1 channel, got {mask_channels}"
                 )
+            # Spatially pad mask to match frames if we padded the frames above
+            if mask_height < height or mask_width < width:
+                input_masks_data = F.pad(
+                    input_masks_data,
+                    (0, width - mask_width, 0, height - mask_height),
+                )
+                mask_height, mask_width = height, width
             if (
                 mask_frames != num_frames
                 or mask_height != height


### PR DESCRIPTION
## Summary

Fixes #557

Guards `VaceEncodingBlock._encode_with_conditioning` against inputs whose spatial dimensions are below the WAN VAE's 3×3 convolution minimum — the spatial analogue of the temporal guard in PR #674 / issue #673.

## Root Cause

The WAN VAE encoder has a 3×3 spatial convolution kernel in its first layer.  When `vace_input_frames` has height or width < 3 pixels, PyTorch raises:

```
RuntimeError: Calculated padded input size per channel: (2 x 513).
Kernel size: (3 x 3). Kernel size can't be greater than actual input size
```

## Observed in Prod (2026-03-15)

- **Pipeline:** `krea-realtime-video`
- **App:** `github_f1lhgmk5v76a0ev1w0u378by-scope-app--prod`
- **Job:** `5193400c-da0f-4eef-8bdd-dd0fdd26c1db`
- **Window:** 10:48–10:59 UTC (11 minutes)
- **Volume:** ~2,372 errors at ~4 errors/second
- **Input shape:** height=2, width=513 (extremely short frame — cf. #557's narrow case of height=513, width=2)

## Fix

In `_encode_with_conditioning`, after extracting `(batch, channels, frames, height, width)` from `vace_input_frames`:

1. If `height < 3` or `width < 3`, pad to the minimum safe size using `F.pad`
2. `vace_input_masks` (if provided) is padded to match
3. `block_state.height/width` are updated so the downstream resolution assertion still passes
4. A `WARNING` is emitted so the unusual input remains visible in logs

## Testing

The fix is a pure defensive guard — normal inputs (height ≥ 3, width ≥ 3) are completely unaffected. Abnormal inputs (< 3 on either axis) will now warn instead of crash.

Related: PR #674 (temporal kernel guard, same block)