### PR TITLE
fix: remove FPS-based throttling from input source receiver loop

### DIFF
--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -857,33 +857,25 @@ class FrameProcessor:
             self.input_source = None
 
     def _input_source_receiver_loop(self):
-        """Background thread that receives frames from a generic input source."""
+        """Background thread that receives frames from a generic input source.
+
+        Receives frames as fast as the source provides them, without throttling
+        based on pipeline FPS. Backpressure is handled by the downstream queues
+        (put_nowait drops frames when full). This matches the behavior of the
+        WebRTC camera input path and avoids a feedback loop where FPS-based
+        throttling + receive latency causes a downward FPS spiral for sources
+        with non-trivial receive overhead (NDI, Syphon).
+        """
         logger.info(f"Input source thread started ({self.input_source_type})")
 
-        target_fps = self.get_fps()
-        frame_interval = 1.0 / target_fps
-        last_frame_time = 0.0
         frame_count = 0
 
         while (
             self.running and self.input_source_enabled and self.input_source is not None
         ):
             try:
-                current_pipeline_fps = self.get_fps()
-                if current_pipeline_fps > 0:
-                    target_fps = current_pipeline_fps
-                    frame_interval = 1.0 / target_fps
-
-                current_time = time.time()
-                time_since_last = current_time - last_frame_time
-                if time_since_last < frame_interval:
-                    time.sleep(frame_interval - time_since_last)
-                    continue
-
                 rgb_frame = self.input_source.receive_frame(timeout_ms=100)
                 if rgb_frame is not None:
-                    last_frame_time = time.time()
-
                     if self._cloud_mode:
                         if self._video_mode and self.cloud_manager:
                             if self.cloud_manager.send_frame(rgb_frame):


### PR DESCRIPTION
The input source loop throttled frame reception based on pipeline FPS, creating a feedback loop: sleep(1/FPS) + receive_latency caused the effective input rate to always undershoot the target, driving FPS downward. For sources with non-trivial receive overhead (NDI, Syphon) this spiraled to ~5.6fps (v0.1.6) or ~2.8fps (v0.1.7). The v0.1.7 regression was caused by the batch-level FPS tracking (66e8d311) being more stable — the old per-frame jitter partially counteracted the spiral via temporary FPS overshoots.

Now the loop receives as fast as the source provides, matching the WebRTC camera input path. Backpressure is handled by put_nowait() dropping frames when the queue is full.