### PR TITLE
fix: add WebSocket heartbeat to prevent code=1006 disconnections

### DIFF
--- a/src/scope/server/cloud_connection.py
+++ b/src/scope/server/cloud_connection.py
@@ -151,7 +151,7 @@ class CloudConnectionManager:
         self._session = aiohttp.ClientSession()
         try:
             self.ws = await asyncio.wait_for(
-                self._session.ws_connect(ws_url),
+                self._session.ws_connect(ws_url, heartbeat=30.0),
                 timeout=30.0,
             )
         except TimeoutError:


### PR DESCRIPTION
## Problem

Closes #707

Users experience abrupt cloud WebSocket disconnections (code=1006, reason=None) after 10-30+ minutes of use. Code 1006 means "abnormal closure" — the TCP connection was dropped without a WebSocket close frame.

Looking at the log from #707:
- Connected at `15:50:49`
- ~15 min idle while setting up
- Krea pipeline started at `16:05:57`
- WebSocket dropped at `16:15:59` (~10 min into active use)

## Root Cause

`aiohttp.ws_connect` has no `heartbeat` set, so it never sends WebSocket ping frames. NAT gateways, proxies, and firewalls commonly drop TCP connections that appear idle (no traffic for some period). When the connection is dropped silently at the TCP level, there's no WebSocket close frame — hence code=1006 with `reason=None`.

This is a well-known aiohttp pattern: without `heartbeat`, long-running WebSocket connections die through middleboxes.

## Fix

Add `heartbeat=30.0` to `ws_connect`. This causes aiohttp to send a WebSocket ping frame every 30 seconds, which:
1. Keeps the TCP connection alive through NAT/proxy/firewall idle timeouts
2. Detects dead connections within ~30s (pong timeout) rather than hanging silently

## Change

```diff
- self._session.ws_connect(ws_url),
+ self._session.ws_connect(ws_url, heartbeat=30.0),
```

One line. The `heartbeat` parameter is built into aiohttp and has no dependencies.