### PR TITLE
Fix: tempo sync modulation interfering with VACE noise scale.

### DIFF
--- a/src/scope/core/pipelines/defaults.py
+++ b/src/scope/core/pipelines/defaults.py
@@ -102,12 +102,14 @@ def apply_mode_defaults_to_state(
     if "denoising_step_list" not in kwargs and config.denoising_steps:
         state.set("denoising_step_list", config.denoising_steps)
 
-    # For text mode, noise controls should be None unless explicitly provided
-    # (e.g. by the modulation engine injecting values into kwargs)
+    # For text mode, noise controls should be None unless the modulation
+    # engine explicitly injected a noise_scale value into kwargs.
+    # We cannot simply check "noise_scale" in kwargs because VACE video
+    # input resolves to text mode yet carries noise params from initial
+    # parameters — those must still be cleared.
     if mode == INPUT_MODE_TEXT:
-        if "noise_scale" not in kwargs:
+        if not kwargs.get("_modulated_noise_scale"):
             state.set("noise_scale", None)
-        if "noise_controller" not in kwargs:
             state.set("noise_controller", None)
     else:
         # For video mode, apply defaults if not provided

--- a/src/scope/server/modulation.py
+++ b/src/scope/server/modulation.py
@@ -256,6 +256,7 @@ class ModulationEngine:
         # otherwise the controller overwrites the modulated value with its own.
         if "noise_scale" in modulated_keys:
             params["noise_controller"] = False
+            params["_modulated_noise_scale"] = True
 
         # Prevent SetTimestepsBlock from triggering a cache reset every frame
         # when the step list is being continuously modulated.


### PR DESCRIPTION
https://github.com/daydreamlive/scope/pull/703 changed `apply_mode_defaults_to_state` to conditionally skip setting `noise_scale` and `noise_controller` to None in text mode:

```
// Before PR #703 (unconditional):
state.set("noise_scale", None)
state.set("noise_controller", None)
```

```
if mode == INPUT_MODE_TEXT:
    if "noise_scale" not in kwargs:
        state.set("noise_scale", None)
    if "noise_controller" not in kwargs:
        state.set("noise_controller", None)
```

This was done so the modulation engine could inject noise_scale into kwargs without it being overridden. However, it has a side effect that breaks VACE with video input.