### PR TITLE
Flush audio buffer on prompt change for immediate TTS playback

### DIFF
--- a/src/scope/server/audio_track.py
+++ b/src/scope/server/audio_track.py
@@ -10,6 +10,7 @@ from aiortc.mediastreams import MediaStreamError
 from av import AudioFrame
 
 from .frame_processor import FrameProcessor
+from .pipeline_processor import AUDIO_FLUSH_SENTINEL
 
 logger = logging.getLogger(__name__)
 
@@ -17,10 +18,11 @@ logger = logging.getLogger(__name__)
 AUDIO_CLOCK_RATE = 48000  # Standard WebRTC audio clock rate (48 kHz for Opus)
 AUDIO_PTIME = 0.020  # 20ms audio frames (standard for WebRTC)
 AUDIO_TIME_BASE = fractions.Fraction(1, AUDIO_CLOCK_RATE)
-# Maximum buffered audio before we start dropping oldest samples (3 seconds).
+# Maximum buffered audio before we start dropping oldest samples (60 seconds).
 # Must be large enough for bursty pipelines like LTX2 that deliver >1s of audio
-# in a single chunk after each denoising pass.
-AUDIO_MAX_BUFFER_SAMPLES = AUDIO_CLOCK_RATE * 3
+# in a single chunk after each denoising pass, and for TTS pipelines that may
+# generate many seconds of speech before playback catches up.
+AUDIO_MAX_BUFFER_SAMPLES = AUDIO_CLOCK_RATE * 60
 
 
 class AudioProcessingTrack(MediaStreamTrack):
@@ -99,8 +101,16 @@ class AudioProcessingTrack(MediaStreamTrack):
         # for bursty or small-chunk pipelines.
         while True:
             audio_tensor, sample_rate = self.frame_processor.get_audio()
-            if audio_tensor is None or sample_rate is None:
+            if audio_tensor is None and sample_rate is None:
                 break
+
+            # Flush sentinel: discard buffered audio so a new prompt
+            # is heard immediately instead of after the old speech finishes.
+            if audio_tensor is None and sample_rate == AUDIO_FLUSH_SENTINEL:
+                self._chunks.clear()
+                self._buffered_samples = 0
+                logger.info("Audio buffer flushed (prompt change)")
+                continue
 
             if not self._first_audio_logged:
                 logger.info(

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -541,6 +541,7 @@ class FrameProcessor:
 
         try:
             audio, sample_rate = self._sink_processor.audio_output_queue.get_nowait()
+            # Pass through flush sentinels (audio=None, sample_rate=-1)
             return audio, sample_rate
         except queue.Empty:
             return None, None

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -23,6 +23,10 @@ OUTPUT_QUEUE_MAX_SIZE_FACTOR = 2
 
 SLEEP_TIME = 0.01
 
+# Sentinel sample_rate value used to signal the audio track to flush its buffer.
+# Sent as (None, AUDIO_FLUSH_SENTINEL) through the audio_output_queue.
+AUDIO_FLUSH_SENTINEL = -1
+
 # FPS calculation constants
 MIN_FPS = 1.0  # Minimum FPS to prevent division by zero
 MAX_FPS = 60.0  # Maximum FPS cap
@@ -77,8 +81,10 @@ class PipelineProcessor:
 
         # Audio output queue: (audio_tensor, sample_rate) tuples.
         # Consumed by FrameProcessor.get_audio() on the sink processor.
+        # Flushed on prompt change, so only needs enough headroom for
+        # bursty production (pipeline thread outpacing real-time playback).
         self.audio_output_queue: queue.Queue[tuple[torch.Tensor, int]] = queue.Queue(
-            maxsize=30
+            maxsize=10
         )
 
         # Current parameters used by processing thread
@@ -225,6 +231,22 @@ class PipelineProcessor:
 
         logger.info(f"PipelineProcessor stopped for pipeline: {self.pipeline_id}")
 
+    def _flush_audio(self):
+        """Drain the audio output queue and send a flush sentinel.
+
+        Called when prompts change so the audio track discards buffered
+        audio from the previous prompt and plays the new speech immediately.
+        """
+        while not self.audio_output_queue.empty():
+            try:
+                self.audio_output_queue.get_nowait()
+            except queue.Empty:
+                break
+        try:
+            self.audio_output_queue.put_nowait((None, AUDIO_FLUSH_SENTINEL))
+        except queue.Full:
+            pass
+
     def update_parameters(self, parameters: dict[str, Any]):
         """Update parameters that will be used in the next pipeline call."""
         try:
@@ -318,6 +340,14 @@ class PipelineProcessor:
         try:
             new_parameters = self.parameters_queue.get_nowait()
             if new_parameters != self.parameters:
+                # Flush stale audio when prompts change so the new
+                # speech is heard immediately instead of after the old
+                # audio finishes playing.
+                if "prompts" in new_parameters and new_parameters.get(
+                    "prompts"
+                ) != self.parameters.get("prompts"):
+                    self._flush_audio()
+
                 # Clear stale transition when new prompts arrive without transition
                 if (
                     "prompts" in new_parameters


### PR DESCRIPTION
When prompts change, drain the audio output queue and send a flush sentinel so the audio track discards buffered speech from the previous prompt. Also increases the max audio buffer to 60s for TTS pipelines and reduces the audio output queue size to 10 (since it's now flushed on prompt changes).

For the context, I haven't yet decided if when we should flash audio. Maybe it's the UI that should decide (kind-of like cache reset), or maybe pipeline should return an information that the audio should be flushed. But for now, let's use the "workaround" to flush when there is a new prompt happening.