### PR TITLE
fix(settings): show preprocessors for pipelines with text default mode (#729)

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -639,6 +639,22 @@ export function SettingsPanel({
               const isPreprocessor =
                 info.usage?.includes("preprocessor") ?? false;
               if (!isPreprocessor) return false;
+              // Show preprocessors that are compatible with any mode the current
+              // pipeline supports, not just the currently-active inputMode.
+              // This ensures preprocessors remain visible for pipelines like
+              // LongLive/Krea/MemFlow/RewardForcing whose defaultMode is "text"
+              // even though their video preprocessors require "video" mode.
+              // Incompatible preprocessors are already cleared in handleModeChange
+              // when the user actually switches inputMode, so we don't need to
+              // hide them here too.
+              const pipelineModes = currentPipeline?.supportedModes ?? [];
+              if (pipelineModes.length > 0) {
+                return (
+                  info.supportedModes?.some(m => pipelineModes.includes(m)) ??
+                  false
+                );
+              }
+              // Fallback: filter by current inputMode if pipeline modes are unknown
               if (inputMode) {
                 return info.supportedModes?.includes(inputMode) ?? false;
               }


### PR DESCRIPTION
## Problem

Closes #729

Pipelines like **LongLive, Krea, MemFlow, and RewardForcing** have `defaultMode='text'`. When selected, the UI sets `inputMode='text'`. All built-in preprocessors (`gray`, `scribble`, `optical_flow`, `video_depth_anything`) only support `video` mode.

The previous preprocessor availability filter filtered by the **currently-active `inputMode`**, so when `inputMode='text'`, no preprocessors passed the filter and the dropdown showed a disabled **"None"** — appearing broken.

StreamDiffusion V2 was unaffected because its `defaultMode='video'`, so `inputMode` was already `'video'` when preprocessors were visible.

The bug is most noticeable in Remote Inference mode because users start fresh with these AI pipelines in `text` mode (no local camera required), whereas in local mode users are more likely to already be in `video` mode from a prior pipeline selection.

## Fix

Change the preprocessor availability filter to match preprocessors compatible with **any mode the current pipeline supports**, rather than the current `inputMode`. This ensures video preprocessors remain visible for multi-mode pipelines (`text` + `video`) even when `inputMode='text'`.

Incompatible preprocessors are already cleared by `handleModeChange` when the user switches `inputMode`, so the extra filter in the dropdown was redundant and harmful.

## Changes

- `frontend/src/components/SettingsPanel.tsx`: update preprocessor `availablePipelines` filter to match against pipeline-supported modes instead of current inputMode

## Testing

1. Enable Remote Inference
2. Select LongLive, Krea, MemFlow, or RewardForcing as the main pipeline
3. Verify preprocessors (e.g. `gray`, `scribble`) now appear in the Preprocessor dropdown
4. Verify switching to StreamDiffusion V2 still shows preprocessors (regression check)
5. Verify switching input mode to `text` on a video-only pipeline still hides video preprocessors (text-only pipelines like a hypothetical passthrough-text have no video modes to match)