### PR TITLE
fix(kafka): improve Kafka producer resilience

### DIFF
--- a/src/scope/server/kafka_publisher.py
+++ b/src/scope/server/kafka_publisher.py
@@ -46,6 +46,7 @@ class KafkaPublisher:
         self._started = False
         self._event_loop: asyncio.AbstractEventLoop | None = None
         self._lock = threading.Lock()
+        self._consecutive_failures: int = 0
 
     async def start(self) -> bool:
         """Start the Kafka producer.
@@ -65,6 +66,9 @@ class KafkaPublisher:
                 "bootstrap_servers": KAFKA_BOOTSTRAP_SERVERS,
                 "value_serializer": lambda v: json.dumps(v).encode("utf-8"),
                 "key_serializer": lambda k: k.encode("utf-8") if k else None,
+                "request_timeout_ms": 10000,     # 10s per-request timeout
+                "retry_backoff_ms": 500,         # 500ms backoff between retries
+                "connections_max_idle_ms": 60000,  # 60s idle connection timeout
             }
 
             # Add SASL authentication if configured
@@ -188,12 +192,19 @@ class KafkaPublisher:
             # Use event ID as key (matching Go format)
             key = event_id
             await self._producer.send_and_wait(KAFKA_TOPIC, value=event, key=key)
+            self._consecutive_failures = 0
             logger.info(
                 f"Published Kafka event: {event_type} (id={event_id}, session={session_id})"
             )
             return True
         except Exception as e:
             logger.error(f"Failed to publish Kafka event {event_type}: {e}")
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= 5:
+                logger.warning(
+                    f"[KafkaPublisher] {self._consecutive_failures} consecutive send failures "
+                    "— broker may be unavailable or partition is rebalancing"
+                )
             return False
 
     def publish(
@@ -247,6 +258,11 @@ class KafkaPublisher:
                 logger.debug(f"Scheduled Kafka event: {event_type}")
             except Exception as e:
                 logger.error(f"Failed to schedule Kafka event publish: {e}")
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Number of consecutive send failures since last success."""
+        return self._consecutive_failures
 
     @property
     def is_running(self) -> bool:


### PR DESCRIPTION
Reference issue https://github.com/daydreamlive/scope/issues/732 — adds explicit retry/timeout config to aiokafka producer and tracks consecutive failures for alerting.

## Changes

- **Retry/timeout config**: Added `request_timeout_ms` (10s), `retry_backoff_ms` (500ms), and `connections_max_idle_ms` (60s) to the aiokafka producer config. These were previously unset, leaving the producer with library defaults that contributed to the 17-min silent failure window documented in #732.
- **Consecutive failure tracking**: Added `_consecutive_failures` counter that increments on each failed `send_and_wait` and resets on success. Emits a `WARNING` log after ≥5 consecutive failures to signal broker unavailability or partition rebalancing.
- **`consecutive_failures` property**: Exposes the counter for external monitoring/health checks.