### PR TITLE
Fix telemetry disclosure: click handling, skip intro, existing user t…

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "source ~/.nvm/nvm.sh && cd frontend && npm run dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/frontend/src/components/onboarding/CloudConnectingStep.tsx
+++ b/frontend/src/components/onboarding/CloudConnectingStep.tsx
@@ -147,7 +147,7 @@ export function CloudConnectingStep({ onConnected }: CloudConnectingStepProps) {
   if (!surveyDone && !telemetrySkippedSurvey) {
     return (
       <div className="flex flex-col items-center gap-6 w-full max-w-md mx-auto">
-        <CloudSurveyScreens onComplete={handleSurveyComplete} />
+        <CloudSurveyScreens onComplete={handleSurveyComplete} initialScreen="referral" />
         {/* Small connection status at bottom */}
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {isConnected ? (

--- a/frontend/src/components/onboarding/TelemetryDisclosure.tsx
+++ b/frontend/src/components/onboarding/TelemetryDisclosure.tsx
@@ -83,7 +83,7 @@ export function TelemetryDisclosure({
     : 0;
 
   return (
-    <div className="w-full max-w-md mx-auto animate-in fade-in-0 slide-in-from-bottom-4 duration-500">
+    <div className="relative z-20 w-full max-w-md mx-auto pointer-events-auto animate-in fade-in-0 slide-in-from-bottom-4 duration-500">
       <div className="rounded-xl border border-border/50 bg-card/80 backdrop-blur-sm p-6 space-y-4">
         <div className="flex items-center gap-3">
           <div className="flex items-center justify-center h-8 w-8 rounded-lg bg-muted">

--- a/frontend/src/contexts/TelemetryContext.tsx
+++ b/frontend/src/contexts/TelemetryContext.tsx
@@ -6,6 +6,8 @@ import {
   useEffect,
   type ReactNode,
 } from "react";
+import { toast } from "sonner";
+import { track } from "../lib/telemetry";
 import {
   initTelemetry,
   identifyUser,
@@ -22,6 +24,7 @@ import {
   getDaydreamUserDisplayName,
   getDaydreamUserEmail,
 } from "../lib/auth";
+import { fetchOnboardingStatus } from "../lib/onboardingStorage";
 
 // ---------------------------------------------------------------------------
 // Context shape
@@ -55,7 +58,7 @@ export function TelemetryProvider({ children }: { children: ReactNode }) {
   const [isEnvDisabled] = useState(() => isEnvTelemetryDisabled());
   const [isDisclosed, setIsDisclosed] = useState(() => checkDisclosed());
 
-  // Initialize Mixpanel SDK on mount, and if user is already logged in,
+  // Initialize analytics SDK on mount, and if user is already logged in,
   // identify them so events are associated with their daydream account.
   useEffect(() => {
     initTelemetry();
@@ -63,6 +66,55 @@ export function TelemetryProvider({ children }: { children: ReactNode }) {
     if (userId) {
       identifyUser(userId, getDaydreamUserDisplayName(), getDaydreamUserEmail());
     }
+
+    // For existing users who completed onboarding before analytics was added,
+    // show an opt-in toast (the onboarding flow handles its own disclosure).
+    if (!checkDisclosed()) {
+      fetchOnboardingStatus().then((status) => {
+        if (status.completed) {
+          track("telemetry_disclosure_shown", { path: "existing_user_banner" });
+          const shownAt = Date.now();
+          toast(
+            "Help us improve Scope by sending anonymous usage data. We track UI interactions and feature usage patterns, and we do not collect prompts, parameters, file paths, videos, images, or session replays.",
+            {
+              duration: Infinity,
+              dismissible: false,
+              action: {
+                label: "Yes",
+                onClick: () => {
+                  persistDisclosed();
+                  setIsDisclosed(true);
+                  setTelemetryEnabled(true);
+                  setIsEnabled(true);
+                  flushTelemetryQueue();
+                  track("telemetry_disclosure_responded", {
+                    action: "accepted",
+                    path: "existing_user_banner",
+                    time_to_respond_ms: Date.now() - shownAt,
+                    auto_advanced: false,
+                  });
+                },
+              },
+              cancel: {
+                label: "No thanks",
+                onClick: () => {
+                  persistDisclosed();
+                  setIsDisclosed(true);
+                  dropTelemetryQueue();
+                  track("telemetry_disclosure_responded", {
+                    action: "disabled",
+                    path: "existing_user_banner",
+                    time_to_respond_ms: Date.now() - shownAt,
+                    auto_advanced: false,
+                  });
+                },
+              },
+            },
+          );
+        }
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const setEnabled = useCallback((enabled: boolean) => {


### PR DESCRIPTION
…oast

- Add relative z-20 + pointer-events-auto to TelemetryDisclosure to fix clicks being blocked by backdrop-blur stacking context
- Skip "let's get to know each other" intro after accepting telemetry by passing initialScreen="referral" to CloudSurveyScreens
- Restore existing-user toast disclosure in TelemetryContext for users who completed onboarding before analytics was added