### PR TITLE
fix(frame_processor): force text mode for sourceless graphs

### DIFF
--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -1090,6 +1090,14 @@ class FrameProcessor:
         graph_data = self.parameters.get("graph")
         if graph_data is not None:
             api_graph = GraphConfig.model_validate(graph_data)
+
+            # A graph without source nodes cannot receive video input.
+            # Force text mode so pipeline processors don't wait forever
+            # for frames that will never arrive (e.g. Workflow Builder
+            # with no Source node connected to cloud).
+            if not api_graph.get_source_node_ids():
+                self.parameters["input_mode"] = "text"
+                self._video_mode = False
         else:
             # Determine which pipelines should receive input as vace_input_frames
             vace_input_video_ids: set[str] = set()


### PR DESCRIPTION
When a graph has no source nodes, force input_mode to text so pipeline processors do not wait forever for video frames that can never arrive. This fixes Workflow Builder + Cloud with no Source node.