### PR TITLE
fal: Set request timeout to 120 minutes.

### DIFF
--- a/src/scope/cloud/fal_app.py
+++ b/src/scope/cloud/fal_app.py
@@ -271,7 +271,7 @@ def _should_forward_log(line: str) -> bool:
 
 # Connection timeout settings
 MAX_CONNECTION_DURATION_SECONDS = (
-    3600  # Close connection after 60 minutes regardless of activity
+    7200  # Close connection after 120 minutes regardless of activity
 )
 TIMEOUT_CHECK_INTERVAL_SECONDS = 60  # Check for timeout every 60 seconds
 


### PR DESCRIPTION
Note there is still a fal-side limit of 60 minutes so that will have to be manually updated on the dashboard as well.

Newly created PR review branches still have a 60 minute limit.