### PR TITLE
fix(yolo pipeline): handle 5D batch tensors in graph stream queues

### DIFF
--- a/src/scope/core/pipelines/wan2_1/blocks/preprocess_video.py
+++ b/src/scope/core/pipelines/wan2_1/blocks/preprocess_video.py
@@ -44,6 +44,12 @@ class PreprocessVideoBlock(ModularPipelineBlocks):
                 description="Input frames for VACE conditioning",
             ),
             InputParam(
+                "vace_input_masks",
+                default=None,
+                type_hint=list[torch.Tensor] | torch.Tensor | None,
+                description="Input masks for VACE conditioning",
+            ),
+            InputParam(
                 "height",
                 required=True,
                 type_hint=int,
@@ -107,6 +113,18 @@ class PreprocessVideoBlock(ModularPipelineBlocks):
                 target_num_frames=target_num_frames,
             )
 
+        if block_state.vace_input_masks is not None and isinstance(
+            block_state.vace_input_masks, list
+        ):
+            block_state.vace_input_masks = preprocess_masks(
+                block_state.vace_input_masks,
+                device=components.config.device,
+                dtype=components.config.dtype,
+                height=block_state.height,
+                width=block_state.width,
+                target_num_frames=target_num_frames,
+            )
+
         self.set_block_state(state, block_state)
         return components, state
 
@@ -144,3 +162,45 @@ def preprocess_video(
         video = video[:, :, indices]
 
     return video
+
+
+def preprocess_masks(
+    masks: list[torch.Tensor],
+    device: torch.device,
+    dtype: torch.dtype,
+    height: int,
+    width: int,
+    target_num_frames: int,
+) -> torch.Tensor:
+    """Preprocess mask frames from list of THWC tensors to [B, 1, F, H, W] tensor.
+
+    Unlike preprocess_video, masks are normalized to [0, 1] (not [-1, 1]).
+    """
+    from einops import rearrange
+
+    from scope.core.pipelines.process import normalize_frame_sizes
+
+    masks = normalize_frame_sizes(
+        masks, target_height=height, target_width=width, device=device, dtype=dtype
+    )
+
+    # Stack and rearrange: list of [1, H, W, C] -> [B, C, T, H, W]
+    masks = rearrange(torch.stack(masks, dim=1), "B T H W C -> B C T H W")
+    # Normalize from [0, 255] uint8 to [0, 1] float (binary masks)
+    masks = (masks.float() / 255.0).clamp(0, 1)
+
+    _, _, num_frames, _, _ = masks.shape
+    if num_frames != target_num_frames:
+        indices = (
+            torch.linspace(
+                0,
+                num_frames - 1,
+                target_num_frames,
+                device=masks.device,
+            )
+            .round()
+            .long()
+        )
+        masks = masks[:, :, indices]
+
+    return masks

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -529,6 +529,22 @@ class PipelineProcessor:
                 queues = self.output_queues.get(port)
                 if not queues:
                     continue
+                # Convert batch-format tensors [B, C, F, H, W] to frame format
+                # [B*F, H, W, C] so they can be split and queued as individual
+                # frames.  This handles outputs from preprocessor pipelines
+                # (e.g. VACE frames/masks) which produce pre-batched 5D tensors
+                # rather than per-frame 4D tensors.
+                if value.dim() == 5:
+                    b, c, f, h, w = value.shape
+                    value = (
+                        value.permute(0, 2, 3, 4, 1)
+                        .reshape(b * f, h, w, c)
+                        .contiguous()
+                    )
+                    # Convert [-1, 1] to [0, 1] for uint8 encoding; downstream
+                    # preprocess_chunk reverses this via (x / 255) * 2 - 1.
+                    if value.min() < 0:
+                        value = (value + 1.0) / 2.0
                 # Resize output queues to fit at least one full batch
                 target_size = value.shape[0] * OUTPUT_QUEUE_MAX_SIZE_FACTOR
                 self._resize_output_queue(port, target_size)


### PR DESCRIPTION
In Perform Mode, preprocessor outputs like vace_input_frames and vace_input_masks bypass stream queues and are passed as raw [B,C,F,H,W] tensors via the parameter path. In Graph Mode (Workflow Builder), these ports have explicit stream edges, so the queue system tried to apply uint8 conversion and dim-0 frame splitting—which mangles 5D tensors.

Convert 5D [B,C,F,H,W] tensors to [B*F,H,W,C] frame format before queuing, and add mask preprocessing in PreprocessVideoBlock so masks arriving as frame lists are properly assembled into [B,1,F,H,W] tensors.