### PR TITLE
fix(cloud_connection): retry on timeout waiting for ready from cloud runner

### DIFF
--- a/src/scope/server/cloud_connection.py
+++ b/src/scope/server/cloud_connection.py
@@ -233,6 +233,10 @@ class CloudConnectionManager:
         Unlike connect(), this returns immediately and runs the connection
         in an asyncio task. Check get_status() for connection progress.
 
+        Automatically retries on timeout (cold-start can be slow) with
+        exponential back-off up to MAX_CONNECT_RETRIES attempts before
+        giving up and surfacing the final error.
+
         Args:
             app_id: The cloud app ID
             api_key: The cloud API key
@@ -249,18 +253,59 @@ class CloudConnectionManager:
         self._connecting = True
         self._connect_error = None
 
+        # Retry configuration: 3 attempts with 5 s back-off between each.
+        # Only "ready" timeouts are retried; auth/config errors fail immediately.
+        _MAX_RETRIES = 3
+        _RETRY_DELAY_SECONDS = 5.0
+        _RETRYABLE_PHRASE = "Timeout waiting for 'ready'"
+
         async def _do_connect():
-            try:
-                await self.connect(app_id, api_key, user_id)
-                self._connecting = False
-            except Exception as e:
-                self._connecting = False
-                self._connect_error = str(e)
-                self._connect_stage = None
-                logger.error(f"Background cloud connection failed: {e}")
-                self._publish_cloud_error(
-                    str(e), type(e).__name__, error_type="cloud_connection_failed"
-                )
+            for attempt in range(1, _MAX_RETRIES + 1):
+                try:
+                    await self.connect(app_id, api_key, user_id)
+                    # Success — clear any transient error from a previous attempt
+                    self._connecting = False
+                    self._connect_error = None
+                    return
+                except asyncio.CancelledError:
+                    # Cancelled externally (e.g. user toggled cloud off) — stop immediately
+                    self._connecting = False
+                    self._connect_stage = None
+                    raise
+                except Exception as e:
+                    error_str = str(e)
+                    is_timeout = _RETRYABLE_PHRASE in error_str
+
+                    if is_timeout and attempt < _MAX_RETRIES:
+                        # Transient cold-start timeout — schedule a retry
+                        self._connect_error = None  # don't surface partial error yet
+                        self._connect_stage = (
+                            f"Cloud runner still starting… retrying "
+                            f"({attempt}/{_MAX_RETRIES - 1})"
+                        )
+                        logger.warning(
+                            f"Cloud connection attempt {attempt}/{_MAX_RETRIES} timed out; "
+                            f"retrying in {_RETRY_DELAY_SECONDS}s…"
+                        )
+                        try:
+                            await asyncio.sleep(_RETRY_DELAY_SECONDS)
+                        except asyncio.CancelledError:
+                            self._connecting = False
+                            self._connect_stage = None
+                            raise
+                        # Continue loop for next attempt
+                    else:
+                        # Non-retryable error OR exhausted retries — surface to user
+                        self._connecting = False
+                        self._connect_error = error_str
+                        self._connect_stage = None
+                        logger.error(f"Background cloud connection failed: {e}")
+                        self._publish_cloud_error(
+                            error_str,
+                            type(e).__name__,
+                            error_type="cloud_connection_failed",
+                        )
+                        return
 
         self._connect_task = asyncio.create_task(_do_connect())
 


### PR DESCRIPTION
## Problem

Issue #743: Users hitting `Timeout waiting for 'ready' from cloud server` and getting stuck — no recovery without manually toggling cloud mode off and back on.

The root cause: when `connect()` times out waiting for the cloud runner's `ready` message, `connect_background()` set `_connecting = False` and surfaced the error immediately. The frontend stopped polling (neither `connecting` nor `connected` was true) leaving the user with a dead error state.

## Fix

Added retry-with-back-off inside `connect_background()`:

- **3 attempts** before giving up
- **5 s delay** between retries
- Only **'ready' timeouts** are retried — auth/config errors fail immediately
- `_connecting` stays `True` and `connect_stage` shows a human-readable retry message while retrying, so the frontend keeps polling and progress is visible
- `asyncio.CancelledError` is re-raised immediately, so toggling cloud off mid-retry still works correctly

## Testing

1. Set `SCOPE_CLOUD_APP_ID` to a valid but slow-to-cold-start app
2. Toggle cloud mode ON
3. Verify the UI shows 'Cloud runner still starting… retrying (1/2)' instead of an error
4. Eventually succeeds (or fails cleanly after 3 attempts with a clear error)

Closes #743