### PR TITLE
fix(torch-compile): handle inductor SubprocException with eager fallback

### DIFF
--- a/src/scope/core/pipelines/krea_realtime_video/modules/causal_model.py
+++ b/src/scope/core/pipelines/krea_realtime_video/modules/causal_model.py
@@ -12,6 +12,7 @@ from torch.nn.attention.flex_attention import (
     flex_attention,
 )
 
+from scope.core.pipelines.utils import compile_with_inductor_fallback
 from scope.core.pipelines.wan2_1.modules.attention import attention
 from .model import (
     WAN_CROSSATTENTION_CLASSES,
@@ -23,7 +24,9 @@ from .model import (
     sinusoidal_embedding_1d,
 )
 
-flex_attention = torch.compile(
+# Wrapped with compile_with_inductor_fallback to handle SubprocException from the inductor subprocess
+# worker pool (e.g. FD/memory exhaustion on fal.ai workers) — falls back to eager execution automatically.
+flex_attention = compile_with_inductor_fallback(
     flex_attention, dynamic=False, mode="max-autotune-no-cudagraphs"
 )
 

--- a/src/scope/core/pipelines/longlive/modules/causal_model.py
+++ b/src/scope/core/pipelines/longlive/modules/causal_model.py
@@ -12,6 +12,7 @@ from torch.nn.attention.flex_attention import (
     flex_attention,
 )
 
+from scope.core.pipelines.utils import compile_with_inductor_fallback
 from scope.core.pipelines.wan2_1.modules.attention import attention
 from .model import (
     WAN_CROSSATTENTION_CLASSES,
@@ -26,7 +27,9 @@ from .model import (
 # wan 1.3B model has a weird channel / head configurations and require max-autotune to work with flexattention
 # see https://github.com/pytorch/pytorch/issues/133254
 # change to default for other models
-flex_attention = torch.compile(
+# Wrapped with compile_with_inductor_fallback to handle SubprocException from the inductor subprocess
+# worker pool (e.g. FD/memory exhaustion on fal.ai workers) — falls back to eager execution automatically.
+flex_attention = compile_with_inductor_fallback(
     flex_attention, dynamic=False, mode="max-autotune-no-cudagraphs"
 )
 

--- a/src/scope/core/pipelines/streamdiffusionv2/modules/causal_model.py
+++ b/src/scope/core/pipelines/streamdiffusionv2/modules/causal_model.py
@@ -1,4 +1,5 @@
 # Modified from https://github.com/chenfengxu714/StreamdiffusionV2
+from scope.core.pipelines.utils import compile_with_inductor_fallback
 from scope.core.pipelines.wan2_1.modules.attention import attention
 from .model import (
     WanRMSNorm,
@@ -22,7 +23,11 @@ import math
 # see https://github.com/pytorch/pytorch/issues/133254
 # change to default for other models
 # Changed from max-autotune to max-autotune-no-cudagraphs because max-autotune did not play well with VACE code.
-flex_attention = torch.compile(flex_attention, dynamic=False, mode="max-autotune-no-cudagraphs")
+# Wrapped with compile_with_inductor_fallback to handle SubprocException from the inductor subprocess
+# worker pool (e.g. FD/memory exhaustion on fal.ai workers) — falls back to eager execution automatically.
+flex_attention = compile_with_inductor_fallback(
+    flex_attention, dynamic=False, mode="max-autotune-no-cudagraphs"
+)
 
 
 def causal_rope_apply(x, grid_sizes, freqs, start_frame=0):

--- a/src/scope/core/pipelines/utils.py
+++ b/src/scope/core/pipelines/utils.py
@@ -1,14 +1,76 @@
 import json
+import logging
 import os
 from pathlib import Path
+from typing import Any, Callable
 
 import torch
 from omegaconf import OmegaConf
 from safetensors.torch import load_file as load_safetensors
 
+logger = logging.getLogger(__name__)
+
 # Re-export enums for backwards compatibility
 from .enums import Quantization as Quantization  # noqa: PLC0414
 from .enums import VaeType as VaeType  # noqa: PLC0414
+
+
+def compile_with_inductor_fallback(
+    fn: Callable, *args: Any, eager_fallback: Callable | None = None, **kwargs: Any
+) -> Callable:
+    """Wrap ``torch.compile`` with a graceful eager fallback on ``InductorError``.
+
+    ``torch.inductor`` uses a subprocess worker pool for kernel compilation.  On
+    some hosting environments (e.g. fal.ai H100 workers) these subprocesses can
+    fail due to resource limits (FD exhaustion, memory pressure, or a locked
+    ``torch_compile_debug`` cache directory), raising ``SubprocException`` wrapped
+    in ``InductorError``.
+
+    This helper attempts ``torch.compile(fn, ...)`` and, if an ``InductorError``
+    is raised *at call time* (i.e. during JIT compilation on the first forward
+    pass), falls back to eager execution.  The actual inner exception message is
+    logged so the underlying cause can be diagnosed.
+
+    Args:
+        fn: The callable to compile.
+        *args: Positional arguments forwarded to ``torch.compile``.
+        eager_fallback: Optional replacement to use when compilation fails.
+            Defaults to the original ``fn`` (uncompiled eager execution).
+        **kwargs: Keyword arguments forwarded to ``torch.compile``.
+
+    Returns:
+        A compiled function that transparently falls back to eager execution on
+        ``InductorError`` / ``SubprocException``.
+    """
+    compiled_fn = torch.compile(fn, *args, **kwargs)
+    _fallback = eager_fallback if eager_fallback is not None else fn
+    _active: list[Callable] = [compiled_fn]  # mutable so the closure can swap it
+
+    def _wrapper(*call_args: Any, **call_kwargs: Any) -> Any:
+        try:
+            return _active[0](*call_args, **call_kwargs)
+        except Exception as exc:
+            # torch._inductor.exc.InductorError wraps SubprocException.
+            # Check by class name to avoid a hard import of the inductor module.
+            exc_type = type(exc).__name__
+            inner_exc = getattr(exc, "inner_exception", None)
+            if exc_type == "InductorError" or (
+                inner_exc is not None
+                and "SubprocException" in type(inner_exc).__name__
+            ):
+                inner_msg = str(inner_exc) if inner_exc is not None else str(exc)
+                logger.warning(
+                    "torch.inductor SubprocException during compilation of %s — "
+                    "falling back to eager execution.  Inner exception: %s",
+                    getattr(fn, "__name__", repr(fn)),
+                    inner_msg,
+                )
+                # Permanently swap to eager so subsequent calls skip compile entirely.
+                _active[0] = _fallback
+                return _fallback(*call_args, **call_kwargs)
+            raise  # re-raise unrelated errors unchanged
+
+    return _wrapper  # type: ignore[return-value]
 
 
 def load_state_dict(weights_path: str) -> dict:

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -306,6 +306,20 @@ class PipelineManager:
 
             models_dir = get_models_dir()
             error_msg = f"Failed to load pipeline {key}: {e}"
+            # For InductorError / SubprocException, log the inner exception too so the
+            # actual subprocess failure reason is visible in logs rather than the wrapper.
+            inner_exc = getattr(e, "inner_exception", None)
+            if type(e).__name__ == "InductorError" or (
+                inner_exc is not None
+                and "SubprocException" in type(inner_exc).__name__
+            ):
+                inner_msg = str(inner_exc) if inner_exc is not None else str(e)
+                logger.error(
+                    "torch.inductor SubprocException during pipeline load for %s — "
+                    "inner exception: %s",
+                    key,
+                    inner_msg,
+                )
             logger.error(
                 f"{error_msg}. If this error persists, consider removing the models "
                 f"directory '{models_dir}' and re-downloading models."

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -704,7 +704,28 @@ class PipelineProcessor:
 
     @staticmethod
     def _is_recoverable(error: Exception) -> bool:
-        """Check if an error is recoverable."""
+        """Check if an error is recoverable.
+
+        Returns False for errors that make further processing impossible:
+        - CUDA OOM (GPU state is unreliable)
+        - InductorError / SubprocException (torch.compile subprocess pool failed;
+          retrying without fallback would loop indefinitely — the compile_with_inductor_fallback
+          wrapper in causal_model.py handles graceful degradation at the call site, but if an
+          InductorError still reaches here it means there is no fallback path available)
+        """
         if isinstance(error, torch.cuda.OutOfMemoryError):
+            return False
+        # Detect InductorError / SubprocException by class name to avoid a hard
+        # import of torch._inductor.exc which may not be available in all builds.
+        exc_type = type(error).__name__
+        inner_exc = getattr(error, "inner_exception", None)
+        if exc_type == "InductorError" or (
+            inner_exc is not None and "SubprocException" in type(inner_exc).__name__
+        ):
+            # Log the inner exception so the actual cause is visible in logs.
+            inner_msg = str(inner_exc) if inner_exc is not None else str(error)
+            logger.error(
+                "torch.inductor SubprocException — inner exception: %s", inner_msg
+            )
             return False
         return True


### PR DESCRIPTION
## Summary

Fixes #750

On fal.ai H100 workers, `torch.inductor`'s subprocess compile worker pool fails with `SubprocException`, crashing pipelines on the first chunk during JIT compilation. The inner exception message was swallowed, making root-cause diagnosis hard. The current error handling treated this as recoverable, causing the worker to loop endlessly on every chunk.

## Changes

### `src/scope/core/pipelines/utils.py`
New `compile_with_inductor_fallback(fn, ...)` utility:
- Wraps `torch.compile(fn, ...)` with a try/except that catches `InductorError`/`SubprocException` **at call time** (i.e. when JIT compilation first runs)
- On failure: logs a WARNING with the full inner exception message, then permanently swaps to eager execution for all subsequent calls
- Detects exception types by class name to avoid hard-importing `torch._inductor.exc`

### `causal_model.py` (streamdiffusionv2, longlive, krea_realtime_video)
- Replace bare `torch.compile(flex_attention, ...))` with `compile_with_inductor_fallback(flex_attention, ...)`
- Pipelines now survive compilation failures gracefully instead of crashing mid-session

### `src/scope/server/pipeline_processor.py`
- `_is_recoverable()`: mark `InductorError` as **non-recoverable** so if one escapes the fallback wrapper it stops the worker instead of looping
- Logs the inner exception message for traceability

### `src/scope/server/pipeline_manager.py`
- Adds inner-exception logging when `InductorError` occurs during pipeline load (the `krea-realtime-video` load failure case)

## Behavior

| Before | After |
|--------|-------|
| Pipeline crashes on first chunk | Falls back to eager flex_attention, continues normally |
| Inner exception message swallowed | Inner `SubprocException` message logged at WARNING |
| Worker loops infinitely on every chunk | Worker exits cleanly if InductorError escapes fallback |

## Testing

Unit-tested fallback logic locally — simulated `InductorError(SubprocException(...)))` confirms: first call triggers fallback + warning, subsequent calls use eager path silently.