### PR TITLE
fix(port): change default port to 18080, handle Windows excluded TCP ranges

### DIFF
--- a/app/src/utils/config.ts
+++ b/app/src/utils/config.ts
@@ -52,8 +52,11 @@ export const UV_DOWNLOAD_URLS = {
   },
 } as const;
 
-// Default port - using 52178 as it's less commonly used than 8000
-const DEFAULT_PORT = 52178;
+// Default port - using 18080 which is outside the Windows dynamic/excluded TCP ranges.
+// Port 52178 (and nearby ports) can fall inside Windows 11's excluded TCP range
+// (reportable via `netsh int ipv4 show excludedportrange protocol=tcp`), causing
+// startup failures on machines with a 5090 or other hardware that reserves those ports.
+const DEFAULT_PORT = 18080;
 const DEFAULT_HOST = '127.0.0.1';
 
 // Mutable server config - port may change if default is busy

--- a/app/src/utils/port.ts
+++ b/app/src/utils/port.ts
@@ -8,13 +8,12 @@ export async function isPortAvailable(port: number, host: string = '127.0.0.1'):
   return new Promise((resolve) => {
     const server = createServer();
 
-    server.once('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE' || err.code === 'EACCES') {
-        resolve(false);
-      } else {
-        // Other errors - assume port is not available
-        resolve(false);
-      }
+    server.once('error', (_err: NodeJS.ErrnoException) => {
+      // EADDRINUSE - port already in use
+      // EACCES     - permission denied (e.g. privileged port)
+      // ENOBUFS    - Windows: port is in an excluded/reserved range
+      // Any other error also means the port is not usable
+      resolve(false);
     });
 
     server.once('listening', () => {
@@ -28,25 +27,47 @@ export async function isPortAvailable(port: number, host: string = '127.0.0.1'):
 }
 
 /**
- * Find an available port starting from the given port
- * Tries up to maxAttempts consecutive ports
+ * Find an available port starting from the given port.
+ *
+ * On Windows 11, large contiguous TCP port ranges can be excluded by the OS
+ * (visible via `netsh int ipv4 show excludedportrange protocol=tcp`).  A small
+ * fixed `maxAttempts` may not be enough to escape such a block, so we use a
+ * larger default and also apply a jump when many consecutive ports fail,
+ * helping us skip over wide exclusion windows quickly.
  */
 export async function findAvailablePort(
   startPort: number,
   host: string = '127.0.0.1',
-  maxAttempts: number = 5
+  maxAttempts: number = 50
 ): Promise<number> {
-  for (let i = 0; i < maxAttempts; i++) {
-    const port = startPort + i;
-    if (port > 65535) {
+  let candidate = startPort;
+  let consecutiveFails = 0;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (candidate > 65535) {
       throw new Error('No available ports found in valid range');
     }
 
-    if (await isPortAvailable(port, host)) {
-      if (i > 0) {
-        logger.info(`Port ${startPort} was busy, using port ${port} instead`);
+    if (await isPortAvailable(candidate, host)) {
+      if (attempt > 0) {
+        logger.info(`Port ${startPort} was busy, using port ${candidate} instead`);
       }
-      return port;
+      return candidate;
+    }
+
+    consecutiveFails++;
+
+    // After 10 consecutive failures, jump ahead by 200 ports to escape a
+    // Windows excluded range block more quickly.
+    if (consecutiveFails >= 10) {
+      logger.warn(
+        `${consecutiveFails} consecutive ports unavailable near ${candidate}; ` +
+        `jumping ahead to escape possible OS-excluded port range`
+      );
+      candidate += 200;
+      consecutiveFails = 0;
+    } else {
+      candidate++;
     }
   }
 


### PR DESCRIPTION
## Problem

Scope hangs at startup on Windows 11 with:
```
Failed to start server: Error: No available ports found after 5 attempts starting from 52178
```

Root cause: Port `52178` (and the 4 ports after it) can fall inside Windows 11's OS-reserved TCP excluded ranges. These ranges are not "in use" in the traditional sense — no process is bound there — but Windows prevents binding to them entirely. This is common on machines with certain hardware (RTX 5090 etc.) that registers port exclusions at the driver level.

You can check your machine's excluded ranges with:
```
netsh int ipv4 show excludedportrange protocol=tcp
```

The old `findAvailablePort` only tried 5 consecutive ports, which wasn't nearly enough to escape a wide exclusion block (e.g. 52085–52184).

## Fix

1. **Change `DEFAULT_PORT` from `52178` to `18080`** — sits well outside both the Windows dynamic ephemeral range (49152–65535) and known exclusion blocks near the high end
2. **Increase `maxAttempts` from 5 → 50** — more headroom for fallback
3. **Add jump-ahead logic** — after 10 consecutive port failures, skip forward 200 ports to escape a wide OS-excluded block quickly, with a warning log
4. **Simplify `isPortAvailable` error handling** — all socket errors (EADDRINUSE, EACCES, ENOBUFS, etc.) correctly return `false`

## Testing

- macOS/Linux: no change in behavior (18080 is available in standard configs)
- Windows: no longer hits the excluded range on affected machines

Closes #606