### PR TITLE
feat: default to Workflow Builder mode

### DIFF
--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -296,7 +296,7 @@ export function StreamPage() {
   const [isCloudConnecting, setIsCloudConnecting] = useState(false);
 
   // Graph mode state
-  const [graphMode, setGraphMode] = useState(false);
+  const [graphMode, setGraphMode] = useState(true);
   const graphEditorRef = useRef<GraphEditorHandle>(null);
 
   // When true, pipeline controls are disabled in Perform Mode


### PR DESCRIPTION
## Summary
- Changes the default UI mode from Perform Mode to Workflow Builder when the app loads
- Single-line change: `useState(false)` → `useState(true)` for the `graphMode` state in `StreamPage.tsx`

## Test plan
- [ ] Open the app and verify Workflow Builder is shown by default
- [ ] Toggle to Perform Mode and verify it still works correctly
- [ ] Reload the page and confirm Workflow Builder is shown again

🤖 Generated with [Claude Code](https://claude.com/claude-code)