### PR TITLE
livepeer: Initialize output-only channels for text mode.

### DIFF
--- a/docs/architecture/livepeer.md
+++ b/docs/architecture/livepeer.md
@@ -80,14 +80,16 @@ The WebSocket application protocol uses three message categories:
 
 #### `create_channels` (runner → orchestrator)
 
-Sent when the runner receives a `start_stream` control message:
+Sent when the runner receives a `start_stream` control message.
+For video input mode, direction is bidirectional; for text input mode,
+direction is output-only:
 
 ```json
 {
   "type": "create_channels",
   "request_id": "<uuid>",
   "mime_type": "video/MP2T",
-  "direction": "bidirectional"
+  "direction": "bidirectional|out"
 }
 ```
 
@@ -130,10 +132,13 @@ Sent when the runner stops a stream:
 
 Directions are defined from the **Scope client** perspective:
 
-| Direction | Client behavior                | Runner behavior                 |
-| --------- | ------------------------------ | ------------------------------- |
-| `in`      | Publishes frames to this URL   | Reads / subscribes from this URL |
-| `out`     | Subscribes / receives from URL | Writes / publishes to this URL   |
+| Direction | Client behavior                | Runner behavior                   |
+| --------- | ------------------------------ | --------------------------------- |
+| `in`      | Publishes frames to this URL   | Reads / subscribes from this URL  |
+| `out`     | Subscribes / receives from URL | Writes / publishes to this URL    |
+
+Text-mode output-only startup can return only an `out` channel. Video-mode
+startup returns both `in` and `out`.
 
 ## Control Messages
 

--- a/frontend/src/hooks/useUnifiedWebRTC.ts
+++ b/frontend/src/hooks/useUnifiedWebRTC.ts
@@ -16,6 +16,7 @@ import {
 import { toast } from "sonner";
 
 interface InitialParameters {
+  input_mode?: "text" | "video";
   prompts?: string[] | PromptItem[];
   prompt_interpolation_method?: "linear" | "slerp";
   transition?: PromptTransition;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,6 +22,7 @@ export interface WebRTCOfferRequest {
   sdp?: string;
   type?: string;
   initialParameters?: {
+    input_mode?: "text" | "video";
     prompts?: string[] | PromptItem[];
     prompt_interpolation_method?: "linear" | "slerp";
     transition?: PromptTransition;

--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -425,7 +425,7 @@ async def _handle_api_request(
         except Exception:
             data = response.text
 
-        logger.info(
+        logger.debug(
             "Completed API request id=%s status=%s binary=false",
             request_id,
             response.status_code,
@@ -520,14 +520,18 @@ async def _handle_control_message(
         new_channels_future: asyncio.Future[dict[str, Any]] = loop.create_future()
         session.ws_pending_responses[ws_request_id] = new_channels_future
 
-        # Ask the orchestrator to create stream channels. request_id is echoed back
-        # on a generic response so we can resolve the correct pending future.
+        # Ask the orchestrator to create stream channels. Text mode only needs
+        # output media, while video mode keeps bidirectional media.
+        input_mode = params.get("input_mode")
+        channels_direction = "out" if input_mode == "text" else "bidirectional"
+        # request_id is echoed back on a generic response so we can resolve the
+        # correct pending future.
         await session.ws.send_json(
             {
                 "type": "create_channels",
                 "request_id": ws_request_id,
                 "mime_type": "video/MP2T",
-                "direction": "bidirectional",
+                "direction": channels_direction,
             }
         )
 
@@ -586,13 +590,21 @@ async def _handle_control_message(
             elif direction == "in":
                 inbound_url = url
 
-        # Bidirectional streaming requires both in and out channels.
-        if not outbound_url or not inbound_url:
-            return {
-                "type": "error",
-                "request_id": request_id,
-                "error": "response did not include in and out URLs",
-            }
+        if input_mode == "text":
+            if not outbound_url:
+                return {
+                    "type": "error",
+                    "request_id": request_id,
+                    "error": "response did not include out URL",
+                }
+        else:
+            # Bidirectional streaming requires both in and out channels.
+            if not outbound_url or not inbound_url:
+                return {
+                    "type": "error",
+                    "request_id": request_id,
+                    "error": "response did not include in and out URLs",
+                }
 
         # Persist URLs so _stop_stream can send full URLs back in stop_stream and
         # so media loops know where to read/write frames for this stream session.
@@ -606,7 +618,10 @@ async def _handle_control_message(
         )
         session.frame_processor.start()
         session.media_stop_event.clear()
-        session.media_input_task = asyncio.create_task(_media_input_loop(session))
+        if input_mode != "text":
+            session.media_input_task = asyncio.create_task(_media_input_loop(session))
+        else:
+            session.media_input_task = None
         fps = float(params.get("fps", 30.0))
         session.media_output_task = asyncio.create_task(
             _media_output_loop(
@@ -615,7 +630,11 @@ async def _handle_control_message(
             )
         )
         session.media_stats_task = asyncio.create_task(_media_stats_loop(session))
-        logger.info("Started stream with pipeline_ids=%s", pipeline_ids)
+        logger.info(
+            "Started stream with pipeline_ids=%s direction=%s",
+            pipeline_ids,
+            channels_direction,
+        )
         return {
             "type": "stream_started",
             "request_id": request_id,

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -99,8 +99,10 @@ class LivepeerClient:
         return (
             self.is_connected
             and self._media_connected
-            and self._media_publisher is not None
-            and self._media_subscriber_task is not None
+            and (
+                self._media_publisher is not None
+                or self._media_subscriber_task is not None
+            )
         )
 
     @property
@@ -276,18 +278,31 @@ class LivepeerClient:
             elif direction == "out":
                 output_url = url
 
-        if input_url is None or output_url is None:
-            raise RuntimeError("stream_started response missing in/out channels")
+        if input_url is None and output_url is None:
+            raise RuntimeError("stream_started response missing usable channels")
 
-        publisher = MediaPublish(input_url, config=MediaPublishConfig(fps=self._fps))
-        media_output = MediaOutput(output_url, start_seq=-1)
+        publisher: MediaPublish | None = None
+        if input_url is not None:
+            publisher = MediaPublish(
+                input_url, config=MediaPublishConfig(fps=self._fps)
+            )
+
+        media_output: MediaOutput | None = None
+        subscriber: asyncio.Task | None = None
+        if output_url is not None:
+            media_output = MediaOutput(output_url, start_seq=-1)
+            subscriber = asyncio.create_task(self._receive_loop(media_output))
+
         self._media_connected = True
-        subscriber = asyncio.create_task(self._receive_loop(media_output))
 
         self._media_publisher = publisher
         self._media_output = media_output
         self._media_subscriber_task = subscriber
-        logger.info("Media channels started")
+        logger.info(
+            "Media channels started (input=%s output=%s)",
+            bool(input_url),
+            bool(output_url),
+        )
 
     async def stop_media(self, current_task: asyncio.Task | None = None) -> None:
         """Stop media I/O while keeping signaling channels alive."""


### PR DESCRIPTION
Avoids idle input channels from timing out and tearing down the rest of the cloud connection from there.

Also tighten up the `InitialParameters` typing; the `input_mode` is already being sent but wasn't typed. 