### PR TITLE
fix(fal): pre-install livepeer extras at build time, increase startup timeout

### DIFF
--- a/src/scope/cloud/livepeer_fal_app.py
+++ b/src/scope/cloud/livepeer_fal_app.py
@@ -22,7 +22,7 @@ RUNNER_HOST = "127.0.0.1"
 RUNNER_PORT = int(os.getenv("LIVEPEER_RUNNER_PORT", "8001"))
 RUNNER_LOCAL_WS_URL = f"ws://{RUNNER_HOST}:{RUNNER_PORT}/ws"
 RUNNER_LOCAL_HTTP_URL = f"http://{RUNNER_HOST}:{RUNNER_PORT}"
-RUNNER_STARTUP_TIMEOUT_SECONDS = 90
+RUNNER_STARTUP_TIMEOUT_SECONDS = 600
 RUNNER_RETRY_DELAY_SECONDS = 2.5
 RUNNER_MAX_FAILURES_PER_WINDOW = 20
 RUNNER_FAILURE_WINDOW_SECONDS = 60.0
@@ -109,6 +109,9 @@ FROM {DOCKER_IMAGE}
 WORKDIR /app
 COPY pyproject.toml uv.lock README.md patches.pth /app/
 COPY src/ /app/src/
+# Pre-install livepeer extras at image build time so the runner can start
+# immediately on cold workers without downloading ~1.4GB of CUDA packages.
+RUN uv sync --extra livepeer --frozen
 """
 custom_image = ContainerImage.from_dockerfile_str(
     dockerfile_str,


### PR DESCRIPTION
## Problem

Fixes #783 — `scope-livepeer-staging` crashes on startup with:

```
RuntimeError: Timed out waiting for Livepeer runner on http://127.0.0.1:8001
```

### Root Cause

The fal Dockerfile only copies source files — it never pre-installs the `livepeer` extras. So every cold fal.ai worker runs:

```
uv run --extra livepeer livepeer-runner ...
```

…which triggers a full `uv sync` including ~1.4GB of NVIDIA/CUDA packages (torch, transformers, etc.) before the runner can start. This easily exceeds the previous 90-second timeout.

From the Loki trace: deps started downloading at 12:10:33, runner timed out at 12:11:37 — only ~64 seconds in.

## Fix

1. **Add `RUN uv sync --extra livepeer --frozen` to the fal Dockerfile** — packages are installed at *image build time* and cached in the container image, so cold workers start the runner immediately.

2. **Increase `RUNNER_STARTUP_TIMEOUT_SECONDS` from 90 → 600** — safety net for any remaining startup variance (model loading, GPU init, etc.).

## Testing

- Deploy to `scope-livepeer-staging` and confirm cold start no longer times out
- Verify `livepeer-runner` comes up quickly (\<30s) on a fresh worker after image rebuild