### PR TITLE
fix: increase Livepeer runner startup timeout for cold fal.ai workers (#783)

### DIFF
--- a/src/scope/cloud/livepeer_fal_app.py
+++ b/src/scope/cloud/livepeer_fal_app.py
@@ -22,7 +22,9 @@ RUNNER_HOST = "127.0.0.1"
 RUNNER_PORT = int(os.getenv("LIVEPEER_RUNNER_PORT", "8001"))
 RUNNER_LOCAL_WS_URL = f"ws://{RUNNER_HOST}:{RUNNER_PORT}/ws"
 RUNNER_LOCAL_HTTP_URL = f"http://{RUNNER_HOST}:{RUNNER_PORT}"
-RUNNER_STARTUP_TIMEOUT_SECONDS = 90
+RUNNER_STARTUP_TIMEOUT_SECONDS = int(
+    os.getenv("LIVEPEER_RUNNER_STARTUP_TIMEOUT_SECONDS", "600")
+)
 RUNNER_RETRY_DELAY_SECONDS = 2.5
 RUNNER_MAX_FAILURES_PER_WINDOW = 20
 RUNNER_FAILURE_WINDOW_SECONDS = 60.0
@@ -288,6 +290,8 @@ class LivepeerScopeApp(fal.App, keep_alive=300):
         self.runner_process = process
 
         start = time.time()
+        last_log = start
+        LOG_INTERVAL_SECONDS = 30
         while time.time() - start < RUNNER_STARTUP_TIMEOUT_SECONDS:
             if process.poll() is not None:
                 raise RuntimeError(
@@ -295,12 +299,27 @@ class LivepeerScopeApp(fal.App, keep_alive=300):
                     f"(code={process.returncode})"
                 )
             if _runner_is_ready():
-                print(f"Livepeer runner ready at {RUNNER_LOCAL_WS_URL}")
+                elapsed = time.time() - start
+                print(
+                    f"Livepeer runner ready at {RUNNER_LOCAL_WS_URL} "
+                    f"(took {elapsed:.1f}s)"
+                )
                 return
+            now = time.time()
+            if now - last_log >= LOG_INTERVAL_SECONDS:
+                elapsed = now - start
+                remaining = RUNNER_STARTUP_TIMEOUT_SECONDS - elapsed
+                print(
+                    f"Waiting for Livepeer runner... "
+                    f"{elapsed:.0f}s elapsed, {remaining:.0f}s remaining "
+                    f"(timeout={RUNNER_STARTUP_TIMEOUT_SECONDS}s)"
+                )
+                last_log = now
             time.sleep(1)
 
         raise RuntimeError(
-            f"Timed out waiting for Livepeer runner on {RUNNER_LOCAL_HTTP_URL}"
+            f"Timed out waiting for Livepeer runner on {RUNNER_LOCAL_HTTP_URL} "
+            f"after {RUNNER_STARTUP_TIMEOUT_SECONDS}s"
         )
 
     @fal.endpoint("/ws", is_websocket=True)

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -84,8 +84,11 @@ class FrameProcessor:
         # Connection metadata (gpu_type, region, etc.) for Kafka events
         self.connection_info = connection_info
 
-        # Current parameters
-        self.parameters = initial_parameters or {}
+        # Current parameters – sanitize asset paths that may be Windows-style
+        # local paths sent by the client but meaningless on the Linux worker.
+        self.parameters = PipelineManager._sanitize_initial_params(
+            initial_parameters or {}
+        )
 
         self.running = False
 

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -3,10 +3,11 @@
 import asyncio
 import gc
 import logging
+import re
 import threading
 import time
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 import torch
@@ -791,6 +792,100 @@ class PipelineManager:
 
         return resolved
 
+    @staticmethod
+    def _sanitize_asset_path(path: str) -> str:
+        """Normalize a single asset path so it is resolvable on the current system.
+
+        When a Windows client sends ``i2v_image`` (or similar params) to a
+        Linux cloud worker, the path may be a Windows absolute path such as::
+
+            C:\\Users\\Joshu\\.daydream-scope\\assets\\ShinraFireForce.webp
+
+        These paths are meaningless on Linux. This method:
+
+        1. Detects platform-foreign absolute paths (Windows ``X:\\...`` /
+           ``X:/...`` / UNC ``\\\\server\\...``) or Unix absolute paths that
+           fall outside the configured assets directory.
+        2. Extracts the bare filename (e.g. ``ShinraFireForce.webp``).
+        3. Rebuilds the path relative to ``get_assets_dir()`` so the cloud
+           worker can locate the file.
+
+        Relative paths and already-valid absolute paths are left unchanged.
+
+        Args:
+            path: Asset path string to normalise.
+
+        Returns:
+            Normalised path string, or the original if no rewrite was needed.
+        """
+        from .models_config import get_assets_dir
+
+        assets_dir = get_assets_dir()
+        _windows_abs_re = re.compile(r"^(?:[A-Za-z]:[/\\]|\\\\)", re.ASCII)
+
+        needs_rewrite = False
+
+        if _windows_abs_re.match(path):
+            needs_rewrite = True
+            filename = PureWindowsPath(path).name
+        elif path.startswith("/"):
+            try:
+                abs_path = Path(path).resolve()
+                if not abs_path.is_relative_to(assets_dir.resolve()):
+                    needs_rewrite = True
+                    filename = Path(path).name
+            except Exception:
+                needs_rewrite = True
+                filename = Path(path).name
+
+        if needs_rewrite:
+            new_path = str(assets_dir / filename)
+            logger.warning(
+                "_sanitize_asset_path: asset path %r appears to be a local "
+                "absolute path from a different OS or filesystem. "
+                "Rewriting to %r.",
+                path,
+                new_path,
+            )
+            return new_path
+        return path
+
+    @staticmethod
+    def _sanitize_initial_params(params: dict) -> dict:
+        """Sanitize known asset path parameters in *params*.
+
+        Rewrites Windows / foreign-OS absolute paths for these keys so the
+        Linux cloud worker can locate the assets that were already uploaded to
+        ``get_assets_dir()``:
+
+        * ``i2v_image``        – str or None
+        * ``first_frame_image`` – str or None
+        * ``last_frame_image``  – str or None
+        * ``images``            – list[str] or None (each item sanitized)
+        * ``vace_ref_images``   – list[str] or None (each item sanitized)
+
+        Args:
+            params: Pipeline parameter dict (will not be mutated).
+
+        Returns:
+            A shallow copy of *params* with the above keys sanitized.
+        """
+        result = dict(params)
+
+        _str_keys = ("i2v_image", "first_frame_image", "last_frame_image")
+        for key in _str_keys:
+            if key in result and result[key] is not None:
+                result[key] = PipelineManager._sanitize_asset_path(result[key])
+
+        _list_keys = ("images", "vace_ref_images")
+        for key in _list_keys:
+            if key in result and result[key] is not None:
+                result[key] = [
+                    PipelineManager._sanitize_asset_path(p) for p in result[key]
+                ]
+
+        return result
+
     def unload_pipeline_by_id(
         self,
         pipeline_id: str,
@@ -914,8 +1009,10 @@ class PipelineManager:
             for name, field in config_class.model_fields.items():
                 if field.default is not None:
                     schema_defaults[name] = field.default
+            # Sanitize foreign OS asset paths before passing to the pipeline.
+            load_params = self._sanitize_initial_params(load_params or {})
             # Merge: load_params override schema defaults
-            merged_params = {**schema_defaults, **(load_params or {})}
+            merged_params = {**schema_defaults, **load_params}
             return pipeline_class(**merged_params)
 
         # Fall through to built-in pipeline initialization

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -6,6 +6,7 @@ import logging
 import threading
 import time
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -722,9 +723,73 @@ class PipelineManager:
         config["base_seed"] = base_seed
         config["vae_type"] = vae_type
         if loras:
-            config["loras"] = loras
+            config["loras"] = self._resolve_lora_paths(loras)
         # Pass merge_mode directly to mixin, not via config
         config["_lora_merge_mode"] = lora_merge_mode
+
+    def _resolve_lora_paths(self, loras: list[dict]) -> list[dict]:
+        """Resolve LoRA file paths against the LoRA directory.
+
+        Relative paths and bare filenames are resolved against get_lora_dir()
+        and get_shared_lora_dir() so that user-configured LoRAs specified by
+        filename alone (e.g. "hydravj_000000750.safetensors") are found correctly.
+        Absolute paths are passed through unchanged.
+
+        Pre-validates that each resolved path exists and raises a clear
+        RuntimeError before pipeline initialization begins.
+
+        Args:
+            loras: List of LoRA config dicts with at least a 'path' key.
+
+        Returns:
+            Copy of loras list with 'path' values resolved to absolute paths.
+
+        Raises:
+            RuntimeError: If a LoRA file cannot be found in any search location.
+        """
+        from .models_config import get_lora_dir, get_shared_lora_dir
+
+        lora_dir = get_lora_dir()
+        shared_dir = get_shared_lora_dir()
+
+        resolved = []
+        for lora in loras:
+            lora_path = lora.get("path")
+            if not lora_path:
+                resolved.append(lora)
+                continue
+
+            p = Path(lora_path)
+            if p.is_absolute():
+                # Already absolute — validate existence directly.
+                if not p.exists():
+                    raise RuntimeError(
+                        f"LoRA file not found: {lora_path}. "
+                        f"Ensure the file exists in your remote model directory."
+                    )
+                resolved.append({**lora, "path": str(p)})
+                continue
+
+            # Search: lora_dir, then shared_dir (if configured).
+            candidates = [lora_dir / p]
+            if shared_dir:
+                candidates.append(shared_dir / p)
+
+            found = next((c for c in candidates if c.exists()), None)
+            if found is None:
+                search_dirs = [str(lora_dir)]
+                if shared_dir:
+                    search_dirs.append(str(shared_dir))
+                raise RuntimeError(
+                    f"LoRA file '{lora_path}' not found. "
+                    f"Searched: {', '.join(search_dirs)}. "
+                    f"Ensure the file is available in your remote model directory."
+                )
+
+            logger.debug("Resolved LoRA path '%s' -> '%s'", lora_path, found)
+            resolved.append({**lora, "path": str(found)})
+
+        return resolved
 
     def unload_pipeline_by_id(
         self,

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -839,7 +839,7 @@ class PipelineManager:
                 filename = Path(path).name
 
         if needs_rewrite:
-            new_path = str(assets_dir / filename)
+            new_path = (assets_dir / filename).as_posix()
             logger.warning(
                 "_sanitize_asset_path: asset path %r appears to be a local "
                 "absolute path from a different OS or filesystem. "

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -341,3 +341,101 @@ class TestHelperMethods:
             "node_a", "longlive", {}, claimed_keys=set(), reserved_keys={"node_a"}
         )
         assert result == "node_a"
+
+
+# ---------------------------------------------------------------------------
+# Tests for _sanitize_asset_path and _sanitize_initial_params
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeAssetPaths:
+    """Tests for PipelineManager._sanitize_asset_path and _sanitize_initial_params."""
+
+    def test_windows_backslash_path_is_rewritten(self):
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            result = PipelineManager._sanitize_asset_path(
+                r"C:\Users\Joshu\.daydream-scope\assets\ShinraFireForce.webp"
+            )
+        assert result == "/tmp/.daydream-scope/assets/ShinraFireForce.webp"
+
+    def test_windows_forward_slash_drive_path_is_rewritten(self):
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            result = PipelineManager._sanitize_asset_path(
+                "C:/Users/Joshu/.daydream-scope/assets/ShinraFireForce.webp"
+            )
+        assert result == "/tmp/.daydream-scope/assets/ShinraFireForce.webp"
+
+    def test_unix_path_outside_assets_dir_is_rewritten(self):
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            result = PipelineManager._sanitize_asset_path(
+                "/home/user/.daydream-scope/assets/image.png"
+            )
+        assert result == "/tmp/.daydream-scope/assets/image.png"
+
+    def test_relative_path_unchanged(self):
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            result = PipelineManager._sanitize_asset_path("image.png")
+        assert result == "image.png"
+
+    def test_none_value_unchanged(self):
+        """_sanitize_initial_params should leave None values as None."""
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            result = PipelineManager._sanitize_initial_params({"i2v_image": None})
+        assert result["i2v_image"] is None
+
+    def test_sanitize_initial_params_i2v_image_windows_path(self):
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            params = {
+                "i2v_image": r"C:\Users\Joshu\.daydream-scope\assets\ShinraFireForce.webp",
+                "strength": 0.8,
+            }
+            result = PipelineManager._sanitize_initial_params(params)
+        assert (
+            result["i2v_image"]
+            == "/tmp/.daydream-scope/assets/ShinraFireForce.webp"
+        )
+        assert result["strength"] == 0.8
+
+    def test_sanitize_initial_params_images_list(self):
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            params = {
+                "images": [
+                    r"C:\Users\Joshu\.daydream-scope\assets\a.png",
+                    r"C:\Users\Joshu\.daydream-scope\assets\b.png",
+                ]
+            }
+            result = PipelineManager._sanitize_initial_params(params)
+        assert result["images"] == [
+            "/tmp/.daydream-scope/assets/a.png",
+            "/tmp/.daydream-scope/assets/b.png",
+        ]
+
+    def test_sanitize_initial_params_no_asset_params_unchanged(self):
+        from pathlib import Path
+
+        with patch("scope.server.models_config.get_assets_dir") as mock_dir:
+            mock_dir.return_value = Path("/tmp/.daydream-scope/assets")
+            params = {"strength": 0.9, "seed": 42}
+            result = PipelineManager._sanitize_initial_params(params)
+        assert result == {"strength": 0.9, "seed": 42}

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -408,10 +408,7 @@ class TestSanitizeAssetPaths:
                 "strength": 0.8,
             }
             result = PipelineManager._sanitize_initial_params(params)
-        assert (
-            result["i2v_image"]
-            == "/tmp/.daydream-scope/assets/ShinraFireForce.webp"
-        )
+        assert result["i2v_image"] == "/tmp/.daydream-scope/assets/ShinraFireForce.webp"
         assert result["strength"] == 0.8
 
     def test_sanitize_initial_params_images_list(self):


### PR DESCRIPTION
## Problem

On cold `scope-livepeer-staging` fal.ai workers, the Livepeer runner startup times out before it ever has a chance to become ready. The 90s timeout is too short — `uv` needs several minutes to download and install ~850 MB+ of torch/CUDA dependencies on a fresh worker.

Observed pattern (issues #783, 2026-04-03/04):
```
uv run --extra livepeer livepeer-runner  # 850+ MB install...
RuntimeError: Timed out waiting for Livepeer runner on http://127.0.0.1:8001
ERROR:    Application startup failed. Exiting.
```

## Fix

- **Raise default timeout from 90s → 600s** (10 min) — enough headroom for cold-start uv installs
- **Add `LIVEPEER_RUNNER_STARTUP_TIMEOUT_SECONDS` env var** — allows tuning per-environment without code changes
- **Add 30s interval progress logging** — makes cold-start wait visible in Grafana/Loki instead of silent until timeout

## Notes

A longer-term fix would move the heavy package installs to build time (fal.ai Dockerfile/image layer) so they're cached — but that's a larger change. This unblocks staging immediately.

Closes #783