### PR TITLE
feat: audio-only workflow support (headless capture + reliable playback)

### DIFF
--- a/frontend/src/components/graph/nodes/CustomNode.tsx
+++ b/frontend/src/components/graph/nodes/CustomNode.tsx
@@ -49,6 +49,9 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
     data.customNodeTypeId ||
     "Custom Node";
   const category = data.customNodeCategory ?? "";
+  const onParameterChange = data.onParameterChange as
+    | ((nodeId: string, key: string, value: unknown) => void)
+    | undefined;
 
   // Measure each port row so handles can be positioned from DOM offsetTop
   // rather than hard-coded pixel math. Re-measures when port lists change.
@@ -59,6 +62,16 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
     outputs.map(p => p.name).join("|"),
     params.length,
   ]);
+
+  const setParam = (name: string, value: unknown) => {
+    updateData({
+      customNodeParams: {
+        ...data.customNodeParams,
+        [name]: value,
+      },
+    });
+    onParameterChange?.(id, name, value);
+  };
 
   return (
     <NodeCard
@@ -145,14 +158,7 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
                       <select
                         className="bg-zinc-900 text-zinc-200 rounded px-1 py-0.5 text-[11px] max-w-[130px]"
                         value={String(val)}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: e.target.value,
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, e.target.value)}
                       >
                         {(p.ui?.options as string[]).map(o => (
                           <option key={o} value={o}>
@@ -164,14 +170,7 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
                       <input
                         type="checkbox"
                         checked={Boolean(val)}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: e.target.checked,
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, e.target.checked)}
                         className="accent-blue-500"
                       />
                     ) : p.param_type === "number" ? (
@@ -182,28 +181,14 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
                         min={(p.ui?.min as number | undefined) ?? undefined}
                         max={(p.ui?.max as number | undefined) ?? undefined}
                         step={(p.ui?.step as number | undefined) ?? undefined}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: Number(e.target.value),
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, Number(e.target.value))}
                       />
                     ) : (
                       <input
                         type="text"
                         className="bg-zinc-900 text-zinc-200 rounded px-1 py-0.5 text-[11px] max-w-[130px]"
                         value={String(val)}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: e.target.value,
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, e.target.value)}
                       />
                     )}
                   </div>

--- a/frontend/src/components/graph/nodes/SinkNode.tsx
+++ b/frontend/src/components/graph/nodes/SinkNode.tsx
@@ -31,6 +31,7 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
   const isPlaying = (data.isPlaying as boolean | undefined) ?? true;
   const onPlayPauseToggle = data.onPlayPauseToggle as (() => void) | undefined;
   const videoRef = useRef<HTMLVideoElement>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
   const [videoSize, setVideoSize] = useState<{
     width: number;
     height: number;
@@ -49,14 +50,27 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
   }, []);
 
   useEffect(() => {
-    if (videoRef.current && remoteStream instanceof MediaStream) {
-      videoRef.current.srcObject = remoteStream;
+    if (remoteStream instanceof MediaStream) {
+      if (videoRef.current) {
+        videoRef.current.srcObject = remoteStream;
+      }
       setHasAudioTrack(remoteStream.getAudioTracks().length > 0);
       setHasVideoTrack(remoteStream.getVideoTracks().length > 0);
+
+      // Persistent <audio> element gives Chrome a reliable target for
+      // audio-only WebRTC streams (zero-size <video> fails autoplay).
+      if (audioRef.current) {
+        audioRef.current.srcObject = remoteStream;
+        audioRef.current.play().catch(() => {});
+      }
 
       const handleTrackAdded = () => {
         setHasAudioTrack(remoteStream.getAudioTracks().length > 0);
         setHasVideoTrack(remoteStream.getVideoTracks().length > 0);
+        if (audioRef.current && audioRef.current.srcObject !== remoteStream) {
+          audioRef.current.srcObject = remoteStream;
+          audioRef.current.play().catch(() => {});
+        }
       };
       remoteStream.addEventListener("addtrack", handleTrackAdded);
       return () => {
@@ -69,7 +83,17 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
     if (videoRef.current) {
       videoRef.current.muted = isMuted;
     }
+    if (audioRef.current) {
+      audioRef.current.muted = isMuted;
+    }
   }, [isMuted, isFullscreen]);
+
+  // Auto-unmute when audio arrives without video (audio-only workflow)
+  useEffect(() => {
+    if (hasAudioTrack && !hasVideoTrack) {
+      setIsMuted(false);
+    }
+  }, [hasAudioTrack, hasVideoTrack]);
 
   useEffect(() => {
     if (!isFullscreen) return;
@@ -130,6 +154,7 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
             playsInline
             onResize={handleResize}
           />
+          <audio ref={audioRef} autoPlay style={{ display: "none" }} />
           {!hasVideoTrack && (
             <div className="flex flex-col items-center justify-center h-full gap-1 text-[#8c8c8d]">
               <Volume2 className="h-5 w-5" />
@@ -298,6 +323,17 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
           collapsed
             ? collapsedHandleStyle("left")
             : { top: handleY, left: 0, backgroundColor: "#ffffff" }
+        }
+      />
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="stream:audio"
+        className="!w-2.5 !h-2.5 !border-0"
+        style={
+          collapsed
+            ? collapsedHandleStyle("left")
+            : { top: (handleY ?? 0) + 16, left: 0, backgroundColor: "#22c55e" }
         }
       />
       <Handle

--- a/frontend/src/components/graph/utils/nodeEnrichment.ts
+++ b/frontend/src/components/graph/utils/nodeEnrichment.ts
@@ -155,6 +155,16 @@ export function enrichNodes(
         },
       };
     }
+    if (n.data.nodeType === "custom_node") {
+      return {
+        ...n,
+        data: {
+          ...n.data,
+          onParameterChange: deps.handleNodeParameterChange,
+          isStreaming: deps.isStreaming,
+        },
+      };
+    }
     if (n.data.nodeType === "source") {
       // Per-node stream if available (multi-source), else fall back to global
       const nodeStream = deps.localStreams?.[n.id] ?? deps.localStream;

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -2921,8 +2921,12 @@ export function StreamPage() {
           settings.kvCacheAttentionBias ?? 1.0;
       }
 
-      // Pipeline chain: preprocessors + main pipeline (already built above)
-      initialParameters.pipeline_ids = pipelineIds;
+      // Pipeline chain: preprocessors + main pipeline (already built above).
+      // Node-only graphs (custom nodes with no pipelines) leave this unset so
+      // the backend skips pipeline loading.
+      if (pipelineIds.length > 0) {
+        initialParameters.pipeline_ids = pipelineIds;
+      }
 
       // Media modalities from pipeline status — used by the backend to decide
       // which tracks to create (avoids unnecessary audio processing for

--- a/src/scope/core/nodes/__init__.py
+++ b/src/scope/core/nodes/__init__.py
@@ -9,16 +9,18 @@ the frontend via ``GET /api/v1/nodes/definitions``.
 """
 
 from .base import BaseNode, NodeDefinition, NodeParam, NodePort
-from .builtins import SchedulerNode
+from .builtins import AudioSourceNode, SchedulerNode
 from .registry import NodeRegistry
 
 
 def register_builtin_nodes() -> None:
     """Register all built-in node types shipped with the foundation."""
     NodeRegistry.register(SchedulerNode)
+    NodeRegistry.register(AudioSourceNode)
 
 
 __all__ = [
+    "AudioSourceNode",
     "BaseNode",
     "NodeDefinition",
     "NodeParam",

--- a/src/scope/core/nodes/builtins/__init__.py
+++ b/src/scope/core/nodes/builtins/__init__.py
@@ -1,5 +1,6 @@
 """Built-in nodes shipped with the foundation abstraction."""
 
+from .audio_io import AudioSourceNode
 from .scheduler import SchedulerNode
 
-__all__ = ["SchedulerNode"]
+__all__ = ["AudioSourceNode", "SchedulerNode"]

--- a/src/scope/core/nodes/builtins/audio_io.py
+++ b/src/scope/core/nodes/builtins/audio_io.py
@@ -1,0 +1,331 @@
+"""Built-in audio I/O nodes: AudioSource (WAV file → audio stream).
+
+Terminal audio output is handled by the regular Sink node: audio edges
+into a Sink are routed straight to the WebRTC audio track via the
+session's audio_output_queue, with no intermediate node needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+import time
+from typing import Any, ClassVar
+
+import numpy as np
+import torch
+
+from ..base import BaseNode, NodeDefinition, NodeParam, NodePort
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 48000
+CHUNK_DURATION = 0.1  # 100ms chunks for streaming
+CHUNK_SAMPLES = int(SAMPLE_RATE * CHUNK_DURATION)
+
+
+def _read_wav_float32(path: str) -> tuple[np.ndarray, int]:
+    """Parse a WAV file into float32 samples without the stdlib ``wave``
+    module, which rejects IEEE-float (format 3) files.
+
+    Returns (data, sample_rate) where ``data`` has shape (samples, channels).
+    Supports formats 1 (PCM int) and 3 (IEEE float) — the two common cases.
+    WAVE_FORMAT_EXTENSIBLE (0xFFFE) is unwrapped to its underlying format.
+    """
+    with open(path, "rb") as f:
+        header = f.read(12)
+        if len(header) < 12 or header[:4] != b"RIFF" or header[8:12] != b"WAVE":
+            raise ValueError(f"Not a WAV file: {path}")
+
+        fmt_code: int | None = None
+        n_channels = 1
+        sample_rate = 0
+        bits_per_sample = 0
+        pcm_bytes = b""
+
+        while True:
+            chunk_header = f.read(8)
+            if len(chunk_header) < 8:
+                break
+            chunk_id, chunk_size = struct.unpack("<4sI", chunk_header)
+            chunk_data = f.read(chunk_size)
+            if chunk_size % 2 == 1:
+                f.read(1)  # RIFF pads odd-sized chunks
+
+            if chunk_id == b"fmt " and len(chunk_data) >= 16:
+                (
+                    fmt_code,
+                    n_channels,
+                    sample_rate,
+                    _byte_rate,
+                    _block_align,
+                    bits_per_sample,
+                ) = struct.unpack("<HHIIHH", chunk_data[:16])
+                # Unwrap WAVE_FORMAT_EXTENSIBLE: real format is first 2 bytes of the GUID.
+                if fmt_code == 0xFFFE and len(chunk_data) >= 26:
+                    fmt_code = struct.unpack("<H", chunk_data[24:26])[0]
+            elif chunk_id == b"data":
+                pcm_bytes = chunk_data
+
+        if fmt_code is None or not pcm_bytes or sample_rate <= 0:
+            raise ValueError(f"WAV missing fmt/data chunk: {path}")
+
+        if fmt_code == 1:  # PCM integer
+            if bits_per_sample == 16:
+                samples = (
+                    np.frombuffer(pcm_bytes, dtype="<i2").astype(np.float32) / 32768.0
+                )
+            elif bits_per_sample == 32:
+                samples = (
+                    np.frombuffer(pcm_bytes, dtype="<i4").astype(np.float32)
+                    / 2147483648.0
+                )
+            elif bits_per_sample == 8:
+                samples = (
+                    np.frombuffer(pcm_bytes, dtype=np.uint8).astype(np.float32) / 128.0
+                    - 1.0
+                )
+            elif bits_per_sample == 24:
+                raw = np.frombuffer(pcm_bytes, dtype=np.uint8).reshape(-1, 3)
+                as32 = (
+                    raw[:, 0].astype(np.int32)
+                    | (raw[:, 1].astype(np.int32) << 8)
+                    | (raw[:, 2].astype(np.int32) << 16)
+                )
+                # Sign-extend the 24-bit value.
+                as32 = np.where(as32 & 0x800000, as32 | ~0xFFFFFF, as32)
+                samples = as32.astype(np.float32) / 8388608.0
+            else:
+                raise ValueError(f"Unsupported PCM bit depth: {bits_per_sample}")
+        elif fmt_code == 3:  # IEEE float
+            if bits_per_sample == 32:
+                samples = np.frombuffer(pcm_bytes, dtype="<f4").astype(
+                    np.float32, copy=True
+                )
+            elif bits_per_sample == 64:
+                samples = np.frombuffer(pcm_bytes, dtype="<f8").astype(np.float32)
+            else:
+                raise ValueError(f"Unsupported float bit depth: {bits_per_sample}")
+        else:
+            raise ValueError(f"Unsupported WAV format code: {fmt_code}")
+
+        samples = samples.reshape(-1, n_channels)
+        return samples, sample_rate
+
+
+class AudioSourceNode(BaseNode):
+    """Load audio from a WAV file and stream it in 100ms chunks, looping."""
+
+    node_type_id: ClassVar[str] = "audio.AudioSource"
+
+    def __init__(self, node_id: str, config: dict[str, Any] | None = None):
+        super().__init__(node_id, config)
+        self._audio_data: np.ndarray | None = None
+        self._position = 0
+        self._loaded_file: str = ""
+        self._last_call_time: float | None = None
+        # In mode=full + loop=false we emit the entire clip once and then
+        # stay silent until the loaded file or mode changes. Otherwise
+        # every worker tick would re-push a 15s clip and flood the graph.
+        self._full_emitted_key: tuple[str, str] | None = None
+        # In mode=full + loop=true we re-emit the full clip paced to
+        # wall clock so downstream (e.g. ACEStep) re-processes at roughly
+        # real-time without flooding.
+        self._last_full_emit_time: float | None = None
+
+    @classmethod
+    def get_definition(cls) -> NodeDefinition:
+        return NodeDefinition(
+            node_type_id=cls.node_type_id,
+            display_name="Audio Source",
+            category="audio",
+            description="Load audio from a WAV file at 48kHz stereo.",
+            continuous=True,
+            inputs=[],
+            outputs=[
+                NodePort(name="audio", port_type="audio", description="Audio waveform"),
+            ],
+            params=[
+                NodeParam(
+                    name="file_id",
+                    param_type="string",
+                    default="",
+                    description="Audio file path",
+                ),
+                NodeParam(
+                    name="duration",
+                    param_type="number",
+                    default=15.0,
+                    description="Duration (s)",
+                    ui={"min": 1, "max": 600, "step": 1},
+                ),
+                NodeParam(
+                    name="mode",
+                    param_type="select",
+                    default="full",
+                    description="Output mode",
+                    ui={"options": ["full", "stream"]},
+                ),
+                NodeParam(
+                    name="loop",
+                    param_type="boolean",
+                    default=False,
+                    description="Repeat the audio continuously",
+                ),
+                NodeParam(
+                    name="pacing",
+                    param_type="select",
+                    default="realtime",
+                    description="Loop pacing",
+                    ui={"options": ["realtime", "downstream"]},
+                ),
+            ],
+        )
+
+    def _load_audio(self, file_path: str, duration: float) -> None:
+        """Load, decode, resample to 48kHz stereo, and clip to duration."""
+        data, sr = _read_wav_float32(file_path)  # (samples, channels)
+
+        if data.shape[1] == 1:
+            data = np.concatenate([data, data], axis=1)
+        elif data.shape[1] > 2:
+            data = data[:, :2]
+        data = data.T  # (channels, samples)
+
+        if sr != SAMPLE_RATE and sr > 0:
+            num_samples = data.shape[1]
+            new_len = int(num_samples * SAMPLE_RATE / sr)
+            old_indices = np.linspace(0, num_samples - 1, new_len)
+            resampled = np.zeros((data.shape[0], new_len), dtype=np.float32)
+            for ch in range(data.shape[0]):
+                resampled[ch] = np.interp(old_indices, np.arange(num_samples), data[ch])
+            data = resampled
+
+        max_samples = int(duration * SAMPLE_RATE)
+        if data.shape[1] > max_samples:
+            data = data[:, :max_samples]
+
+        self._audio_data = data
+        self._position = 0
+        self._loaded_file = file_path
+        logger.info(
+            "AudioSource loaded: %s (%.1fs)",
+            file_path,
+            data.shape[1] / SAMPLE_RATE,
+        )
+
+    def execute(self, inputs: dict[str, Any], **kwargs) -> dict[str, Any]:
+        file_id = kwargs.get("file_id", "")
+        duration = float(kwargs.get("duration", 15.0))
+        # "full" = emit entire clip once (for batch DAGs); "stream" = 100ms chunks
+        mode = kwargs.get("mode", "stream")
+        loop = bool(kwargs.get("loop", False))
+        pacing = kwargs.get("pacing", "realtime")
+
+        if not file_id:
+            return {}
+        file_id = self._resolve_path(file_id)
+        if not file_id:
+            return {}
+
+        if file_id != self._loaded_file:
+            try:
+                self._load_audio(file_id, duration)
+            except Exception as e:
+                logger.error("AudioSourceNode failed to load %s: %s", file_id, e)
+                return {}
+
+        if self._audio_data is None or self._audio_data.shape[1] == 0:
+            return {}
+
+        if mode == "full":
+            if loop:
+                if pacing == "downstream":
+                    # Skip the wall-clock gate: re-emit every tick and let
+                    # the downstream edge queue's maxsize=1 + blocking put
+                    # in _route_outputs backpressure us to consumer speed.
+                    self._last_full_emit_time = None
+                    return self._emit_full()
+                # realtime: re-emit the full clip paced by clip duration
+                # on the wall clock so downstream re-processes at roughly
+                # real-time without flooding the audio track.
+                clip_seconds = self._audio_data.shape[1] / SAMPLE_RATE
+                now = time.monotonic()
+                if (
+                    self._last_full_emit_time is not None
+                    and now - self._last_full_emit_time < clip_seconds
+                ):
+                    return {}
+                self._last_full_emit_time = now
+                return self._emit_full()
+            # Loop=false: emit the entire clip once per (file, mode) pair
+            # and then stay silent.
+            self._last_full_emit_time = None
+            key = (self._loaded_file, "full")
+            if self._full_emitted_key == key:
+                return {}
+            self._full_emitted_key = key
+            return self._emit_full()
+        # Stream mode: clear the full-mode flags so switching back to full
+        # later re-emits once.
+        self._full_emitted_key = None
+        self._last_full_emit_time = None
+        return self._emit_chunk(loop=loop, pacing=pacing)
+
+    @staticmethod
+    def _resolve_path(file_id: str) -> str | None:
+        """Resolve a file path. Absolute → cwd → ~/.daydream-scope/assets."""
+        if os.path.isabs(file_id) and os.path.exists(file_id):
+            return file_id
+        if os.path.exists(file_id):
+            return os.path.abspath(file_id)
+        from pathlib import Path
+
+        candidate = Path.home() / ".daydream-scope" / "assets" / file_id
+        if candidate.exists():
+            return str(candidate)
+        logger.warning("AudioSource: file not found: %s", file_id)
+        return None
+
+    def _emit_full(self) -> dict[str, Any]:
+        return {"audio": (torch.from_numpy(self._audio_data.copy()), SAMPLE_RATE)}
+
+    def _emit_chunk(
+        self, loop: bool = True, pacing: str = "realtime"
+    ) -> dict[str, Any]:
+        # Pace to real-time unless downstream-paced — in that mode the
+        # maxsize=1 edge queues handle rate limiting via backpressure.
+        if pacing != "downstream":
+            now = time.monotonic()
+            if self._last_call_time is not None:
+                elapsed = now - self._last_call_time
+                if elapsed < CHUNK_DURATION * 0.8:
+                    time.sleep(CHUNK_DURATION - elapsed)
+            self._last_call_time = time.monotonic()
+        else:
+            self._last_call_time = None
+
+        total = self._audio_data.shape[1]
+        if not loop and self._position >= total:
+            return {}
+
+        chunk = np.zeros((self._audio_data.shape[0], CHUNK_SAMPLES), dtype=np.float32)
+        remaining = CHUNK_SAMPLES
+        offset = 0
+        while remaining > 0:
+            avail = min(remaining, total - self._position)
+            if avail <= 0:
+                if not loop:
+                    # Stop at end of clip; emit a partial chunk (remaining
+                    # samples stay zero-padded).
+                    break
+                self._position = 0
+                avail = min(remaining, total - self._position)
+            chunk[:, offset : offset + avail] = self._audio_data[
+                :, self._position : self._position + avail
+            ]
+            self._position += avail
+            offset += avail
+            remaining -= avail
+        return {"audio": (torch.from_numpy(chunk), SAMPLE_RATE)}

--- a/src/scope/core/nodes/processor.py
+++ b/src/scope/core/nodes/processor.py
@@ -5,8 +5,10 @@ interface (input/output queues, worker thread).
 """
 
 import logging
+import os
 import queue
 import threading
+import time
 from typing import Any
 
 import torch
@@ -16,6 +18,10 @@ from .base import BaseNode
 logger = logging.getLogger(__name__)
 
 SLEEP_TIME = 0.01
+
+# Set SCOPE_NODE_TRACE=1 for per-node diagnostics: param updates,
+# route-outputs backpressure events. Off by default.
+_TRACE = os.environ.get("SCOPE_NODE_TRACE", "").lower() in ("1", "true", "yes")
 
 
 class NodeProcessor:
@@ -136,15 +142,28 @@ class NodeProcessor:
         # this guard a stream-level tweak like quantize_mode would fire
         # _needs_rerun on every custom node and cascade through the DAG.
         changed = False
+        changed_keys: list[str] = []
         for key, value in parameters.items():
             if key not in self._declared_param_names:
                 continue
             if self.parameters.get(key) != value:
                 changed = True
-                break
+                changed_keys.append(key)
         self.parameters.update(parameters)
         if changed:
             self._needs_rerun = True
+        if _TRACE:
+            accepted = {k: parameters[k] for k in changed_keys}
+            rejected = [
+                k for k in parameters.keys() if k not in self._declared_param_names
+            ]
+            if accepted or rejected:
+                logger.info(
+                    "[scope.update_parameters][%s] accepted=%s rejected_unknown=%s",
+                    self.node_id,
+                    accepted,
+                    rejected,
+                )
 
     def set_beat_cache_reset_rate(self, rate):  # PipelineProcessor compat
         pass
@@ -270,12 +289,23 @@ class NodeProcessor:
             out_queues = self.output_queues.get(port_name)
             if out_queues:
                 for oq in out_queues:
+                    block_start = time.monotonic() if _TRACE else 0.0
+                    blocks = 0
                     while not self.shutdown_event.is_set():
                         try:
                             oq.put(value, timeout=0.1)
                             break
                         except queue.Full:
+                            blocks += 1
                             continue
+                    if _TRACE and blocks > 0:
+                        logger.info(
+                            "[scope._route_outputs][%s:%s] blocked %.2fs (%d retries) on full downstream queue",
+                            self.node_id,
+                            port_name,
+                            time.monotonic() - block_start,
+                            blocks,
+                        )
 
     def _route_audio(self, value: Any) -> None:
         """Extract audio tensor and push to audio_output_queue for WebRTC."""
@@ -299,9 +329,19 @@ class NodeProcessor:
         # track hasn't finished serving the previous chunk, which is the
         # backpressure mechanism that rate-limits batch generators to
         # real-time playback instead of silently dropping audio.
+        block_start = time.monotonic() if _TRACE else 0.0
+        blocks = 0
         while not self.shutdown_event.is_set():
             try:
                 self.audio_output_queue.put((audio_tensor, audio_sr), timeout=0.1)
                 break
             except queue.Full:
+                blocks += 1
                 continue
+        if _TRACE and blocks > 0:
+            logger.info(
+                "[scope._route_audio][%s] blocked %.2fs (%d retries) on full audio_output_queue (WebRTC backpressure)",
+                self.node_id,
+                time.monotonic() - block_start,
+                blocks,
+            )

--- a/src/scope/core/nodes/processor.py
+++ b/src/scope/core/nodes/processor.py
@@ -9,6 +9,8 @@ import queue
 import threading
 from typing import Any
 
+import torch
+
 from .base import BaseNode
 
 logger = logging.getLogger(__name__)
@@ -21,8 +23,8 @@ class NodeProcessor:
     output queues fan out its results to downstream nodes.
 
     Source nodes (no inputs) execute once by default; nodes marked
-    ``continuous=True`` in their definition re-execute on every tick so
-    streaming sources and sinks stay alive.
+    ``continuous=True`` in their definition re-execute on every tick, which
+    is how streaming sources (audio) and sinks (audio loop) stay alive.
     """
 
     def __init__(
@@ -42,11 +44,31 @@ class NodeProcessor:
         self.external_queue_refs: list[tuple[dict, str]] = []
 
         definition = node.get_definition()
+        self.audio_input_ports: set[str] = {
+            p.name for p in definition.inputs if p.port_type == "audio"
+        }
+        # Output ports wired to a sink node via graph_executor. Only these
+        # route through ``audio_output_queue`` → FrameProcessor.get_audio().
+        # A node whose audio output feeds another node (e.g. AudioSource →
+        # VAEEncodeAudio) must NOT push to audio_output_queue: with
+        # maxsize=1 + blocking put, nothing would ever drain it and the
+        # worker would deadlock after the second emission.
+        self.audio_sink_ports: set[str] = set()
+        # Names of parameters this node actually declares. Global param
+        # updates (no node_id) are broadcast to every processor; without
+        # this filter a graph-level tweak (quantize_mode, modulations…)
+        # would spuriously flag every custom node for re-execution.
+        self._declared_param_names: set[str] = {p.name for p in definition.params}
 
-        # Consumed by FrameProcessor.get_audio_packet() on the sink feeder.
-        # Kept here (even without a routing implementation) so a NodeProcessor
-        # can stand in as the sink's feeder without crashing the audio path.
-        self.audio_output_queue: queue.Queue = queue.Queue(maxsize=10)
+        # Audio output queue consumed by FrameProcessor.get_audio() on the
+        # sink. Size 1 + blocking producer (see _route_audio) gives us
+        # backpressure: audio_decode stalls until AudioProcessingTrack has
+        # served enough of the current chunk to pull a new one, which
+        # cascades upstream through node-to-node edge queues and
+        # rate-limits batch generators to real-time playback.
+        self.audio_output_queue: queue.Queue[tuple[torch.Tensor, int]] = queue.Queue(
+            maxsize=1
+        )
 
         self.worker_thread: threading.Thread | None = None
         self.shutdown_event = threading.Event()
@@ -56,6 +78,26 @@ class NodeProcessor:
         self._source_executed = False
         self._has_executed = False
         self._continuous = definition.continuous
+        # Cached inputs from the last successful run, replayed when
+        # parameters change so non-continuous nodes can refresh their
+        # output without requiring upstream to re-emit.
+        self._last_inputs: dict[str, Any] = {}
+        self._needs_rerun = False
+
+        # Input ports whose upstream is transitively reachable from a
+        # ``continuous=True`` node. Populated by graph_executor at build
+        # time. When non-empty, ``_process_once`` waits until every
+        # dynamic port has received fresh data since the last run before
+        # firing, so a single upstream cycle triggers exactly one run
+        # (not one run per fresh-port arrival). Static ports — typically
+        # one-shot handles like MODEL/VAE/CONFIG — always latch from
+        # ``_last_inputs``. Empty set falls back to the legacy "fire on
+        # any fresh input" behaviour.
+        self.dynamic_input_ports: set[str] = set()
+        # Fresh values drained from input queues while waiting for every
+        # dynamic port to catch up. Draining unblocks upstream producers
+        # without committing to a run yet.
+        self._pending_inputs: dict[str, Any] = {}
 
         # PipelineProcessor interface compatibility: graph_executor populates
         # this for every processor; kept as an empty dict so that write is safe.
@@ -84,14 +126,25 @@ class NodeProcessor:
         self.shutdown_event.set()
         if self.worker_thread is not None:
             self.worker_thread.join(timeout=5.0)
-        try:
-            self.node.shutdown()
-        except Exception:
-            logger.exception("Error shutting down node %s", self.node_id)
         logger.info("NodeProcessor stopped: %s", self.node_id)
 
     def update_parameters(self, parameters: dict[str, Any]) -> None:
+        # Only mark the node dirty when the update actually touches a
+        # parameter this node declares AND the value differs from the
+        # current one. FrameProcessor.update_parameters broadcasts
+        # global updates (no node_id) to every processor, so without
+        # this guard a stream-level tweak like quantize_mode would fire
+        # _needs_rerun on every custom node and cascade through the DAG.
+        changed = False
+        for key, value in parameters.items():
+            if key not in self._declared_param_names:
+                continue
+            if self.parameters.get(key) != value:
+                changed = True
+                break
         self.parameters.update(parameters)
+        if changed:
+            self._needs_rerun = True
 
     def set_beat_cache_reset_rate(self, rate):  # PipelineProcessor compat
         pass
@@ -122,52 +175,94 @@ class NodeProcessor:
             all_queues = dict(self.input_queues)
 
         is_source_node = not all_queues
-
-        # Source nodes execute once; continuous=True nodes re-execute every
-        # tick (for streaming I/O).
-        if is_source_node and self._source_executed and not self._continuous:
-            self.shutdown_event.wait(1.0)
-            return
-
-        # Gather inputs. Continuous nodes consume whatever's available
-        # (empty inputs stay absent). Non-continuous nodes wait until every
-        # input queue has data, so they execute with a complete input set.
         inputs: dict[str, Any] = {}
-        if all_queues:
-            if self._continuous:
-                for port_name, q in all_queues.items():
-                    try:
-                        inputs[port_name] = q.get_nowait()
-                    except queue.Empty:
-                        pass
-            else:
+
+        if is_source_node:
+            # Source nodes run once, then re-run only when params change
+            # (or every tick when continuous).
+            if self._source_executed and not self._continuous and not self._needs_rerun:
+                self.shutdown_event.wait(1.0)
+                return
+        elif self._continuous:
+            # Continuous nodes: pick up whatever's currently in the queues
+            # and run every tick.
+            for port_name, q in all_queues.items():
+                try:
+                    inputs[port_name] = q.get_nowait()
+                except queue.Empty:
+                    pass
+        else:
+            # Non-continuous node with inputs:
+            # - First run waits until every port has received data at least
+            #   once so the latch cache (_last_inputs) is populated.
+            # - Subsequent runs drain fresh values into ``_pending_inputs``
+            #   (so upstream producers unblock immediately) and fire once
+            #   every dynamic input port has caught up. Static ports —
+            #   upstreams that never re-emit, e.g. MODEL/VAE handles —
+            #   are latched from ``_last_inputs``. Parameter changes on
+            #   this node bypass the gate via ``_needs_rerun``.
+            # - When ``dynamic_input_ports`` is empty (graph_executor did
+            #   not classify this node, e.g. a static-only subgraph), we
+            #   fall back to the legacy "fire on any fresh input" gate.
+            if not self._has_executed:
                 if any(q.empty() for q in all_queues.values()):
                     self.shutdown_event.wait(SLEEP_TIME)
                     return
                 inputs = {name: q.get_nowait() for name, q in all_queues.items()}
+            else:
+                for port_name, q in all_queues.items():
+                    try:
+                        self._pending_inputs[port_name] = q.get_nowait()
+                    except queue.Empty:
+                        pass
 
-        # Non-continuous nodes skip re-execution when no new inputs arrived
-        # and they already have a cached output.
-        if self._has_executed and not inputs and not self._continuous:
-            self.shutdown_event.wait(SLEEP_TIME)
-            return
+                if self._needs_rerun:
+                    fire = True
+                elif self.dynamic_input_ports:
+                    fire = self.dynamic_input_ports <= self._pending_inputs.keys()
+                else:
+                    fire = bool(self._pending_inputs)
+
+                if not fire:
+                    self.shutdown_event.wait(SLEEP_TIME)
+                    return
+
+                inputs = {}
+                for port_name in all_queues:
+                    if port_name in self._pending_inputs:
+                        inputs[port_name] = self._pending_inputs[port_name]
+                    elif port_name in self._last_inputs:
+                        inputs[port_name] = self._last_inputs[port_name]
+                self._pending_inputs.clear()
 
         outputs = self.node.execute(inputs, **self.parameters)
 
         if is_source_node:
             self._source_executed = True
+        self._needs_rerun = False
 
         if not outputs:
             self.shutdown_event.wait(SLEEP_TIME)
             return
 
         self._has_executed = True
+        self._last_inputs = inputs
         self._route_outputs(outputs)
 
     def _route_outputs(self, outputs: dict[str, Any]) -> None:
         for port_name, value in outputs.items():
             if value is None:
                 continue
+
+            # Audio outputs also feed the FrameProcessor's audio path
+            # — but only for ports that graph_executor wired to a sink,
+            # not every port whose type is "audio". Otherwise an
+            # intermediate audio-producing node (AudioSource → encoder)
+            # would also push to its own audio_output_queue, which
+            # nothing drains → worker deadlocks on the blocking put
+            # after the second emission.
+            if port_name in self.audio_sink_ports:
+                self._route_audio(value)
 
             # Fan out to all downstream queues on this port. Block briefly
             # when queues are full so producers throttle to consumer pace
@@ -181,3 +276,32 @@ class NodeProcessor:
                             break
                         except queue.Full:
                             continue
+
+    def _route_audio(self, value: Any) -> None:
+        """Extract audio tensor and push to audio_output_queue for WebRTC."""
+        if isinstance(value, tuple) and len(value) == 2:
+            audio_tensor, audio_sr = value
+        else:
+            audio_tensor = getattr(value, "waveform", None)
+            audio_sr = getattr(value, "sample_rate", 48000)
+        if audio_tensor is None:
+            return
+        if hasattr(audio_tensor, "is_cuda") and audio_tensor.is_cuda:
+            audio_tensor = audio_tensor.detach().cpu()
+        # VAE decoders (e.g. ACEStep) return (1, C, T); the audio track
+        # expects (C, T). Drop a leading singleton batch dim so the
+        # channel/interleave path in AudioProcessingTrack doesn't misread
+        # the layout and produce slowed-down / garbled playback.
+        if hasattr(audio_tensor, "dim") and audio_tensor.dim() == 3:
+            if audio_tensor.shape[0] == 1:
+                audio_tensor = audio_tensor.squeeze(0)
+        # Blocking-with-retry put. Stalls the worker thread when the audio
+        # track hasn't finished serving the previous chunk, which is the
+        # backpressure mechanism that rate-limits batch generators to
+        # real-time playback instead of silently dropping audio.
+        while not self.shutdown_event.is_set():
+            try:
+                self.audio_output_queue.put((audio_tensor, audio_sr), timeout=0.1)
+                break
+            except queue.Full:
+                continue

--- a/src/scope/server/audio_track.py
+++ b/src/scope/server/audio_track.py
@@ -100,9 +100,15 @@ class AudioProcessingTrack(MediaStreamTrack):
         if self.frame_processor.paused:
             return self._create_silence_frame()
 
-        # Drain all available audio from the queue to minimise latency
-        # for bursty or small-chunk pipelines.
-        while True:
+        samples_needed = self._samples_per_frame * self.channels
+
+        # Lazy drain: pull chunks from the queue only until the local buffer
+        # has enough samples to serve this frame. Leaving unconsumed chunks
+        # in ``audio_output_queue`` creates natural backpressure — producers
+        # block on the (small) queue's blocking put and cascade the stall
+        # upstream through node-to-node edge queues, matching production
+        # rate to real-time consumption without silent drops.
+        while self._buffered_samples < samples_needed:
             audio_packet = self.frame_processor.get_audio_packet()
             if audio_packet is None:
                 break
@@ -182,7 +188,6 @@ class AudioProcessingTrack(MediaStreamTrack):
             logger.warning("Audio buffer overflow, dropped oldest chunks")
 
         # Serve a 20ms frame from the buffer
-        samples_needed = self._samples_per_frame * self.channels
         if self._buffered_samples >= samples_needed:
             frame_parts: list[np.ndarray] = []
             remaining = samples_needed

--- a/src/scope/server/audio_track.py
+++ b/src/scope/server/audio_track.py
@@ -2,9 +2,12 @@ import asyncio
 import collections
 import fractions
 import logging
+import threading
 import time
+import weakref
 
 import numpy as np
+import torch
 from aiortc import MediaStreamTrack
 from aiortc.mediastreams import MediaStreamError
 from av import AudioFrame
@@ -23,6 +26,28 @@ AUDIO_TIME_BASE = fractions.Fraction(1, AUDIO_CLOCK_RATE)
 # in a single chunk after each denoising pass, and for TTS pipelines that may
 # generate many seconds of speech before playback catches up.
 AUDIO_MAX_BUFFER_SAMPLES = AUDIO_CLOCK_RATE * 60
+
+
+# Registry of live audio tracks so graph nodes that need the playhead (e.g.
+# ACE-Step's StreamVAEDecode skip gate, which mirrors the realtime demo's
+# ``audio_eng.position / SAMPLE_RATE`` read in pipeline.py) can query it
+# without a hard dependency on FrameProcessor. Weak refs so closed tracks
+# drop out automatically.
+_PLAYHEAD_LOCK = threading.Lock()
+_PLAYHEAD_TRACKS: "weakref.WeakSet[AudioProcessingTrack]" = weakref.WeakSet()
+
+
+def get_current_playhead_seconds() -> float | None:
+    """Return the playhead position of the first live audio track, in seconds.
+
+    Returns None if no track is registered yet or none are live. Callers
+    should treat None as "skip gate disabled this tick".
+    """
+    with _PLAYHEAD_LOCK:
+        for track in _PLAYHEAD_TRACKS:
+            if track.readyState == "live":
+                return track.playhead_seconds
+    return None
 
 
 class AudioProcessingTrack(MediaStreamTrack):
@@ -56,6 +81,19 @@ class AudioProcessingTrack(MediaStreamTrack):
         self._start: float | None = None
         self._timestamp: int = 0
         self._last_preserved_pts: int | None = None
+
+        with _PLAYHEAD_LOCK:
+            _PLAYHEAD_TRACKS.add(self)
+
+    @property
+    def playhead_seconds(self) -> float:
+        """Current playback position in seconds (monotonic recv timestamp).
+
+        Mirrors the realtime demo's ``audio_eng.position / SAMPLE_RATE``
+        (see ``demos/realtime_motion_graph/pipeline.py``). Value is 0 before
+        the first ``recv`` call.
+        """
+        return self._timestamp / AUDIO_CLOCK_RATE
 
     @staticmethod
     def _resample_audio(
@@ -131,6 +169,10 @@ class AudioProcessingTrack(MediaStreamTrack):
                 )
                 self._first_audio_logged = True
 
+            # numpy() rejects bfloat16/float16; upcast so half-precision tensors
+            # from GPU models (e.g. ACE-Step VAE decode) don't silently become silence.
+            if audio_tensor.dtype in (torch.bfloat16, torch.float16):
+                audio_tensor = audio_tensor.float()
             audio_np = audio_tensor.numpy()
             if audio_np.ndim == 1:
                 audio_np = audio_np.reshape(1, -1)

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -776,6 +776,18 @@ class FrameProcessor:
 
     def update_parameters(self, parameters: dict[str, Any]):
         """Update parameters that will be used in the next pipeline call."""
+        # Trace: surface every inbound parameter update at its entry point
+        # so we can distinguish "UI never sent anything" from "UI sent but
+        # was stripped upstream of the NodeProcessor dispatch".
+        import os as _os
+
+        if _os.environ.get("SCOPE_NODE_TRACE", "").lower() in ("1", "true", "yes"):
+            logger.info(
+                "[scope.FrameProcessor.update_parameters] inbound keys=%s node_id=%s",
+                sorted(parameters.keys()),
+                parameters.get("node_id"),
+            )
+
         # Always strip tempo-control keys so they never leak into pipelines,
         # even when the corresponding helper (scheduler/engine/tempo_sync) is absent.
 

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -173,6 +173,9 @@ def build_graph(
             q = stream_queues.get((node.id, e.to_port))
             if q is not None:
                 processor.input_queues[e.to_port] = q
+                # Mark audio ports so the processor consumes them differently
+                if e.to_port == "audio":
+                    processor.audio_input_ports.add(e.to_port)
 
     # 3) Set each producer's output_queues per port
     for node in graph.nodes:
@@ -203,6 +206,13 @@ def build_graph(
 
     # 3d) Resize inter-pipeline queues based on downstream pipeline requirements
     _resize_graph_queues(graph, node_processors)
+
+    # 3d2) Propagate "dynamic" marking from continuous source nodes forward.
+    # A non-continuous NodeProcessor only re-fires once every dynamic input
+    # port has caught up for the current upstream cycle; static ports latch
+    # from cache. Without this, latch-fallback fires the node once per
+    # fresh-port arrival, which can double or triple GPU work per cycle.
+    _mark_dynamic_input_ports(graph, node_processors)
 
     # 3e) Derive source_queues from processor input_queues (post-resize).
     # Also build per-source-node queue mappings for multi-source support.
@@ -237,6 +247,18 @@ def build_graph(
                 feeder_proc = node_processors.get(e.from_node)
                 if feeder_proc is not None:
                     sink_processors_by_node[sink_id] = feeder_proc
+                    # Audio edges to sinks are served via audio_output_queue,
+                    # not dedicated sink queues — skip queue allocation so
+                    # the feeder isn't blocked on a queue nobody drains.
+                    if e.from_port == "audio" or e.to_port == "audio":
+                        # Mark the feeder's audio output port as sink-bound
+                        # so its _route_outputs pushes into audio_output_queue
+                        # (NodeProcessor only — PipelineProcessor has its own
+                        # always-on audio path via put_nowait).
+                        sink_ports = getattr(feeder_proc, "audio_sink_ports", None)
+                        if sink_ports is not None:
+                            sink_ports.add(e.from_port)
+                        break
                     sink_node = node_by_id[sink_id]
                     sink_mode = sink_node.sink_mode
                     # WebRTC preview reads sink_queues_by_node; NDI/Spout/Syphon threads
@@ -404,6 +426,64 @@ def _validate_edge_ports(
                 )
     if errors:
         raise ValueError(f"Invalid graph ports: {'; '.join(errors)}")
+
+
+def _mark_dynamic_input_ports(
+    graph: GraphConfig,
+    node_processors: dict[str, Any],
+) -> None:
+    """Populate ``dynamic_input_ports`` on each NodeProcessor.
+
+    A node is "dynamic" if it is ``continuous=True`` (streaming source)
+    or reachable from one through stream edges. An input port on a
+    non-continuous node is "dynamic" when its upstream producer is
+    dynamic — meaning fresh values are expected once per upstream cycle.
+    Ports whose upstream is a one-shot static node (e.g. ``LoadModel``,
+    ``DiffusionConfig``) stay empty and fall back to latch-from-cache.
+
+    PipelineProcessor has its own tick loop and does not use this
+    attribute; we guard on ``hasattr`` rather than isinstance to avoid
+    dragging a type import into graph_executor.
+    """
+    dynamic_nodes: set[str] = set()
+    for node_id, proc in node_processors.items():
+        node = getattr(proc, "node", None)
+        if node is None:
+            continue
+        try:
+            if node.get_definition().continuous:
+                dynamic_nodes.add(node_id)
+        except Exception:
+            continue
+
+    # Fixed-point forward propagation over stream edges.
+    changed = True
+    while changed:
+        changed = False
+        for e in graph.edges:
+            if e.kind != "stream":
+                continue
+            if e.from_node in dynamic_nodes and e.to_node not in dynamic_nodes:
+                if e.to_node in node_processors:
+                    dynamic_nodes.add(e.to_node)
+                    changed = True
+
+    for node_id, proc in node_processors.items():
+        if not hasattr(proc, "dynamic_input_ports"):
+            continue
+        dynamic_ports: set[str] = set()
+        for e in graph.edges:
+            if e.kind != "stream" or e.to_node != node_id:
+                continue
+            if e.from_node in dynamic_nodes:
+                dynamic_ports.add(e.to_port)
+        proc.dynamic_input_ports = dynamic_ports
+        if dynamic_ports:
+            logger.debug(
+                "Node %s: dynamic input ports = %s",
+                node_id,
+                sorted(dynamic_ports),
+            )
 
 
 def _resize_graph_queues(

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -89,6 +89,10 @@ class PipelineProcessor:
         # record_queues_by_node). Updated by _resize_output_queue so cached
         # references stay in sync when a queue object is replaced.
         self.external_queue_refs: list[tuple[dict, str]] = []
+        # Input ports that carry audio (tensor, sample_rate) tuples instead
+        # of video frame tensors. Set by graph_executor when wiring audio
+        # edges so audio inputs don't get accumulated into a video chunk.
+        self.audio_input_ports: set[str] = set()
 
         # Audio output queue: (audio_tensor, sample_rate) tuples.
         # Consumed by FrameProcessor.get_audio() on the sink processor.

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -657,6 +657,18 @@ class WebRTCManager:
                         # Parse the JSON message
                         data = json.loads(message)
                         logger.debug(f"Received parameter update: {data}")
+                        import os as _os
+
+                        if _os.environ.get("SCOPE_NODE_TRACE", "").lower() in (
+                            "1",
+                            "true",
+                            "yes",
+                        ):
+                            logger.info(
+                                "[scope.webrtc.datachannel] inbound keys=%s node_id=%s",
+                                sorted(data.keys()) if isinstance(data, dict) else None,
+                                data.get("node_id") if isinstance(data, dict) else None,
+                            )
 
                         # Always handle paused immediately (before quantized
                         # scheduling) so pause/unpause is never delayed.

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -60,6 +60,39 @@ vpx.MIN_BITRATE = 5000000
 vpx.MAX_BITRATE = 10000000
 
 
+def _graph_produces_audio(graph_data: dict) -> bool:
+    """Return True when any node in the graph exposes an audio output.
+
+    Inspects custom-node definitions from :class:`NodeRegistry` and
+    pipeline configs so WebRTC can decide whether to open an audio
+    track for graphs that produce audio through custom nodes rather
+    than through a registered pipeline.
+    """
+    from scope.core.nodes.registry import NodeRegistry
+
+    for node in graph_data.get("nodes", []):
+        node_type = node.get("type")
+        if node_type == "node":
+            node_type_id = node.get("node_type_id")
+            if node_type_id:
+                node_cls = NodeRegistry.get(node_type_id)
+                if node_cls is not None:
+                    defn = node_cls.get_definition()
+                    if any(p.port_type == "audio" for p in defn.outputs):
+                        return True
+        elif node_type == "pipeline":
+            pid = node.get("pipeline_id")
+            if pid:
+                cfg = PipelineRegistry.get_config_class(pid)
+                if cfg and getattr(cfg, "produces_audio", False):
+                    return True
+    # Also treat any audio-kind edge as an audio-producing graph.
+    for edge in graph_data.get("edges", []):
+        if edge.get("from_port") == "audio" or edge.get("to_port") == "audio":
+            return True
+    return False
+
+
 def _parse_graph_node_ids(
     initial_parameters: dict,
 ) -> tuple[list[str], list[str], list[str], list[str], list[str], bool]:
@@ -478,6 +511,11 @@ class WebRTCManager:
                 )
 
             produces_audio = PipelineRegistry.chain_produces_audio(pipeline_ids)
+            # Graphs that emit audio through custom nodes (e.g. ACEStep)
+            # have no pipeline-produced audio, so also inspect the graph.
+            graph_data_for_audio = initial_parameters.get("graph")
+            if not produces_audio and graph_data_for_audio:
+                produces_audio = _graph_produces_audio(graph_data_for_audio)
             if produces_audio:
                 audio_track = AudioProcessingTrack(
                     frame_processor=frame_processor,


### PR DESCRIPTION
## Summary

Two fixes and one new endpoint that together make audio-only workflows (e.g. ACEStep audio cover, `AudioSourceNode` → `AudioSinkNode`) usable end-to-end: a headless capture endpoint for tests/MCP, a Sink node audio handle so imported audio workflows render correctly, and a dedicated `<audio>` element so Chrome reliably plays the incoming stream.

## Headless audio capture endpoint

- `HeadlessSession`: buffer raw `(channels, samples, sample_rate)` audio chunks in `_audio_chunks` as `_consume_frames` drains `FrameProcessor.get_audio()`. Expose `capture_audio()` that drains the buffer and returns a stereo 16-bit PCM WAV.
- `mcp_router`: add `GET /api/v1/session/audio` that delegates to `HeadlessSession.capture_audio()`, returning 404 when no session or no audio has been buffered.

Used to verify audio-producing graphs work without a browser.

## Sink node audio handle + reliable audio-only playback

Without these fixes the generated audio arrives over WebRTC but Chrome never plays it:

- Add a `stream:audio` input handle to `SinkNode` so the edge from an upstream audio-emitting node (`audio.AudioSink`) renders against a real target handle; otherwise React Flow drops the edge and the user sees an unconnected Sink when importing an ACEStep workflow.
- Add a persistent hidden `<audio>` element that always has `srcObject` set (with explicit `play()`) on `remoteStream` arrival. A zero-size `<video>` element is unreliable for audio under Chrome's autoplay policy; a dedicated audio element dodges that.
- Auto-unmute when the arriving stream has audio tracks but no video tracks, so the user doesn't have to click unmute on the first run of an audio-only workflow.

## Test plan

- [ ] Import the ACEStep audio cover workflow, hit Play, and verify audio plays without manually unmuting.
- [ ] Start a headless session with an audio-only graph, call `GET /api/v1/session/audio`, and verify a valid WAV is returned.
- [ ] Run a mixed audio+video graph and confirm video playback is unaffected.