### PR TITLE
feat: wire LTX i2v_image parameter to Reference Image UI

### DIFF
--- a/frontend/src/components/InputAndControlsPanel.tsx
+++ b/frontend/src/components/InputAndControlsPanel.tsx
@@ -95,6 +95,8 @@ interface InputAndControlsPanelProps {
   isDownloading?: boolean;
   // Images input support - presence of images field in pipeline schema
   supportsImages?: boolean;
+  // i2v image input support - presence of i2v_image field in pipeline schema (LTX)
+  supportsI2V?: boolean;
   // FFLF (First-Frame-Last-Frame) extension mode
   firstFrameImage?: string;
   onFirstFrameImageChange?: (imagePath: string | undefined) => void;
@@ -165,6 +167,7 @@ export function InputAndControlsPanel({
   onSendHints,
   isDownloading = false,
   supportsImages = false,
+  supportsI2V = false,
   firstFrameImage,
   onFirstFrameImageChange,
   lastFrameImage,
@@ -654,8 +657,8 @@ export function InputAndControlsPanel({
           </div>
         )}
 
-        {/* Reference Images - show when VACE enabled OR when pipeline supports images without VACE */}
-        {(vaceEnabled || (supportsImages && !pipeline?.supportsVACE)) && (
+        {/* Reference Images - show when VACE enabled OR when pipeline supports images without VACE OR when pipeline supports i2v */}
+        {(vaceEnabled || (supportsImages && !pipeline?.supportsVACE) || supportsI2V) && (
           <div>
             <ImageManager
               images={refImages}
@@ -666,12 +669,16 @@ export function InputAndControlsPanel({
               label={
                 vaceEnabled && pipeline?.supportsVACE
                   ? "Reference Images"
-                  : "Images"
+                  : supportsI2V
+                    ? "Reference Image"
+                    : "Images"
               }
               tooltip={
                 vaceEnabled && pipeline?.supportsVACE
                   ? "Select reference images for VACE conditioning. Images will guide the video generation style and content."
-                  : "Select images to send to the pipeline for conditioning."
+                  : supportsI2V
+                    ? "Select a reference image for image-to-video generation."
+                    : "Select images to send to the pipeline for conditioning."
               }
             />
             {onSendHints && refImages && refImages.length > 0 && (

--- a/frontend/src/hooks/usePipelines.ts
+++ b/frontend/src/hooks/usePipelines.ts
@@ -26,6 +26,10 @@ export function usePipelines() {
         const supportsImages =
           schema.config_schema?.properties?.images !== undefined;
 
+        // Check if pipeline supports i2v image input (has i2v_image field in schema)
+        const supportsI2V =
+          schema.config_schema?.properties?.i2v_image !== undefined;
+
         transformed[id] = {
           name: schema.name,
           about: schema.description,
@@ -55,6 +59,7 @@ export function usePipelines() {
           pluginName: schema.plugin_name ?? undefined,
           supportsControllerInput,
           supportsImages,
+          supportsI2V,
           configSchema: schema.config_schema,
         };
       }

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -1382,6 +1382,11 @@ export function StreamPage() {
       sendParameterUpdate({
         vace_ref_images: imagePaths,
       });
+    } else if (currentPipeline?.supportsI2V) {
+      // LTX i2v pipeline - use i2v_image (single image)
+      sendParameterUpdate({
+        i2v_image: imagePaths[0] ?? null,
+      });
     } else if (currentPipeline?.supportsImages) {
       // Non-VACE pipeline with images support - use images
       sendParameterUpdate({
@@ -2806,6 +2811,11 @@ export function StreamPage() {
         }
         initialParameters.vace_enabled = vaceEnabled;
       } else if (
+        currentPipeline?.supportsI2V &&
+        settings.refImages?.length
+      ) {
+        initialParameters.i2v_image = settings.refImages[0];
+      } else if (
         currentPipeline?.supportsImages &&
         settings.refImages?.length
       ) {
@@ -3336,6 +3346,7 @@ export function StreamPage() {
                 supportsImages={
                   pipelines?.[settings.pipelineId]?.supportsImages
                 }
+                supportsI2V={pipelines?.[settings.pipelineId]?.supportsI2V}
                 firstFrameImage={settings.firstFrameImage}
                 onFirstFrameImageChange={handleFirstFrameImageChange}
                 lastFrameImage={settings.lastFrameImage}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -163,6 +163,8 @@ export interface PipelineInfo {
   supportsControllerInput?: boolean;
   // Images input support - presence of images field in pipeline schema
   supportsImages?: boolean;
+  // i2v image input support - presence of i2v_image field in pipeline schema (LTX)
+  supportsI2V?: boolean;
   // Raw config schema for dynamic settings UI
   configSchema?: import("../lib/api").PipelineConfigSchema;
 }


### PR DESCRIPTION
## Summary

- Adds `supportsI2V` detection in `usePipelines.ts` by checking for `i2v_image` in the pipeline's `config_schema.properties`
- Adds `supportsI2V?: boolean` to the `PipelineInfo` interface in `types/index.ts`
- Wires `supportsI2V` through `StreamPage.tsx`: passes prop to `InputAndControlsPanel`, adds i2v branch in `handleSendHints` (sends `i2v_image: imagePaths[0]`), and includes `i2v_image` in initial session parameters
- Updates `InputAndControlsPanel.tsx` to accept `supportsI2V` prop and show `ImageManager` for LTX workflows with appropriate label ("Reference Image") and tooltip

## Test plan

- [ ] Load an LTX pipeline in Scope — ImageManager UI should appear in the controls panel
- [ ] Upload/select an image — clicking send should send `i2v_image` parameter to the backend
- [ ] Confirm max 1 image enforced in i2v mode
- [ ] Load a VACE pipeline — verify no regression (VACE reference images still work)
- [ ] Load a non-VACE `images`-supporting pipeline — verify no regression
- [ ] Load a pipeline with none of the above — ImageManager should not appear

Closes [DAY-54](/DAY/issues/DAY-54)

🤖 Generated with [Claude Code](https://claude.com/claude-code)