### PR TITLE
[harness testing] feat: add web_app input source type (Playwright headless browser)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ midi = [
     "mido>=1.3.0",
     "python-rtmidi>=1.5.0",
 ]
+web = [
+    "playwright>=1.40.0",
+]
 
 [project.scripts]
 daydream-scope = "scope.server.app:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ midi = [
 ]
 web = [
     "playwright>=1.40.0",
+    "Pillow>=9.0",
 ]
 
 [project.scripts]

--- a/src/scope/core/inputs/__init__.py
+++ b/src/scope/core/inputs/__init__.py
@@ -48,6 +48,13 @@ def get_input_source_classes() -> dict[str, type[InputSource]]:
     except Exception:
         pass
 
+    try:
+        from .web_app import WebAppInputSource
+
+        sources[WebAppInputSource.source_id] = WebAppInputSource
+    except Exception:
+        pass
+
     return sources
 
 

--- a/src/scope/core/inputs/web_app.py
+++ b/src/scope/core/inputs/web_app.py
@@ -44,7 +44,7 @@ class WebAppInputSource(InputSource):
     def is_available(cls) -> bool:
         """Check if Playwright is installed."""
         try:
-            import playwright  # noqa: F401
+            from playwright.sync_api import sync_playwright  # noqa: F401
 
             return True
         except ImportError:
@@ -83,14 +83,14 @@ class WebAppInputSource(InputSource):
             self._cleanup()
             return False
 
-    def receive_frame(self, timeout_ms: int = 100) -> np.ndarray | None:
+    def receive_frame(self, timeout_ms: int = 5000) -> np.ndarray | None:
         """Capture a screenshot and return it as an RGB numpy array."""
-        if not self._connected or self._page is None:
-            return None
         try:
             from PIL import Image
 
             with self._lock:
+                if not self._connected or self._page is None:
+                    return None
                 png_bytes = self._page.screenshot(type="png", timeout=timeout_ms)
 
             img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
@@ -101,25 +101,19 @@ class WebAppInputSource(InputSource):
 
     def disconnect(self):
         """Disconnect and release browser resources."""
-        self._connected = False
         self._cleanup()
 
     def _cleanup(self):
-        try:
-            if self._page:
-                self._page.close()
-        except Exception:
-            pass
-        try:
-            if self._browser:
-                self._browser.close()
-        except Exception:
-            pass
-        try:
-            if self._playwright:
-                self._playwright.stop()
-        except Exception:
-            pass
-        self._page = None
-        self._browser = None
-        self._playwright = None
+        with self._lock:
+            self._connected = False
+            page, browser, pw = self._page, self._browser, self._playwright
+            self._page = self._browser = self._playwright = None
+
+        # Close resources outside the lock to avoid blocking receive_frame
+        for resource, method in ((page, "close"), (browser, "close"), (pw, "stop")):
+            if resource is None:
+                continue
+            try:
+                getattr(resource, method)()
+            except Exception:
+                pass

--- a/src/scope/core/inputs/web_app.py
+++ b/src/scope/core/inputs/web_app.py
@@ -1,0 +1,125 @@
+"""Web App input source implementation.
+
+Uses Playwright for headless browser frame capture.
+Install with: uv sync --extra web && uv run playwright install chromium
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import threading
+from typing import ClassVar
+
+import numpy as np
+
+from .interface import InputSource, InputSourceInfo
+
+logger = logging.getLogger(__name__)
+
+
+class WebAppInputSource(InputSource):
+    """Input source that captures frames from a local HTML file or URL.
+
+    Uses Playwright's headless Chromium browser to render and capture frames.
+    Install the optional dependency with:
+        uv sync --extra web && uv run playwright install chromium
+    """
+
+    source_id: ClassVar[str] = "web_app"
+    source_name: ClassVar[str] = "Web App"
+    source_description: ClassVar[str] = (
+        "Capture frames from a local HTML file or URL using a headless browser. "
+        "Requires Playwright: uv sync --extra web && uv run playwright install chromium"
+    )
+
+    def __init__(self):
+        self._browser = None
+        self._page = None
+        self._playwright = None
+        self._lock = threading.Lock()
+        self._connected = False
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """Check if Playwright is installed."""
+        try:
+            import playwright  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    def list_sources(self, timeout_ms: int = 5000) -> list[InputSourceInfo]:
+        """No discovery needed — user provides URL or file path directly."""
+        return []
+
+    def connect(self, identifier: str) -> bool:
+        """Connect to a web app by file path or URL.
+
+        Args:
+            identifier: Local file path or http(s):// URL.
+        """
+        try:
+            from playwright.sync_api import sync_playwright
+
+            self._playwright = sync_playwright().start()
+            self._browser = self._playwright.chromium.launch(headless=True)
+            self._page = self._browser.new_page()
+
+            # Local files need file:// prefix
+            if identifier.startswith(("http://", "https://", "file://")):
+                url = identifier
+            else:
+                url = f"file://{identifier}"
+
+            self._page.goto(url, wait_until="networkidle", timeout=30000)
+            self._connected = True
+            logger.info(f"WebApp connected to '{identifier}'")
+            return True
+        except Exception as e:
+            logger.error(f"WebApp connect failed: {e}")
+            self._connected = False
+            self._cleanup()
+            return False
+
+    def receive_frame(self, timeout_ms: int = 100) -> np.ndarray | None:
+        """Capture a screenshot and return it as an RGB numpy array."""
+        if not self._connected or self._page is None:
+            return None
+        try:
+            from PIL import Image
+
+            with self._lock:
+                png_bytes = self._page.screenshot(type="png", timeout=timeout_ms)
+
+            img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+            return np.array(img, dtype=np.uint8)
+        except Exception as e:
+            logger.error(f"WebApp receive_frame failed: {e}")
+            return None
+
+    def disconnect(self):
+        """Disconnect and release browser resources."""
+        self._connected = False
+        self._cleanup()
+
+    def _cleanup(self):
+        try:
+            if self._page:
+                self._page.close()
+        except Exception:
+            pass
+        try:
+            if self._browser:
+                self._browser.close()
+        except Exception:
+            pass
+        try:
+            if self._playwright:
+                self._playwright.stop()
+        except Exception:
+            pass
+        self._page = None
+        self._browser = None
+        self._playwright = None

--- a/src/scope/server/source_manager.py
+++ b/src/scope/server/source_manager.py
@@ -334,7 +334,13 @@ class SourceManager:
         for node in graph.nodes:
             if node.type != "source":
                 continue
-            if node.source_mode not in ("spout", "ndi", "syphon", "video_file", "web_app"):
+            if node.source_mode not in (
+                "spout",
+                "ndi",
+                "syphon",
+                "video_file",
+                "web_app",
+            ):
                 continue
             source_name = node.source_name or ""
             node_id = node.id

--- a/src/scope/server/source_manager.py
+++ b/src/scope/server/source_manager.py
@@ -334,7 +334,7 @@ class SourceManager:
         for node in graph.nodes:
             if node.type != "source":
                 continue
-            if node.source_mode not in ("spout", "ndi", "syphon", "video_file"):
+            if node.source_mode not in ("spout", "ndi", "syphon", "video_file", "web_app"):
                 continue
             source_name = node.source_name or ""
             node_id = node.id


### PR DESCRIPTION
## Summary

- Adds a native `web_app` input source type that captures frames from a local HTML file or HTTP(S) URL using Playwright's headless Chromium browser
- Follows the same `InputSource` pattern as NDI, Syphon, video_file
- `is_available()` returns `False` gracefully when Playwright is not installed (optional dependency)
- `playwright>=1.40.0` added as optional `[web]` extra in `pyproject.toml`

Closes DAY-55 (parent: DAY-34).
PR #874 (docs-only, wrong repo) was already closed.

## Usage

```json
{
  "nodes": [
    {"id": "web", "type": "source", "source_mode": "web_app", "source_name": "/path/to/app.html"}
  ]
}
```

Or with a URL:
```json
{"source_mode": "web_app", "source_name": "http://localhost:3000"}
```

Install:
```bash
uv sync --extra web && uv run playwright install chromium
```

## Changes

- `src/scope/core/inputs/web_app.py` — new `WebAppInputSource` class
- `src/scope/core/inputs/__init__.py` — register `web_app` in `get_input_source_classes()`
- `src/scope/server/source_manager.py` — add `"web_app"` to allowed source modes
- `pyproject.toml` — add `[web]` optional dependency group with `playwright>=1.40.0`

## Test plan

- [ ] `GET /api/v1/input-sources` returns `web_app` in the source list
- [ ] `WebAppInputSource.is_available()` returns `False` when Playwright is not installed
- [ ] Connecting to a local HTML file produces RGB frames via `receive_frame()`
- [ ] Connecting to `http://localhost:3000` produces RGB frames
- [ ] Session start with `source_mode: "web_app"` works in graph mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)