### PR TITLE
Post-session NPS survey

### DIFF
--- a/frontend/src/components/SurveyModal.tsx
+++ b/frontend/src/components/SurveyModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import {
   Dialog,
   DialogContent,
@@ -22,10 +22,6 @@ interface SurveyShellProps {
   title: string;
   description: string;
   size?: ShellSize;
-  /** Event name to fire when the modal opens. */
-  shownEvent?: string;
-  /** Event name to fire when the user skips/dismisses without answering. */
-  skippedEvent?: string;
   children: ReactNode;
 }
 
@@ -35,26 +31,15 @@ function SurveyShell({
   title,
   description,
   size = "md",
-  shownEvent,
-  skippedEvent,
   children,
 }: SurveyShellProps) {
-  // Fire _shown on open so we have a denominator for response rates.
-  useEffect(() => {
-    if (open && shownEvent) {
-      trackEvent(shownEvent);
-    }
-  }, [open, shownEvent]);
-
+  // Intentionally no telemetry on open, skip, or dismiss. The only event fired
+  // by surveys is a single `survey` event on answer (see child components).
   const handleOpenChange = (isOpen: boolean) => {
-    if (!isOpen) {
-      if (skippedEvent) trackEvent(skippedEvent);
-      onClose();
-    }
+    if (!isOpen) onClose();
   };
 
   const handleSkip = () => {
-    if (skippedEvent) trackEvent(skippedEvent);
     onClose();
   };
 
@@ -119,7 +104,7 @@ interface SurveyProps {
 
 export function SeanEllisSurvey({ open, onClose }: SurveyProps) {
   const handleSelect = (value: SeanEllisResponse) => {
-    trackEvent("sean_ellis_response", { response: value });
+    trackEvent("survey", { name: "sean_ellis", response: value });
     onClose();
   };
 
@@ -130,8 +115,6 @@ export function SeanEllisSurvey({ open, onClose }: SurveyProps) {
       title="Help us improve Scope"
       description="How would you feel if you could no longer use Daydream Scope?"
       size="md"
-      shownEvent="sean_ellis_shown"
-      skippedEvent="sean_ellis_skipped"
     >
       <div
         role="radiogroup"
@@ -186,7 +169,7 @@ export function SeanEllisSurvey({ open, onClose }: SurveyProps) {
 
 export function NpsSurvey({ open, onClose }: SurveyProps) {
   const handleSelect = (score: number) => {
-    trackEvent("nps_response", { score });
+    trackEvent("survey", { name: "nps", response: score });
     onClose();
   };
 
@@ -197,8 +180,6 @@ export function NpsSurvey({ open, onClose }: SurveyProps) {
       title="Help us improve Scope"
       description="How likely are you to recommend Daydream Scope to a friend or colleague?"
       size="lg"
-      shownEvent="nps_shown"
-      skippedEvent="nps_skipped"
     >
       <div className="mt-2">
         <div

--- a/frontend/src/components/SurveyModal.tsx
+++ b/frontend/src/components/SurveyModal.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "./ui/dialog";
+import { Button } from "./ui/button";
+import { trackEvent } from "../lib/analytics";
+
+type SeanEllisResponse =
+  | "very_disappointed"
+  | "somewhat_disappointed"
+  | "not_disappointed";
+
+interface SurveyModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SEAN_ELLIS_OPTIONS: { label: string; value: SeanEllisResponse }[] = [
+  { label: "Very disappointed", value: "very_disappointed" },
+  { label: "Somewhat disappointed", value: "somewhat_disappointed" },
+  { label: "Not disappointed", value: "not_disappointed" },
+];
+
+export function SurveyModal({ open, onClose }: SurveyModalProps) {
+  const [step, setStep] = useState<"sean_ellis" | "nps">("sean_ellis");
+
+  const handleSeanEllisSelect = (value: SeanEllisResponse) => {
+    trackEvent("sean_ellis_response", { response: value });
+    setStep("nps");
+  };
+
+  const handleNpsSelect = (score: number) => {
+    trackEvent("nps_response", { score });
+    onClose();
+  };
+
+  const handleSkip = () => {
+    onClose();
+  };
+
+  // Reset step when modal reopens (shouldn't happen, but defensive)
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        {step === "sean_ellis" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Quick question</DialogTitle>
+              <DialogDescription>
+                How would you feel if you could no longer use Daydream Scope?
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col gap-2 mt-2">
+              {SEAN_ELLIS_OPTIONS.map(({ label, value }) => (
+                <Button
+                  key={value}
+                  variant="outline"
+                  className="justify-start text-left h-auto py-3 px-4"
+                  onClick={() => handleSeanEllisSelect(value)}
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+            <div className="flex justify-end mt-1">
+              <button
+                onClick={handleSkip}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
+              >
+                Skip
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>One more</DialogTitle>
+              <DialogDescription>
+                How likely are you to recommend Daydream Scope to a friend or
+                colleague?
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-2">
+              <div className="flex gap-1 flex-wrap justify-center">
+                {Array.from({ length: 11 }, (_, i) => (
+                  <Button
+                    key={i}
+                    variant="outline"
+                    className="w-10 h-10 p-0 text-sm font-medium"
+                    onClick={() => handleNpsSelect(i)}
+                  >
+                    {i}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex justify-between mt-1 px-1">
+                <span className="text-xs text-muted-foreground">
+                  Not likely
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  Very likely
+                </span>
+              </div>
+            </div>
+            <div className="flex justify-end mt-1">
+              <button
+                onClick={handleSkip}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
+              >
+                Skip
+              </button>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/SurveyModal.tsx
+++ b/frontend/src/components/SurveyModal.tsx
@@ -60,7 +60,25 @@ function SurveyShell({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className={cn(size === "lg" ? "max-w-lg" : "max-w-md")}>
+      <DialogContent
+        className={cn(
+          "overflow-hidden",
+          size === "lg" ? "max-w-lg" : "max-w-md"
+        )}
+      >
+        {/* Brand "fog" aurora — static CSS version of the onboarding
+            FogOfWarBackground effect. Subtle, non-interactive. */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10"
+          style={{
+            background: `
+              radial-gradient(ellipse 80% 60% at 85% 10%, rgba(255, 152, 46, 0.10) 0%, transparent 60%),
+              radial-gradient(ellipse 70% 60% at 15% 90%, rgba(47, 190, 197, 0.09) 0%, transparent 60%),
+              radial-gradient(ellipse 60% 50% at 50% 50%, rgba(247, 59, 65, 0.05) 0%, transparent 65%)
+            `,
+          }}
+        />
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
@@ -118,20 +136,45 @@ export function SeanEllisSurvey({ open, onClose }: SurveyProps) {
       <div
         role="radiogroup"
         aria-label="Disappointment level"
-        className="flex flex-col gap-2 mt-2"
+        className="flex flex-col mt-2"
       >
-        {SEAN_ELLIS_OPTIONS.map(({ label, value }) => (
-          <Button
-            key={value}
-            role="radio"
-            aria-checked={false}
-            variant="outline"
-            className="justify-start text-left h-auto py-3 px-4"
-            onClick={() => handleSelect(value)}
-          >
-            {label}
-          </Button>
-        ))}
+        {SEAN_ELLIS_OPTIONS.map(({ label, value }, i) => {
+          // Brand gradient mapping: "Very disappointed" is the strong PMF
+          // signal → teal (positive end), "Not disappointed" → red (negative
+          // end), middle → orange. Matches the NPS scale ordering and uses
+          // the onboarding fog-of-war palette. Applied on hover only so
+          // default state doesn't bias the user.
+          const bucketHover =
+            i === 0
+              ? "hover:bg-[#2FBEC5]/15 hover:border-[#2FBEC5]/25"
+              : i === 1
+                ? "hover:bg-[#FF982E]/15 hover:border-[#FF982E]/25"
+                : "hover:bg-[#F73B41]/15 hover:border-[#F73B41]/25";
+          // Connect buttons vertically: first keeps its top radius, last
+          // keeps its bottom radius, middle collapses.
+          const radius =
+            i === 0
+              ? "rounded-t-md rounded-b-none"
+              : i === SEAN_ELLIS_OPTIONS.length - 1
+                ? "rounded-b-md rounded-t-none"
+                : "rounded-none";
+          return (
+            <Button
+              key={value}
+              role="radio"
+              aria-checked={false}
+              variant="outline"
+              className={cn(
+                "justify-start text-left h-11 px-4 -mt-px first:mt-0 focus:z-10",
+                radius,
+                bucketHover
+              )}
+              onClick={() => handleSelect(value)}
+            >
+              {label}
+            </Button>
+          );
+        })}
       </div>
     </SurveyShell>
   );
@@ -165,14 +208,16 @@ export function NpsSurvey({ open, onClose }: SurveyProps) {
           className="flex flex-nowrap"
         >
           {Array.from({ length: 11 }, (_, i) => {
-            // Promoter/passive/detractor tints applied on hover only so
-            // the default state doesn't bias the user.
+            // Brand gradient mapping: promoters (9-10) → teal (positive end),
+            // passives (7-8) → orange, detractors (0-6) → red. Uses the
+            // onboarding fog-of-war palette. Applied on hover only so the
+            // default state doesn't bias the user.
             const bucketHover =
               i >= 9
-                ? "hover:bg-green-500/15 hover:border-green-500/40"
+                ? "hover:bg-[#2FBEC5]/15 hover:border-[#2FBEC5]/25"
                 : i >= 7
-                  ? "hover:bg-yellow-500/15 hover:border-yellow-500/40"
-                  : "hover:bg-red-500/15 hover:border-red-500/40";
+                  ? "hover:bg-[#FF982E]/15 hover:border-[#FF982E]/25"
+                  : "hover:bg-[#F73B41]/15 hover:border-[#F73B41]/25";
             // Connect buttons: only the first keeps its left radius,
             // only the last keeps its right radius.
             const radius =

--- a/frontend/src/components/SurveyModal.tsx
+++ b/frontend/src/components/SurveyModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, type ReactNode } from "react";
 import {
   Dialog,
   DialogContent,
@@ -8,16 +8,85 @@ import {
 } from "./ui/dialog";
 import { Button } from "./ui/button";
 import { trackEvent } from "../lib/analytics";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Shared shell
+// ---------------------------------------------------------------------------
+
+type ShellSize = "md" | "lg";
+
+interface SurveyShellProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+  size?: ShellSize;
+  /** Event name to fire when the modal opens. */
+  shownEvent?: string;
+  /** Event name to fire when the user skips/dismisses without answering. */
+  skippedEvent?: string;
+  children: ReactNode;
+}
+
+function SurveyShell({
+  open,
+  onClose,
+  title,
+  description,
+  size = "md",
+  shownEvent,
+  skippedEvent,
+  children,
+}: SurveyShellProps) {
+  // Fire _shown on open so we have a denominator for response rates.
+  useEffect(() => {
+    if (open && shownEvent) {
+      trackEvent(shownEvent);
+    }
+  }, [open, shownEvent]);
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      if (skippedEvent) trackEvent(skippedEvent);
+      onClose();
+    }
+  };
+
+  const handleSkip = () => {
+    if (skippedEvent) trackEvent(skippedEvent);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className={cn(size === "lg" ? "max-w-lg" : "max-w-md")}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {children}
+        <div className="flex justify-end mt-1">
+          <button
+            onClick={handleSkip}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
+          >
+            Skip
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sean Ellis (vertical / stacked)
+// ---------------------------------------------------------------------------
 
 type SeanEllisResponse =
   | "very_disappointed"
   | "somewhat_disappointed"
   | "not_disappointed";
-
-interface SurveyModalProps {
-  open: boolean;
-  onClose: () => void;
-}
 
 const SEAN_ELLIS_OPTIONS: { label: string; value: SeanEllisResponse }[] = [
   { label: "Very disappointed", value: "very_disappointed" },
@@ -25,104 +94,119 @@ const SEAN_ELLIS_OPTIONS: { label: string; value: SeanEllisResponse }[] = [
   { label: "Not disappointed", value: "not_disappointed" },
 ];
 
-export function SurveyModal({ open, onClose }: SurveyModalProps) {
-  const [step, setStep] = useState<"sean_ellis" | "nps">("sean_ellis");
+interface SurveyProps {
+  open: boolean;
+  onClose: () => void;
+}
 
-  const handleSeanEllisSelect = (value: SeanEllisResponse) => {
+export function SeanEllisSurvey({ open, onClose }: SurveyProps) {
+  const handleSelect = (value: SeanEllisResponse) => {
     trackEvent("sean_ellis_response", { response: value });
-    setStep("nps");
+    onClose();
   };
 
-  const handleNpsSelect = (score: number) => {
+  return (
+    <SurveyShell
+      open={open}
+      onClose={onClose}
+      title="Help us improve Scope"
+      description="How would you feel if you could no longer use Daydream Scope?"
+      size="md"
+      shownEvent="sean_ellis_shown"
+      skippedEvent="sean_ellis_skipped"
+    >
+      <div
+        role="radiogroup"
+        aria-label="Disappointment level"
+        className="flex flex-col gap-2 mt-2"
+      >
+        {SEAN_ELLIS_OPTIONS.map(({ label, value }) => (
+          <Button
+            key={value}
+            role="radio"
+            aria-checked={false}
+            variant="outline"
+            className="justify-start text-left h-auto py-3 px-4"
+            onClick={() => handleSelect(value)}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+    </SurveyShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NPS (horizontal / traditional)
+// ---------------------------------------------------------------------------
+
+export function NpsSurvey({ open, onClose }: SurveyProps) {
+  const handleSelect = (score: number) => {
     trackEvent("nps_response", { score });
     onClose();
   };
 
-  const handleSkip = () => {
-    onClose();
-  };
-
-  // Reset step when modal reopens (shouldn't happen, but defensive)
-  const handleOpenChange = (isOpen: boolean) => {
-    if (!isOpen) {
-      onClose();
-    }
-  };
-
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md">
-        {step === "sean_ellis" ? (
-          <>
-            <DialogHeader>
-              <DialogTitle>Quick question</DialogTitle>
-              <DialogDescription>
-                How would you feel if you could no longer use Daydream Scope?
-              </DialogDescription>
-            </DialogHeader>
-            <div className="flex flex-col gap-2 mt-2">
-              {SEAN_ELLIS_OPTIONS.map(({ label, value }) => (
-                <Button
-                  key={value}
-                  variant="outline"
-                  className="justify-start text-left h-auto py-3 px-4"
-                  onClick={() => handleSeanEllisSelect(value)}
-                >
-                  {label}
-                </Button>
-              ))}
-            </div>
-            <div className="flex justify-end mt-1">
-              <button
-                onClick={handleSkip}
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
+    <SurveyShell
+      open={open}
+      onClose={onClose}
+      title="Help us improve Scope"
+      description="How likely are you to recommend Daydream Scope to a friend or colleague?"
+      size="lg"
+      shownEvent="nps_shown"
+      skippedEvent="nps_skipped"
+    >
+      <div className="mt-2">
+        <div
+          role="radiogroup"
+          aria-label="Net Promoter Score, 0 to 10"
+          aria-describedby="nps-anchors"
+          className="flex flex-nowrap"
+        >
+          {Array.from({ length: 11 }, (_, i) => {
+            // Promoter/passive/detractor tints applied on hover only so
+            // the default state doesn't bias the user.
+            const bucketHover =
+              i >= 9
+                ? "hover:bg-green-500/15 hover:border-green-500/40"
+                : i >= 7
+                  ? "hover:bg-yellow-500/15 hover:border-yellow-500/40"
+                  : "hover:bg-red-500/15 hover:border-red-500/40";
+            // Connect buttons: only the first keeps its left radius,
+            // only the last keeps its right radius.
+            const radius =
+              i === 0
+                ? "rounded-l-md rounded-r-none"
+                : i === 10
+                  ? "rounded-r-md rounded-l-none"
+                  : "rounded-none";
+            return (
+              <Button
+                key={i}
+                role="radio"
+                aria-checked={false}
+                variant="outline"
+                className={cn(
+                  "flex-1 min-w-0 h-11 p-0 text-sm font-medium -ml-px first:ml-0 focus:z-10",
+                  radius,
+                  bucketHover
+                )}
+                onClick={() => handleSelect(i)}
               >
-                Skip
-              </button>
-            </div>
-          </>
-        ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle>One more</DialogTitle>
-              <DialogDescription>
-                How likely are you to recommend Daydream Scope to a friend or
-                colleague?
-              </DialogDescription>
-            </DialogHeader>
-            <div className="mt-2">
-              <div className="flex gap-1 flex-wrap justify-center">
-                {Array.from({ length: 11 }, (_, i) => (
-                  <Button
-                    key={i}
-                    variant="outline"
-                    className="w-10 h-10 p-0 text-sm font-medium"
-                    onClick={() => handleNpsSelect(i)}
-                  >
-                    {i}
-                  </Button>
-                ))}
-              </div>
-              <div className="flex justify-between mt-1 px-1">
-                <span className="text-xs text-muted-foreground">
-                  Not likely
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  Very likely
-                </span>
-              </div>
-            </div>
-            <div className="flex justify-end mt-1">
-              <button
-                onClick={handleSkip}
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
-              >
-                Skip
-              </button>
-            </div>
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
+                {i}
+              </Button>
+            );
+          })}
+        </div>
+        <div
+          id="nps-anchors"
+          className="flex justify-between mt-1 px-1 text-xs text-muted-foreground"
+        >
+          <span>Not likely</span>
+          <span>Very likely</span>
+        </div>
+      </div>
+    </SurveyShell>
   );
 }

--- a/frontend/src/lib/surveyEligibility.ts
+++ b/frontend/src/lib/surveyEligibility.ts
@@ -1,0 +1,145 @@
+/**
+ * Survey eligibility logic and localStorage accessors.
+ *
+ * Two independent surveys:
+ * - Sean Ellis (PMF snapshot): one-shot, gated on 45 days since first meaningful
+ *   use AND active within the last 14 days.
+ * - NPS (recurring pulse): shown no more than every 90 days, gated on 60 days
+ *   since first meaningful use AND active within the last 14 days.
+ *
+ * "Meaningful use" is defined as a stream session that ran at least
+ * MEANINGFUL_USE_MIN_SECONDS seconds.
+ */
+
+export const MEANINGFUL_USE_MIN_SECONDS = 30;
+
+export const SEAN_ELLIS_MIN_AGE_DAYS = 45;
+export const SEAN_ELLIS_ACTIVE_WINDOW_DAYS = 14;
+
+export const NPS_MIN_AGE_DAYS = 60;
+export const NPS_ACTIVE_WINDOW_DAYS = 14;
+export const NPS_COOLDOWN_DAYS = 90;
+
+export const POST_STREAM_DELAY_MS = 750;
+
+const STORAGE_KEYS = {
+  firstMeaningfulUseAt: "scope_first_meaningful_use_at",
+  lastMeaningfulUseAt: "scope_last_meaningful_use_at",
+  seanEllisShownAt: "scope_sean_ellis_shown_at",
+  npsLastShownAt: "scope_nps_last_shown_at",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Safe localStorage helpers (Safari private mode / quota can throw)
+// ---------------------------------------------------------------------------
+
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Ignore — quota / private mode. Survey just won't gate correctly, which
+    // is acceptable (at worst the user sees it again).
+  }
+}
+
+function readTimestamp(key: string): number | null {
+  const raw = safeGetItem(key);
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ---------------------------------------------------------------------------
+// Meaningful use tracking
+// ---------------------------------------------------------------------------
+
+export function recordMeaningfulUse(now: number = Date.now()): void {
+  const nowStr = String(now);
+  if (!safeGetItem(STORAGE_KEYS.firstMeaningfulUseAt)) {
+    safeSetItem(STORAGE_KEYS.firstMeaningfulUseAt, nowStr);
+  }
+  safeSetItem(STORAGE_KEYS.lastMeaningfulUseAt, nowStr);
+}
+
+export function getFirstMeaningfulUseAt(): number | null {
+  return readTimestamp(STORAGE_KEYS.firstMeaningfulUseAt);
+}
+
+export function getLastMeaningfulUseAt(): number | null {
+  return readTimestamp(STORAGE_KEYS.lastMeaningfulUseAt);
+}
+
+// ---------------------------------------------------------------------------
+// Shown-flag accessors
+// ---------------------------------------------------------------------------
+
+export function getSeanEllisShownAt(): number | null {
+  return readTimestamp(STORAGE_KEYS.seanEllisShownAt);
+}
+
+export function markSeanEllisShown(now: number = Date.now()): void {
+  safeSetItem(STORAGE_KEYS.seanEllisShownAt, String(now));
+}
+
+export function getNpsLastShownAt(): number | null {
+  return readTimestamp(STORAGE_KEYS.npsLastShownAt);
+}
+
+export function markNpsShown(now: number = Date.now()): void {
+  safeSetItem(STORAGE_KEYS.npsLastShownAt, String(now));
+}
+
+// ---------------------------------------------------------------------------
+// Eligibility rules (pure)
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface EligibilityInputs {
+  telemetryEnabled: boolean;
+  firstMeaningfulUseAt: number | null;
+  lastMeaningfulUseAt: number | null;
+  now?: number;
+}
+
+export function isSeanEllisEligible(
+  inputs: EligibilityInputs & { seanEllisShownAt: number | null }
+): boolean {
+  const now = inputs.now ?? Date.now();
+  if (!inputs.telemetryEnabled) return false;
+  if (inputs.seanEllisShownAt !== null) return false;
+  if (inputs.firstMeaningfulUseAt === null) return false;
+  if (inputs.lastMeaningfulUseAt === null) return false;
+  if (now - inputs.firstMeaningfulUseAt < SEAN_ELLIS_MIN_AGE_DAYS * DAY_MS)
+    return false;
+  if (now - inputs.lastMeaningfulUseAt > SEAN_ELLIS_ACTIVE_WINDOW_DAYS * DAY_MS)
+    return false;
+  return true;
+}
+
+export function isNpsEligible(
+  inputs: EligibilityInputs & { npsLastShownAt: number | null }
+): boolean {
+  const now = inputs.now ?? Date.now();
+  if (!inputs.telemetryEnabled) return false;
+  if (inputs.firstMeaningfulUseAt === null) return false;
+  if (inputs.lastMeaningfulUseAt === null) return false;
+  if (now - inputs.firstMeaningfulUseAt < NPS_MIN_AGE_DAYS * DAY_MS)
+    return false;
+  if (now - inputs.lastMeaningfulUseAt > NPS_ACTIVE_WINDOW_DAYS * DAY_MS)
+    return false;
+  if (
+    inputs.npsLastShownAt !== null &&
+    now - inputs.npsLastShownAt < NPS_COOLDOWN_DAYS * DAY_MS
+  )
+    return false;
+  return true;
+}

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -81,8 +81,21 @@ import { toast } from "sonner";
 import { useOnboarding } from "../contexts/OnboardingContext";
 import { OnboardingOverlay } from "../components/onboarding/OnboardingOverlay";
 import { WorkspaceTour } from "../components/onboarding/WorkspaceTour";
-import { SurveyModal } from "../components/SurveyModal";
+import { SeanEllisSurvey, NpsSurvey } from "../components/SurveyModal";
 import { useTelemetry } from "../contexts/TelemetryContext";
+import {
+  MEANINGFUL_USE_MIN_SECONDS,
+  POST_STREAM_DELAY_MS,
+  getFirstMeaningfulUseAt,
+  getLastMeaningfulUseAt,
+  getNpsLastShownAt,
+  getSeanEllisShownAt,
+  isNpsEligible,
+  isSeanEllisEligible,
+  markNpsShown,
+  markSeanEllisShown,
+  recordMeaningfulUse,
+} from "../lib/surveyEligibility";
 
 import {
   isAuthenticated as checkIsAuthenticated,
@@ -154,8 +167,11 @@ export function StreamPage() {
   // Telemetry opt-in status (used for survey gating)
   const { isEnabled: isTelemetryEnabled } = useTelemetry();
 
-  // Post-session survey state
-  const [showSurvey, setShowSurvey] = useState(false);
+  // Post-session survey state — two independent surveys with different gating.
+  // Sean Ellis has priority: if both are eligible the same session, we show
+  // Sean Ellis and defer NPS to the next eligible session.
+  const [showSeanEllis, setShowSeanEllis] = useState(false);
+  const [showNps, setShowNps] = useState(false);
 
   // Get API functions that work in both local and cloud modes
   const api = useApi();
@@ -645,18 +661,62 @@ export function StreamPage() {
     onTempoUpdate: updateTempoFromNotification,
   });
 
-  // Show post-session survey once after the first completed stream
+  // Track stream start time to measure session duration for "meaningful use".
+  const streamStartedAtRef = useRef<number | null>(null);
   const prevIsStreamingRef = useRef(isStreaming);
   useEffect(() => {
-    if (prevIsStreamingRef.current && !isStreaming) {
-      // Stream just stopped — trigger survey if not yet shown and telemetry opted in
-      const alreadyShown = localStorage.getItem("scope_survey_shown");
-      if (!alreadyShown && isTelemetryEnabled) {
-        localStorage.setItem("scope_survey_shown", "true");
-        setShowSurvey(true);
+    const wasStreaming = prevIsStreamingRef.current;
+    prevIsStreamingRef.current = isStreaming;
+
+    // true → false transition: session just ended.
+    if (wasStreaming && !isStreaming) {
+      const startedAt = streamStartedAtRef.current;
+      streamStartedAtRef.current = null;
+      const durationSec =
+        startedAt !== null ? (Date.now() - startedAt) / 1000 : 0;
+
+      // Record meaningful use if the session was long enough.
+      if (durationSec >= MEANINGFUL_USE_MIN_SECONDS) {
+        recordMeaningfulUse();
+      }
+
+      // Evaluate eligibility against the freshly-updated timestamps. Sean Ellis
+      // wins if both are eligible; we defer the NPS ask to the next stop.
+      const commonInputs = {
+        telemetryEnabled: isTelemetryEnabled,
+        firstMeaningfulUseAt: getFirstMeaningfulUseAt(),
+        lastMeaningfulUseAt: getLastMeaningfulUseAt(),
+      };
+      const seanEllisEligible = isSeanEllisEligible({
+        ...commonInputs,
+        seanEllisShownAt: getSeanEllisShownAt(),
+      });
+      const npsEligible =
+        !seanEllisEligible &&
+        isNpsEligible({
+          ...commonInputs,
+          npsLastShownAt: getNpsLastShownAt(),
+        });
+
+      if (seanEllisEligible) {
+        markSeanEllisShown();
+        const t = setTimeout(
+          () => setShowSeanEllis(true),
+          POST_STREAM_DELAY_MS
+        );
+        return () => clearTimeout(t);
+      }
+      if (npsEligible) {
+        markNpsShown();
+        const t = setTimeout(() => setShowNps(true), POST_STREAM_DELAY_MS);
+        return () => clearTimeout(t);
       }
     }
-    prevIsStreamingRef.current = isStreaming;
+
+    // false → true transition: note the start time.
+    if (!wasStreaming && isStreaming) {
+      streamStartedAtRef.current = Date.now();
+    }
   }, [isStreaming, isTelemetryEnabled]);
 
   // Whether beat-quantized output gating is active
@@ -3799,8 +3859,12 @@ export function StreamPage() {
         )}
       </div>
 
-      {/* Post-session survey modal */}
-      <SurveyModal open={showSurvey} onClose={() => setShowSurvey(false)} />
+      {/* Post-session surveys — independently gated; rendered as peers. */}
+      <SeanEllisSurvey
+        open={showSeanEllis}
+        onClose={() => setShowSeanEllis(false)}
+      />
+      <NpsSurvey open={showNps} onClose={() => setShowNps(false)} />
     </MIDIProvider>
   );
 }

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -664,6 +664,14 @@ export function StreamPage() {
   // Track stream start time to measure session duration for "meaningful use".
   const streamStartedAtRef = useRef<number | null>(null);
   const prevIsStreamingRef = useRef(isStreaming);
+  // Mirror telemetry state into a ref so it can be read inside the
+  // stream-transition effect without making the effect re-run (and cancel the
+  // pending timer) when the user toggles telemetry between stream stop and
+  // the modal opening.
+  const isTelemetryEnabledRef = useRef(isTelemetryEnabled);
+  useEffect(() => {
+    isTelemetryEnabledRef.current = isTelemetryEnabled;
+  }, [isTelemetryEnabled]);
   useEffect(() => {
     const wasStreaming = prevIsStreamingRef.current;
     prevIsStreamingRef.current = isStreaming;
@@ -683,7 +691,7 @@ export function StreamPage() {
       // Evaluate eligibility against the freshly-updated timestamps. Sean Ellis
       // wins if both are eligible; we defer the NPS ask to the next stop.
       const commonInputs = {
-        telemetryEnabled: isTelemetryEnabled,
+        telemetryEnabled: isTelemetryEnabledRef.current,
         firstMeaningfulUseAt: getFirstMeaningfulUseAt(),
         lastMeaningfulUseAt: getLastMeaningfulUseAt(),
       };
@@ -698,8 +706,10 @@ export function StreamPage() {
           npsLastShownAt: getNpsLastShownAt(),
         });
 
+      // Schedule the modal open. The shown flag is committed in a separate
+      // effect when the modal actually renders — if this timer is ever
+      // cancelled (unmount, etc.) the user doesn't lose their one-shot.
       if (seanEllisEligible) {
-        markSeanEllisShown();
         const t = setTimeout(
           () => setShowSeanEllis(true),
           POST_STREAM_DELAY_MS
@@ -707,7 +717,6 @@ export function StreamPage() {
         return () => clearTimeout(t);
       }
       if (npsEligible) {
-        markNpsShown();
         const t = setTimeout(() => setShowNps(true), POST_STREAM_DELAY_MS);
         return () => clearTimeout(t);
       }
@@ -717,7 +726,16 @@ export function StreamPage() {
     if (!wasStreaming && isStreaming) {
       streamStartedAtRef.current = Date.now();
     }
-  }, [isStreaming, isTelemetryEnabled]);
+  }, [isStreaming]);
+
+  // Commit the shown flag only when the modal actually opens, so a cancelled
+  // timer (unmount or rapid re-render) doesn't permanently burn the one-shot.
+  useEffect(() => {
+    if (showSeanEllis) markSeanEllisShown();
+  }, [showSeanEllis]);
+  useEffect(() => {
+    if (showNps) markNpsShown();
+  }, [showNps]);
 
   // Whether beat-quantized output gating is active
   const isQuantizeActive =

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -81,6 +81,8 @@ import { toast } from "sonner";
 import { useOnboarding } from "../contexts/OnboardingContext";
 import { OnboardingOverlay } from "../components/onboarding/OnboardingOverlay";
 import { WorkspaceTour } from "../components/onboarding/WorkspaceTour";
+import { SurveyModal } from "../components/SurveyModal";
+import { useTelemetry } from "../contexts/TelemetryContext";
 
 import {
   isAuthenticated as checkIsAuthenticated,
@@ -148,6 +150,12 @@ export function StreamPage() {
   // Onboarding state
   const { state: onboardingState, isOverlayVisible: showOnboardingOverlay } =
     useOnboarding();
+
+  // Telemetry opt-in status (used for survey gating)
+  const { isEnabled: isTelemetryEnabled } = useTelemetry();
+
+  // Post-session survey state
+  const [showSurvey, setShowSurvey] = useState(false);
 
   // Get API functions that work in both local and cloud modes
   const api = useApi();
@@ -636,6 +644,20 @@ export function StreamPage() {
     onParametersUpdated: handleParametersUpdated,
     onTempoUpdate: updateTempoFromNotification,
   });
+
+  // Show post-session survey once after the first completed stream
+  const prevIsStreamingRef = useRef(false);
+  useEffect(() => {
+    if (prevIsStreamingRef.current && !isStreaming) {
+      // Stream just stopped — trigger survey if not yet shown and telemetry opted in
+      const alreadyShown = localStorage.getItem("scope_survey_shown");
+      if (!alreadyShown && isTelemetryEnabled) {
+        localStorage.setItem("scope_survey_shown", "true");
+        setShowSurvey(true);
+      }
+    }
+    prevIsStreamingRef.current = isStreaming;
+  }, [isStreaming, isTelemetryEnabled]);
 
   // Whether beat-quantized output gating is active
   const isQuantizeActive =
@@ -3776,6 +3798,9 @@ export function StreamPage() {
           />
         )}
       </div>
+
+      {/* Post-session survey modal */}
+      <SurveyModal open={showSurvey} onClose={() => setShowSurvey(false)} />
     </MIDIProvider>
   );
 }

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -646,7 +646,7 @@ export function StreamPage() {
   });
 
   // Show post-session survey once after the first completed stream
-  const prevIsStreamingRef = useRef(false);
+  const prevIsStreamingRef = useRef(isStreaming);
   useEffect(() => {
     if (prevIsStreamingRef.current && !isStreaming) {
       // Stream just stopped — trigger survey if not yet shown and telemetry opted in


### PR DESCRIPTION
## Summary

Implements DAY-56 — post-session survey UX for PMF + advocacy signal. Splits the combined Sean Ellis + NPS flow into **two independent surveys** with proper eligibility gating, denominator tracking, and separated visual design.

### Why split them

A combined Sean Ellis → NPS flow contaminates both metrics: Sean Ellis's emotional "how disappointed would you be" framing primes the NPS response (response-set bias). Coupling them to the same one-shot lifecycle also makes NPS impossible to run as a recurring pulse.

### What ships

**Two surveys, two lifecycles:**
- **Sean Ellis (PMF snapshot)** — one-shot per install. Vertical stack of 3 outline buttons (`max-w-md` modal).
- **NPS (recurring pulse)** — cooldown-gated. Horizontal 0–10 bar, connected radii, `flex-nowrap` so it never wraps, hover-only red/yellow/green bucket tints (`max-w-lg` modal).

**"Meaningful use" gating** — surveys only fire for users who've actually experienced the product. Defined as a stream session ≥ 30s. Tracked with two `localStorage` keys:
- `scope_first_meaningful_use_at` — written once, never overwritten
- `scope_last_meaningful_use_at` — updated every qualifying session

**Independent eligibility rules:**

| | Sean Ellis | NPS |
|---|---|---|
| Min install age | 45 days since first meaningful use | 60 days |
| Active window | Used in last 14 days | Last 14 days |
| Cadence | One-shot (`scope_sean_ellis_shown_at`) | Every 90 days (`scope_nps_last_shown_at`) |

If both are eligible the same session, Sean Ellis wins; NPS defers to the next eligible stop. Never stacked back-to-back.

**Telemetry-gated at two layers** — surveys never render for opted-out users:
1. `isTelemetryEnabled` is the first check in both `isSeanEllisEligible` / `isNpsEligible` — short-circuits before any other condition
2. `trackEvent` routes through the telemetry module, which itself gates on opt-in

**Denominator tracking** — every modal lifecycle now fires an event so response rate and drop-off are measurable:
- `sean_ellis_shown` / `sean_ellis_response {response}` / `sean_ellis_skipped`
- `nps_shown` / `nps_response {score}` / `nps_skipped`

**Other polish:**
- 750ms delay after stream stop so the modal doesn't interrupt the natural review moment
- `role="radiogroup"` + `aria-label` on both; NPS anchors wired via `aria-describedby`
- All `localStorage` access wrapped in try/catch (Safari private mode / quota safety)
- Eligibility rules extracted to pure functions in `frontend/src/lib/surveyEligibility.ts`

### Files

- **New:** `frontend/src/lib/surveyEligibility.ts` — pure eligibility rules + safe localStorage helpers + tunable constants
- **Rewritten:** `frontend/src/components/SurveyModal.tsx` — `SurveyShell` primitive + `SeanEllisSurvey` + `NpsSurvey`
- **Modified:** `frontend/src/pages/StreamPage.tsx` — meaningful-use tracking on stream stop + two independent eligibility effects

## Test plan

Time-gated flows require `localStorage` overrides to test end-to-end:

- [ ] **Meaningful use** — stop stream in <30s, confirm no `scope_first_meaningful_use_at`. Stream ≥30s, confirm both keys set; repeat and confirm first-use unchanged but last-use advances.
- [ ] **Sean Ellis eligible** — set first-use to 46d ago, last-use to now, telemetry on → modal appears next stream stop, fires `sean_ellis_shown` then `sean_ellis_response`. Next stop: does NOT reappear.
- [ ] **Sean Ellis too young** — set first-use to 10d ago → modal does NOT appear.
- [ ] **Sean Ellis inactive** — set last-use to 20d ago → modal does NOT appear.
- [ ] **NPS eligible** — set first-use to 61d ago, last-use recent, no NPS shown flag → NPS appears, fires `nps_shown` then `nps_response`.
- [ ] **NPS cooldown** — set `scope_nps_last_shown_at` to 89d ago → no show. 91d ago → shows again.
- [ ] **Both eligible same session** — clear both shown flags, first-use 70d ago → Sean Ellis shows this stop; NPS shows on next eligible stop.
- [ ] **Telemetry opt-out** — flip telemetry off → neither survey appears regardless of flags.
- [ ] **Skip / dismiss** — skip or ESC each flow → `_skipped` event fires, `_response` does not.
- [ ] **Delayed open** — modal appears ~750ms after stream stop, not instantly.
- [ ] **NPS layout** — 11 buttons on one row, never wraps at `max-w-lg`; hover tints: 0–6 red, 7–8 yellow, 9–10 green.
- [ ] `cd frontend && npm run lint && npm run format:check && npm run build` pass.

Closes [DAY-56](/DAY/issues/DAY-56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)