### PR TITLE
[harness testing] feat: welcome splash step for first-time onboarding

### DIFF
--- a/frontend/src/components/onboarding/OnboardingOverlay.tsx
+++ b/frontend/src/components/onboarding/OnboardingOverlay.tsx
@@ -7,6 +7,7 @@ import { CloudAuthStep } from "./CloudAuthStep";
 import { CloudConnectingStep } from "./CloudConnectingStep";
 import { WorkflowPickerStep } from "./WorkflowPickerStep";
 import { TelemetryDisclosure } from "./TelemetryDisclosure";
+import { WelcomeSplashStep } from "./WelcomeSplashStep";
 import { FogOfWarBackground } from "./FogOfWarBackground";
 import type { StarterWorkflow } from "./starterWorkflows";
 
@@ -31,6 +32,7 @@ export function OnboardingOverlay({
 }: OnboardingOverlayProps) {
   const {
     state,
+    advanceWelcome,
     selectInferenceMode,
     completeAuth,
     cloudConnected,
@@ -110,9 +112,10 @@ export function OnboardingOverlay({
 
       {/* Content layer — above the fog canvas + blur veil */}
       <div className="relative z-10 flex flex-col items-center justify-center h-full p-6">
-        {/* Back button — visible after the first step (hidden during survey
-            screens which handle their own internal back navigation) */}
-        {state.phase !== "inference" &&
+        {/* Back button — visible after the first step (hidden during welcome,
+            loading, and survey screens which handle their own navigation) */}
+        {state.phase !== "welcome" &&
+          state.phase !== "inference" &&
           state.phase !== "loading" &&
           state.phase !== "cloud_connecting" && (
             <button
@@ -124,21 +127,27 @@ export function OnboardingOverlay({
             </button>
           )}
 
-        {/* Step indicator */}
-        <div className="absolute top-6 left-1/2 -translate-x-1/2 flex items-center gap-2">
-          {Array.from({ length: totalSteps }).map((_, i) => (
-            <div
-              key={i}
-              className={`h-1 rounded-full transition-all ${
-                i <= phaseIndex
-                  ? "w-8 bg-foreground/40"
-                  : "w-8 bg-foreground/10"
-              }`}
-            />
-          ))}
-        </div>
+        {/* Step indicator — hidden during welcome phase */}
+        {state.phase !== "welcome" && (
+          <div className="absolute top-6 left-1/2 -translate-x-1/2 flex items-center gap-2">
+            {Array.from({ length: totalSteps }).map((_, i) => (
+              <div
+                key={i}
+                className={`h-1 rounded-full transition-all ${
+                  i <= phaseIndex
+                    ? "w-8 bg-foreground/40"
+                    : "w-8 bg-foreground/10"
+                }`}
+              />
+            ))}
+          </div>
+        )}
 
         {/* Phase content */}
+        {state.phase === "welcome" && (
+          <WelcomeSplashStep onAdvance={advanceWelcome} />
+        )}
+
         {state.phase === "loading" && (
           <div className="flex items-center justify-center">
             <div className="h-6 w-6 border-2 border-foreground/20 border-t-foreground/60 rounded-full animate-spin" />

--- a/frontend/src/components/onboarding/WelcomeSplashStep.tsx
+++ b/frontend/src/components/onboarding/WelcomeSplashStep.tsx
@@ -1,0 +1,37 @@
+interface WelcomeSplashStepProps {
+  onAdvance: () => void;
+}
+
+export function WelcomeSplashStep({ onAdvance }: WelcomeSplashStepProps) {
+  return (
+    <div className="flex flex-col items-center justify-center text-center max-w-lg mx-auto gap-6">
+      <div className="flex flex-col items-center gap-3">
+        <h1 className="text-4xl font-semibold tracking-tight text-foreground">
+          Real-time generative video.
+        </h1>
+        <p className="text-xl text-foreground/70">
+          For performers and creators.
+        </p>
+      </div>
+
+      <p className="text-base text-muted-foreground max-w-sm leading-relaxed">
+        Transform live video with AI — in real time, on stage or in the studio.
+      </p>
+
+      <div className="flex flex-col items-center gap-3 mt-2">
+        <button
+          onClick={onAdvance}
+          className="px-8 py-3 bg-foreground text-background rounded-lg text-base font-medium hover:bg-foreground/90 transition-colors"
+        >
+          Get Started →
+        </button>
+        <button
+          onClick={onAdvance}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Skip
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -21,6 +21,7 @@ import { isDisclosed as checkTelemetryDisclosed } from "../lib/telemetry";
 export type OnboardingPhase =
   | "loading" // waiting for backend status check
   | "idle" // returning user or post-completion
+  | "welcome" // pre-onboarding splash (first-time only)
   | "inference" // step 1: local vs cloud
   | "cloud_auth" // step 2a: sign in (only if cloud chosen)
   | "cloud_connecting" // step 2b: waiting for cloud relay connection
@@ -44,6 +45,7 @@ export interface OnboardingState {
 // ---------------------------------------------------------------------------
 
 type OnboardingAction =
+  | { type: "ADVANCE_WELCOME" }
   | { type: "SELECT_INFERENCE_MODE"; mode: "local" | "cloud" }
   | { type: "COMPLETE_AUTH" }
   | { type: "CLOUD_CONNECTED" }
@@ -77,6 +79,14 @@ function reducer(
   action: OnboardingAction
 ): OnboardingState {
   switch (action.type) {
+    case "ADVANCE_WELCOME":
+      try {
+        localStorage.setItem("scope_welcome_shown", "1");
+      } catch {
+        // no-op
+      }
+      return { ...state, phase: "inference" };
+
     case "SELECT_INFERENCE_MODE":
       persistInferenceMode(action.mode);
       // Set a sessionStorage flag so we can resume after a full-page auth
@@ -205,7 +215,15 @@ function reducer(
           };
         }
       }
-      return { ...state, phase: "inference" };
+      // Show welcome splash only the very first time (no prior onboarding state)
+      const welcomeShown = (() => {
+        try {
+          return !!localStorage.getItem("scope_welcome_shown");
+        } catch {
+          return false;
+        }
+      })();
+      return { ...state, phase: welcomeShown ? "inference" : "welcome" };
     }
 
     default:
@@ -223,6 +241,7 @@ interface OnboardingContextValue {
   isOnboarding: boolean;
   /** True only during the full-screen overlay phases */
   isOverlayVisible: boolean;
+  advanceWelcome: () => void;
   selectInferenceMode: (mode: "local" | "cloud") => void;
   completeAuth: () => void;
   cloudConnected: () => void;
@@ -272,6 +291,10 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const advanceWelcome = useCallback(
+    () => dispatch({ type: "ADVANCE_WELCOME" }),
+    []
+  );
   const selectInferenceMode = useCallback(
     (mode: "local" | "cloud") =>
       dispatch({ type: "SELECT_INFERENCE_MODE", mode }),
@@ -328,6 +351,7 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
   const isOnboarding = state.phase !== "idle";
   const isOverlayVisible = [
     "loading",
+    "welcome",
     "inference",
     "cloud_auth",
     "cloud_connecting",
@@ -341,6 +365,7 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
         state,
         isOnboarding,
         isOverlayVisible,
+        advanceWelcome,
         selectInferenceMode,
         completeAuth,
         cloudConnected,


### PR DESCRIPTION
## Summary

- Adds `WelcomeSplashStep.tsx` — cinematic full-screen splash with FogOfWar background, headline copy, and CTA
- Adds `welcome` as initial onboarding phase in `OnboardingContext.tsx`, gated by `localStorage` flag so it only shows once
- Updates `OnboardingOverlay.tsx` to render `WelcomeSplashStep` during `welcome` phase and hide step indicators on that phase
- Both "Get Started →" and "Skip" advance to the `inference` phase

Closes DAY-69

## Test plan

- [ ] First launch (no prior localStorage): welcome splash appears before inference step
- [ ] Returning user (after completing onboarding): welcome splash is skipped
- [ ] "Get Started →" advances to inference mode step
- [ ] "Skip" also advances to inference mode step
- [ ] Step indicator dots are NOT shown during welcome phase
- [ ] `npm run lint` and `npm run format:check` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)