### PR TITLE
fix(frontend): map hardware input (NDI/Spout/Syphon) onto perform-mode graph source node

### DIFF
--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -1411,6 +1411,43 @@ export function linearGraphFromSettings(
 }
 
 /**
+ * Perform mode sends a linear graph whose default source is WebRTC (`video`).
+ * When the user selects Spout, NDI, or Syphon, `input_source` is also set, but
+ * the backend drops `input_source` whenever the session includes any graph
+ * source node — hardware capture is wired only from per-node `source_mode` /
+ * `source_name` (see FrameProcessor.start). Patch the linear graph's `input`
+ * node so multi-source setup matches Workflow Builder.
+ */
+export function applyHardwareInputSourceToLinearGraph(
+  graph: GraphConfig,
+  inputSource?: {
+    enabled: boolean;
+    source_type: string;
+    source_name: string;
+  }
+): GraphConfig {
+  const t = inputSource?.source_type;
+  if (
+    !inputSource?.enabled ||
+    (t !== "ndi" && t !== "spout" && t !== "syphon")
+  ) {
+    return graph;
+  }
+  return {
+    ...graph,
+    nodes: graph.nodes.map(n =>
+      n.id === "input" && n.type === "source"
+        ? {
+            ...n,
+            source_mode: t,
+            source_name: inputSource.source_name ?? "",
+          }
+        : n
+    ),
+  };
+}
+
+/**
  * Drop layout fields (x, y, w, h) and omit `ui_state` from the payload to the
  * server. Execution topology — including `type: "record"` nodes and their
  * edges — stays in `nodes` / `edges`; record nodes are not frontend-only.

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -71,7 +71,11 @@ import {
   getDmxStatus,
 } from "../lib/api";
 import type { ScopeWorkflow } from "../lib/workflowApi";
-import { linearGraphFromSettings, stripUIFields } from "../lib/graphUtils";
+import {
+  applyHardwareInputSourceToLinearGraph,
+  linearGraphFromSettings,
+  stripUIFields,
+} from "../lib/graphUtils";
 import { resolveLoRAPath } from "../lib/workflowSettings";
 import { useLoRAsContext } from "../contexts/LoRAsContext";
 import { usePluginsContext } from "../contexts/PluginsContext";
@@ -2543,11 +2547,14 @@ export function StreamPage() {
           }
         }
 
-        graphConfigForStream = linearGraphFromSettings(
-          pipelineIdToUse,
-          settings.preprocessorIds ?? [],
-          settings.postprocessorIds ?? [],
-          vaceInputVideoIds.size > 0 ? vaceInputVideoIds : undefined
+        graphConfigForStream = applyHardwareInputSourceToLinearGraph(
+          linearGraphFromSettings(
+            pipelineIdToUse,
+            settings.preprocessorIds ?? [],
+            settings.postprocessorIds ?? [],
+            vaceInputVideoIds.size > 0 ? vaceInputVideoIds : undefined
+          ),
+          settings.inputSource
         );
 
         // Extract sink node IDs so WebRTC stats can map tracks to sinks
@@ -3123,10 +3130,13 @@ export function StreamPage() {
               ) {
                 // No graph yet — create a linear one from current settings
                 // and save to localStorage so the graph editor picks it up
-                const graph = linearGraphFromSettings(
-                  settings.pipelineId,
-                  settings.preprocessorIds ?? [],
-                  settings.postprocessorIds ?? []
+                const graph = applyHardwareInputSourceToLinearGraph(
+                  linearGraphFromSettings(
+                    settings.pipelineId,
+                    settings.preprocessorIds ?? [],
+                    settings.postprocessorIds ?? []
+                  ),
+                  settings.inputSource
                 );
                 try {
                   localStorage.setItem(


### PR DESCRIPTION
## Problem

In **Perform** mode, `linearGraphFromSettings()` builds a linear graph whose default `input` source uses WebRTC (`source_mode: "video"`). The real hardware choice (NDI, Spout, or Syphon) still lives in the legacy `input_source` field on session settings.

The backend drops global `input_source` whenever the session graph includes any `source` node (see `FrameProcessor.start` / #797), and wires hardware only from **per-node** `source_mode` / `source_name` via `setup_multi_sources`. With the graph still advertising `video`, multi-source setup never starts NDI/Spout/Syphon, so the pipeline can sit at `frames_in = 0`.

## Fix

- Add `applyHardwareInputSourceToLinearGraph()` in `frontend/src/lib/graphUtils.ts`: when `input_source` is enabled and `source_type` is `ndi`, `spout`, or `syphon`, patch the linear graph’s `input` node so `source_mode` and `source_name` match Workflow Builder–style graphs.
- Call it from `StreamPage.tsx` wherever the perform-mode linear graph is built for streaming and when persisting a default graph to localStorage.

This keeps the WebRTC path for camera/browser video unchanged and only upgrades the graph payload when the user explicitly chose a hardware capture source.
