### PR TITLE
feat: ui: visual redesign of graph mode

### DIFF
--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -343,7 +343,7 @@ function NodeTile({
         onClick={onSelect}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        className="flex items-center gap-1.5 p-2 h-[56px] rounded-lg bg-[#242424] border border-[rgba(119,119,119,0.12)] hover:bg-[#2e2e2e] hover:border-[rgba(119,119,119,0.35)] transition-colors text-left group"
+        className="flex items-center gap-1.5 p-2 h-[56px] rounded-md bg-[#222222] border border-[rgba(255,255,255,0.04)] hover:bg-[#2a2a2a] hover:border-[rgba(255,255,255,0.1)] transition-colors text-left group"
       >
         <div
           className="w-2.5 h-2.5 rounded-full shrink-0 transition-transform group-hover:scale-125"
@@ -363,7 +363,7 @@ function NodeTile({
             transform: "translate(-50%, -100%)",
           }}
         >
-          <div className="px-2.5 py-1.5 rounded-lg bg-[#111] border border-[rgba(119,119,119,0.3)] text-[11px] text-[#ccc] max-w-[180px] text-center shadow-lg">
+          <div className="px-2.5 py-1.5 rounded-md bg-[#141414] border border-[rgba(255,255,255,0.08)] text-[11px] text-[#ccc] max-w-[180px] text-center shadow-lg">
             {tooltip.text}
           </div>
           <div
@@ -417,7 +417,7 @@ export function AddNodeModal({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="!max-w-xl w-full p-0 overflow-hidden bg-[#1a1a1a] border border-[rgba(119,119,119,0.2)] rounded-2xl">
+      <DialogContent className="!max-w-xl w-full p-0 overflow-hidden bg-[#1a1a1a] border border-[rgba(119,119,119,0.2)] rounded-xl">
         <DialogHeader className="sr-only">
           <DialogTitle>Add Node</DialogTitle>
           <DialogDescription>
@@ -461,7 +461,7 @@ export function AddNodeModal({
               <button
                 key={cat}
                 onClick={() => setActiveCategory(cat)}
-                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
                   activeCategory === cat
                     ? "bg-[#fafafa] text-[#111]"
                     : "text-[#888] hover:text-[#ccc]"
@@ -495,7 +495,7 @@ export function AddNodeModal({
           <div className="flex items-center justify-between px-4 py-3 border-t border-[rgba(119,119,119,0.12)]">
             <button
               onClick={handleClose}
-              className="px-5 py-2 rounded-full bg-[#2a2a2a] border border-[rgba(119,119,119,0.2)] text-xs font-medium text-[#fafafa] hover:bg-[#333] transition-colors"
+              className="px-5 py-2 rounded-md bg-[#2a2a2a] border border-[rgba(255,255,255,0.06)] text-xs font-medium text-[#fafafa] hover:bg-[#333] transition-colors"
             >
               Cancel
             </button>

--- a/frontend/src/components/graph/BlueprintBrowserModal.tsx
+++ b/frontend/src/components/graph/BlueprintBrowserModal.tsx
@@ -28,7 +28,7 @@ function BlueprintCard({
   onInsert: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-2 p-3 rounded-xl bg-[#242424] border border-[rgba(119,119,119,0.12)] hover:border-[rgba(119,119,119,0.3)] transition-colors">
+    <div className="flex flex-col gap-2 p-3 rounded-lg bg-[#242424] border border-[rgba(255,255,255,0.04)] hover:border-[rgba(255,255,255,0.1)] transition-colors">
       <div className="flex items-center gap-2">
         <div
           className="w-2.5 h-2.5 rounded-full shrink-0"
@@ -37,7 +37,7 @@ function BlueprintCard({
         <span className="text-[12px] font-medium text-[#e0e0e0] truncate flex-1">
           {blueprint.name}
         </span>
-        <span className="text-[10px] text-[#666] shrink-0 bg-[#1a1a1a] px-1.5 py-0.5 rounded-full border border-[rgba(119,119,119,0.12)]">
+        <span className="text-[10px] text-[#666] shrink-0 bg-[#1a1a1a] px-1.5 py-0.5 rounded-md border border-[rgba(255,255,255,0.06)]">
           {blueprint.category}
         </span>
       </div>
@@ -52,7 +52,7 @@ function BlueprintCard({
         </span>
         <button
           onClick={onInsert}
-          className="px-3 py-1 rounded-full bg-[#fafafa] text-[#111] text-[11px] font-medium hover:bg-[#e0e0e0] transition-colors"
+          className="px-3 py-1 rounded-md bg-[#fafafa] text-[#111] text-[11px] font-medium hover:bg-[#e0e0e0] transition-colors"
         >
           Insert
         </button>
@@ -96,7 +96,7 @@ export function BlueprintBrowserModal({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="!max-w-xl w-full p-0 overflow-hidden bg-[#1a1a1a] border border-[rgba(119,119,119,0.2)] rounded-2xl">
+      <DialogContent className="!max-w-xl w-full p-0 overflow-hidden bg-[#1a1a1a] border border-[rgba(119,119,119,0.2)] rounded-xl">
         <DialogHeader className="sr-only">
           <DialogTitle>Blueprint Library</DialogTitle>
           <DialogDescription>
@@ -138,7 +138,7 @@ export function BlueprintBrowserModal({
               <button
                 key={cat}
                 onClick={() => setActiveCategory(cat)}
-                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
                   activeCategory === cat
                     ? "bg-[#fafafa] text-[#111]"
                     : "text-[#888] hover:text-[#ccc]"
@@ -173,7 +173,7 @@ export function BlueprintBrowserModal({
           <div className="flex items-center justify-between px-4 py-3 border-t border-[rgba(119,119,119,0.12)]">
             <button
               onClick={handleClose}
-              className="px-5 py-2 rounded-full bg-[#2a2a2a] border border-[rgba(119,119,119,0.2)] text-xs font-medium text-[#fafafa] hover:bg-[#333] transition-colors"
+              className="px-5 py-2 rounded-md bg-[#2a2a2a] border border-[rgba(255,255,255,0.06)] text-xs font-medium text-[#fafafa] hover:bg-[#333] transition-colors"
             >
               Cancel
             </button>

--- a/frontend/src/components/graph/ContextMenu.tsx
+++ b/frontend/src/components/graph/ContextMenu.tsx
@@ -140,7 +140,7 @@ export function ContextMenu({
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[180px] rounded-lg bg-[#111111] border border-[rgba(255,255,255,0.08)] shadow-xl overflow-visible"
+      className="fixed z-50 min-w-[180px] rounded-lg bg-[#141414] border border-[rgba(255,255,255,0.06)] shadow-[0_4px_24px_rgba(0,0,0,0.5)] overflow-visible"
       style={{ left: `${pos.left}px`, top: `${pos.top}px` }}
     >
       {/* Search */}
@@ -154,7 +154,7 @@ export function ContextMenu({
             setActiveSubmenu(null);
           }}
           placeholder="Search…"
-          className="w-full px-2 py-1 text-[12px] bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] rounded-md text-[#e0e0e0] placeholder-[#444] focus:outline-none focus:border-[rgba(255,255,255,0.18)]"
+          className="w-full px-2 py-1 text-[12px] bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md text-[#e0e0e0] placeholder-[#444] focus:outline-none focus:border-[rgba(255,255,255,0.18)]"
           onMouseDown={e => e.stopPropagation()}
         />
       </div>
@@ -178,8 +178,8 @@ export function ContextMenu({
                 onClick={() => handleSelect(item)}
                 className={`w-full text-left px-3 py-1.5 text-[13px] flex items-center gap-2.5 transition-colors ${
                   item.danger
-                    ? "text-red-400 hover:bg-[#1f1f1f] hover:text-red-300"
-                    : "text-[#e0e0e0] hover:bg-[#1f1f1f]"
+                    ? "text-red-400 hover:bg-[rgba(255,255,255,0.05)] hover:text-red-300"
+                    : "text-[#e0e0e0] hover:bg-[rgba(255,255,255,0.05)]"
                 }`}
               >
                 {item.icon && (
@@ -212,8 +212,8 @@ export function ContextMenu({
                 }}
                 className={`w-full text-left px-3 py-1.5 text-[13px] flex items-center gap-2.5 transition-colors ${
                   item.danger
-                    ? "text-red-400 hover:bg-[#1f1f1f] hover:text-red-300"
-                    : "text-[#e0e0e0] hover:bg-[#1f1f1f]"
+                    ? "text-red-400 hover:bg-[rgba(255,255,255,0.05)] hover:text-red-300"
+                    : "text-[#e0e0e0] hover:bg-[rgba(255,255,255,0.05)]"
                 }`}
               >
                 {item.icon && (
@@ -307,12 +307,12 @@ function SubmenuPanel({
 
   return (
     <div ref={ref} style={style}>
-      <div className="min-w-[140px] rounded-lg bg-[#111111] border border-[rgba(255,255,255,0.08)] shadow-xl py-1.5">
+      <div className="min-w-[140px] rounded-lg bg-[#141414] border border-[rgba(255,255,255,0.06)] shadow-[0_4px_24px_rgba(0,0,0,0.5)] py-1.5">
         {items.map((child, ci) => (
           <button
             key={ci}
             onClick={() => onSelect(child)}
-            className="w-full text-left px-3 py-1.5 text-[13px] flex items-center gap-2.5 text-[#e0e0e0] hover:bg-[#1f1f1f] transition-colors"
+            className="w-full text-left px-3 py-1.5 text-[13px] flex items-center gap-2.5 text-[#e0e0e0] hover:bg-[rgba(255,255,255,0.05)] transition-colors"
           >
             {child.icon && (
               <span className="text-[#777] shrink-0 [&_svg]:w-[15px] [&_svg]:h-[15px]">

--- a/frontend/src/components/graph/CustomEdge.tsx
+++ b/frontend/src/components/graph/CustomEdge.tsx
@@ -25,7 +25,7 @@ export function CustomEdge({
   const flashing = data?.flashing === true;
   const edgeColor = flashing
     ? "#ffffff"
-    : (style?.stroke as string) || "#9ca3af";
+    : (style?.stroke as string) || "#6b7280";
 
   const edgeStyle = flashing
     ? {
@@ -63,10 +63,10 @@ export function CustomEdge({
           }}
         />
         <circle
-          r={5}
+          r={4}
           fill={edgeColor}
-          stroke="rgba(0, 0, 0, 0.4)"
-          strokeWidth={1}
+          stroke="rgba(0, 0, 0, 0.5)"
+          strokeWidth={1.5}
           style={{ pointerEvents: "none" }}
         />
       </g>

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -73,6 +73,7 @@ import { createDaydreamImportSession } from "../../lib/daydreamExport";
 import { openExternalUrl } from "../../lib/openExternal";
 import { buildPaneMenuItems, buildNodeMenuItems } from "./contextMenuItems";
 import type { FlowNodeData } from "../../lib/graphUtils";
+import { generateNodeId } from "../../lib/graphUtils";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -588,6 +589,74 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         setSelectedNodeIds,
       });
 
+    const handleDebugNodes = useCallback(() => {
+      const DEBUG_NODE_TYPES: Array<{
+        type: string;
+        nodeType: string;
+        extra?: Partial<FlowNodeData>;
+      }> = [
+        { type: "source", nodeType: "source" },
+        { type: "pipeline", nodeType: "pipeline" },
+        { type: "sink", nodeType: "sink" },
+        { type: "record", nodeType: "record" },
+        { type: "primitive", nodeType: "primitive" },
+        { type: "bool", nodeType: "bool" },
+        { type: "slider", nodeType: "slider" },
+        { type: "knobs", nodeType: "knobs" },
+        { type: "xypad", nodeType: "xypad" },
+        {
+          type: "control",
+          nodeType: "control",
+          extra: { controlType: "float" },
+        },
+        { type: "control", nodeType: "control", extra: { controlType: "int" } },
+        {
+          type: "control",
+          nodeType: "control",
+          extra: { controlType: "string" },
+        },
+        { type: "math", nodeType: "math" },
+        { type: "tuple", nodeType: "tuple" },
+        { type: "output", nodeType: "output" },
+        { type: "image", nodeType: "image" },
+        { type: "vace", nodeType: "vace" },
+        { type: "lora", nodeType: "lora" },
+        { type: "midi", nodeType: "midi" },
+        { type: "trigger", nodeType: "trigger" },
+        { type: "tempo", nodeType: "tempo" },
+        { type: "prompt_list", nodeType: "prompt_list" },
+        { type: "prompt_blend", nodeType: "prompt_blend" },
+        { type: "scheduler", nodeType: "scheduler" },
+        { type: "note", nodeType: "note" },
+        { type: "reroute", nodeType: "reroute" },
+      ];
+
+      const cols = 5;
+      const spacingX = 320;
+      const spacingY = 300;
+      const ids = new Set<string>();
+
+      const debugNodes = DEBUG_NODE_TYPES.map((def, idx) => {
+        const col = idx % cols;
+        const row = Math.floor(idx / cols);
+        const id = generateNodeId(def.nodeType, ids);
+        ids.add(id);
+        return {
+          id,
+          type: def.type,
+          position: { x: 50 + col * spacingX, y: 50 + row * spacingY },
+          data: {
+            label: id,
+            nodeType: def.nodeType,
+            ...def.extra,
+          } as FlowNodeData,
+        };
+      });
+
+      setNodes(debugNodes as any);
+      setEdges([]);
+    }, [setNodes, setEdges]);
+
     const onPromptForwardRef = useRef(handlePromptChange);
     onPromptForwardRef.current = handlePromptChange;
 
@@ -1007,6 +1076,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
             onExport={() => setShowExportDialog(true)}
             onClear={() => setShowClearConfirm(true)}
             onDefaultWorkflow={() => setShowDefaultConfirm(true)}
+            onDebugNodes={handleDebugNodes}
             fileInputRef={fileInputRef}
           />
 
@@ -1064,14 +1134,19 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
               deleteKeyCode={isStreaming ? [] : ["Backspace", "Delete"]}
             >
               <Controls />
-              <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+              <Background
+                variant={BackgroundVariant.Dots}
+                gap={20}
+                size={1.2}
+                color="rgba(255,255,255,0.07)"
+              />
             </ReactFlow>
 
             {/* Add node button — upper right of canvas */}
             {!isStreaming && (
               <button
                 onClick={e => handleOpenCreateMenu(e.clientX, e.clientY)}
-                className="absolute top-4 right-4 z-30 w-12 h-12 rounded-xl border-2 border-dashed border-[rgba(119,119,119,0.4)] bg-[rgba(17,17,17,0.6)] hover:border-[rgba(119,119,119,0.7)] hover:bg-[rgba(17,17,17,0.8)] transition-colors cursor-pointer flex items-center justify-center"
+                className="absolute top-4 right-4 z-30 w-12 h-12 rounded-lg border-2 border-dashed border-[rgba(119,119,119,0.3)] bg-[rgba(17,17,17,0.6)] hover:border-[rgba(119,119,119,0.6)] hover:bg-[rgba(17,17,17,0.8)] transition-colors cursor-pointer flex items-center justify-center"
                 title="Add node"
               >
                 <Plus className="h-5 w-5 text-[#8c8c8d]" />
@@ -1085,7 +1160,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
                   onClick={e => handleOpenCreateMenu(e.clientX, e.clientY)}
                   className="pointer-events-auto flex flex-col items-center gap-3 cursor-pointer group"
                 >
-                  <div className="w-28 h-28 rounded-xl border-2 border-dashed border-[rgba(119,119,119,0.3)] bg-[rgba(17,17,17,0.3)] flex items-center justify-center group-hover:border-[rgba(119,119,119,0.5)] transition-colors">
+                  <div className="w-28 h-28 rounded-lg border-2 border-dashed border-[rgba(119,119,119,0.2)] bg-[rgba(17,17,17,0.3)] flex items-center justify-center group-hover:border-[rgba(119,119,119,0.4)] transition-colors">
                     <Plus className="h-8 w-8 text-[#555]" />
                   </div>
                   <span className="text-sm text-[#555] group-hover:text-[#777] transition-colors">

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -751,7 +751,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         },
       ];
 
-      const debugNodes = DEBUG_NODES.map(def => ({
+      const debugNodes: Node<FlowNodeData>[] = DEBUG_NODES.map(def => ({
         id: def.id,
         type: def.type,
         position: def.position,
@@ -762,7 +762,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         } as FlowNodeData,
       }));
 
-      setNodes(debugNodes as any);
+      setNodes(debugNodes);
       setEdges([]);
     }, [setNodes, setEdges]);
 

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -73,7 +73,6 @@ import { createDaydreamImportSession } from "../../lib/daydreamExport";
 import { openExternalUrl } from "../../lib/openExternal";
 import { buildPaneMenuItems, buildNodeMenuItems } from "./contextMenuItems";
 import type { FlowNodeData } from "../../lib/graphUtils";
-import { generateNodeId } from "../../lib/graphUtils";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -590,68 +589,178 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
       });
 
     const handleDebugNodes = useCallback(() => {
-      const DEBUG_NODE_TYPES: Array<{
+      const DEBUG_NODES: Array<{
+        id: string;
         type: string;
         nodeType: string;
+        position: { x: number; y: number };
         extra?: Partial<FlowNodeData>;
       }> = [
-        { type: "source", nodeType: "source" },
-        { type: "pipeline", nodeType: "pipeline" },
-        { type: "sink", nodeType: "sink" },
-        { type: "record", nodeType: "record" },
-        { type: "primitive", nodeType: "primitive" },
-        { type: "bool", nodeType: "bool" },
-        { type: "slider", nodeType: "slider" },
-        { type: "knobs", nodeType: "knobs" },
-        { type: "xypad", nodeType: "xypad" },
         {
+          id: "source",
+          type: "source",
+          nodeType: "source",
+          position: { x: 50, y: 50 },
+        },
+        {
+          id: "pipeline",
+          type: "pipeline",
+          nodeType: "pipeline",
+          position: { x: 321.74, y: 49.33 },
+        },
+        {
+          id: "sink",
+          type: "sink",
+          nodeType: "sink",
+          position: { x: 577.54, y: 42.91 },
+        },
+        {
+          id: "record",
+          type: "record",
+          nodeType: "record",
+          position: { x: 584.35, y: 274.9 },
+        },
+        {
+          id: "primitive",
+          type: "primitive",
+          nodeType: "primitive",
+          position: { x: 586.99, y: 393.92 },
+        },
+        {
+          id: "bool",
+          type: "bool",
+          nodeType: "bool",
+          position: { x: 50, y: 350 },
+        },
+        {
+          id: "slider",
+          type: "slider",
+          nodeType: "slider",
+          position: { x: 43.29, y: 773.73 },
+        },
+        {
+          id: "knobs",
+          type: "knobs",
+          nodeType: "knobs",
+          position: { x: 39.43, y: 966.33 },
+        },
+        {
+          id: "xypad",
+          type: "xypad",
+          nodeType: "xypad",
+          position: { x: 850.46, y: 46.12 },
+        },
+        {
+          id: "control",
           type: "control",
           nodeType: "control",
+          position: { x: 856.59, y: 334.32 },
           extra: { controlType: "float" },
         },
-        { type: "control", nodeType: "control", extra: { controlType: "int" } },
         {
+          id: "control_1",
           type: "control",
           nodeType: "control",
+          position: { x: 47.15, y: 558.69 },
+          extra: { controlType: "int" },
+        },
+        {
+          id: "control_2",
+          type: "control",
+          nodeType: "control",
+          position: { x: 318.9, y: 923.97 },
           extra: { controlType: "string" },
         },
-        { type: "math", nodeType: "math" },
-        { type: "tuple", nodeType: "tuple" },
-        { type: "output", nodeType: "output" },
-        { type: "image", nodeType: "image" },
-        { type: "vace", nodeType: "vace" },
-        { type: "lora", nodeType: "lora" },
-        { type: "midi", nodeType: "midi" },
-        { type: "trigger", nodeType: "trigger" },
-        { type: "tempo", nodeType: "tempo" },
-        { type: "prompt_list", nodeType: "prompt_list" },
-        { type: "prompt_blend", nodeType: "prompt_blend" },
-        { type: "scheduler", nodeType: "scheduler" },
-        { type: "note", nodeType: "note" },
-        { type: "reroute", nodeType: "reroute" },
+        {
+          id: "math",
+          type: "math",
+          nodeType: "math",
+          position: { x: 586.16, y: 588.74 },
+        },
+        {
+          id: "tuple",
+          type: "tuple",
+          nodeType: "tuple",
+          position: { x: 857.59, y: 543.01 },
+        },
+        {
+          id: "output",
+          type: "output",
+          nodeType: "output",
+          position: { x: 860.87, y: 697.09 },
+        },
+        {
+          id: "vace",
+          type: "vace",
+          nodeType: "vace",
+          position: { x: 587.22, y: 914.44 },
+        },
+        {
+          id: "lora",
+          type: "lora",
+          nodeType: "lora",
+          position: { x: 586.18, y: 794.57 },
+        },
+        {
+          id: "midi",
+          type: "midi",
+          nodeType: "midi",
+          position: { x: 860.45, y: 860.13 },
+        },
+        {
+          id: "trigger",
+          type: "trigger",
+          nodeType: "trigger",
+          position: { x: 318.72, y: 817.36 },
+        },
+        {
+          id: "tempo",
+          type: "tempo",
+          nodeType: "tempo",
+          position: { x: 1121.76, y: 278.44 },
+        },
+        {
+          id: "prompt_list",
+          type: "prompt_list",
+          nodeType: "prompt_list",
+          position: { x: 1123.61, y: 479.6 },
+        },
+        {
+          id: "prompt_blend",
+          type: "prompt_blend",
+          nodeType: "prompt_blend",
+          position: { x: 1129.74, y: 709.3 },
+        },
+        {
+          id: "scheduler",
+          type: "scheduler",
+          nodeType: "scheduler",
+          position: { x: 1128.73, y: 883.37 },
+        },
+        {
+          id: "note",
+          type: "note",
+          nodeType: "note",
+          position: { x: 1122.5, y: 49.42 },
+        },
+        {
+          id: "reroute",
+          type: "reroute",
+          nodeType: "reroute",
+          position: { x: 971.33, y: 1063.07 },
+        },
       ];
 
-      const cols = 5;
-      const spacingX = 320;
-      const spacingY = 300;
-      const ids = new Set<string>();
-
-      const debugNodes = DEBUG_NODE_TYPES.map((def, idx) => {
-        const col = idx % cols;
-        const row = Math.floor(idx / cols);
-        const id = generateNodeId(def.nodeType, ids);
-        ids.add(id);
-        return {
-          id,
-          type: def.type,
-          position: { x: 50 + col * spacingX, y: 50 + row * spacingY },
-          data: {
-            label: id,
-            nodeType: def.nodeType,
-            ...def.extra,
-          } as FlowNodeData,
-        };
-      });
+      const debugNodes = DEBUG_NODES.map(def => ({
+        id: def.id,
+        type: def.type,
+        position: def.position,
+        data: {
+          label: def.id,
+          nodeType: def.nodeType,
+          ...def.extra,
+        } as FlowNodeData,
+      }));
 
       setNodes(debugNodes as any);
       setEdges([]);

--- a/frontend/src/components/graph/GraphToolbar.tsx
+++ b/frontend/src/components/graph/GraphToolbar.tsx
@@ -39,6 +39,7 @@ interface GraphToolbarProps {
   onExport: () => void;
   onClear: () => void;
   onDefaultWorkflow?: () => void;
+  onDebugNodes?: () => void;
   fileInputRef?: RefObject<HTMLInputElement | null>;
 }
 
@@ -54,6 +55,7 @@ export function GraphToolbar({
   onExport,
   onClear,
   onDefaultWorkflow,
+  onDebugNodes,
   fileInputRef: externalFileInputRef,
 }: GraphToolbarProps) {
   const internalFileInputRef = useRef<HTMLInputElement>(null);
@@ -106,6 +108,17 @@ export function GraphToolbar({
               <Trash2 className="h-4 w-4" />
               Clear Graph
             </DropdownMenuItem>
+            {import.meta.env.DEV && onDebugNodes && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={onDebugNodes}
+                  className="text-[#8c8c8d] focus:text-[#ccc]"
+                >
+                  Debug Nodes (dev)
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
 

--- a/frontend/src/components/graph/constants.ts
+++ b/frontend/src/components/graph/constants.ts
@@ -11,6 +11,7 @@ import {
   COLOR_AUDIO,
   COLOR_BOOLEAN,
   COLOR_TRIGGER,
+  COLOR_LORA,
   COLOR_DEFAULT,
 } from "./nodeColors";
 
@@ -66,6 +67,9 @@ export function getEdgeColor(
     }
     if (sourceNode.data.nodeType === "vace") {
       return COLOR_VACE;
+    }
+    if (sourceNode.data.nodeType === "lora") {
+      return COLOR_LORA;
     }
     if (sourceNode.data.nodeType === "midi") {
       return COLOR_NUMBER;

--- a/frontend/src/components/graph/hooks/node/useNodeFactories.ts
+++ b/frontend/src/components/graph/hooks/node/useNodeFactories.ts
@@ -8,6 +8,7 @@ import {
 } from "../../utils/subgraphSerialization";
 import { buildEdgeStyle } from "../../constants";
 import type { Blueprint } from "../../../../data/blueprints/types";
+import { resetAutoHeightNodes } from "../../utils/nodeEnrichment";
 
 import type { EnrichNodesDeps } from "../graph/useGraphPersistence";
 import { enrichNodes } from "../graph/useGraphPersistence";
@@ -658,7 +659,8 @@ export function useNodeFactories({
       const minY = Math.min(...rawNodes.map(n => n.position.y));
       const targetPos = insertPos ?? { x: 200, y: 200 };
 
-      const newNodes: Node<FlowNodeData>[] = rawNodes.map(node => ({
+      const sizedNodes = resetAutoHeightNodes(rawNodes);
+      const newNodes: Node<FlowNodeData>[] = sizedNodes.map(node => ({
         ...node,
         id: idMap.get(node.id)!,
         position: {

--- a/frontend/src/components/graph/nodes/ControlNode.tsx
+++ b/frontend/src/components/graph/nodes/ControlNode.tsx
@@ -400,11 +400,7 @@ export function ControlNode({
   ]);
 
   return (
-    <NodeCard
-      selected={selected}
-      autoMinHeight={isSwitchMode && !collapsed}
-      collapsed={collapsed}
-    >
+    <NodeCard selected={selected} collapsed={collapsed}>
       <NodeHeader
         title={data.customTitle || title}
         onTitleChange={newTitle => updateNodeData({ customTitle: newTitle })}

--- a/frontend/src/components/graph/nodes/ImageNode.tsx
+++ b/frontend/src/components/graph/nodes/ImageNode.tsx
@@ -80,6 +80,7 @@ export function ImageNode({ id, data, selected }: NodeProps<ImageNodeType>) {
       minHeight={80}
       className="!min-w-0"
       collapsed={collapsed}
+      autoMinHeight={false}
     >
       <NodeHeader
         title={data.customTitle || "Media"}

--- a/frontend/src/components/graph/nodes/PipelineNode.tsx
+++ b/frontend/src/components/graph/nodes/PipelineNode.tsx
@@ -361,11 +361,14 @@ export function PipelineNode({
             return (
               <div
                 key={`param-${param.name}`}
-                ref={setRowRef(`param:${param.name}`)}
+                className="bg-[rgba(255,255,255,0.02)] rounded-md -mx-1 px-1 py-1"
               >
                 {isConnected ? (
                   <div className="flex flex-col gap-1">
-                    <p className={`${NODE_TOKENS.labelText} text-[10px]`}>
+                    <p
+                      ref={setRowRef(`param:${param.name}`)}
+                      className={`${NODE_TOKENS.labelText} text-[10px]`}
+                    >
                       {param.label || param.name}
                     </p>
                     <NodePill className="opacity-50">
@@ -376,7 +379,10 @@ export function PipelineNode({
                   </div>
                 ) : (
                   <div className="flex flex-col gap-1">
-                    <p className={`${NODE_TOKENS.labelText} text-[10px]`}>
+                    <p
+                      ref={setRowRef(`param:${param.name}`)}
+                      className={`${NODE_TOKENS.labelText} text-[10px]`}
+                    >
                       {param.label || param.name}
                     </p>
                     {values.map((stepVal, idx) => (

--- a/frontend/src/components/graph/nodes/PrimitiveNode.tsx
+++ b/frontend/src/components/graph/nodes/PrimitiveNode.tsx
@@ -170,7 +170,11 @@ export function PrimitiveNode({
         style={
           collapsed
             ? collapsedHandleStyle("left")
-            : { top: rowPositions["value"] ?? 44, left: 0, backgroundColor: color }
+            : {
+                top: rowPositions["value"] ?? 44,
+                left: 0,
+                backgroundColor: color,
+              }
         }
       />
       <Handle
@@ -181,7 +185,11 @@ export function PrimitiveNode({
         style={
           collapsed
             ? collapsedHandleStyle("right")
-            : { top: rowPositions["value"] ?? 44, right: 0, backgroundColor: color }
+            : {
+                top: rowPositions["value"] ?? 44,
+                right: 0,
+                backgroundColor: color,
+              }
         }
       />
     </NodeCard>

--- a/frontend/src/components/graph/nodes/PrimitiveNode.tsx
+++ b/frontend/src/components/graph/nodes/PrimitiveNode.tsx
@@ -18,6 +18,7 @@ import {
 } from "../ui";
 import { PARAM_TYPE_COLORS } from "../nodeColors";
 import { NODE_TOKENS } from "../ui/tokens";
+import { useHandlePositions } from "../hooks/node/useHandlePositions";
 
 type PrimitiveNodeType = Node<FlowNodeData, "primitive">;
 
@@ -42,6 +43,11 @@ export function PrimitiveNode({
   const { collapsed, toggleCollapse } = useNodeCollapse();
   const valueType = data.valueType || "string";
   const currentValue = data.value ?? getDefaultForType(valueType);
+  const { setRowRef, rowPositions } = useHandlePositions([
+    collapsed,
+    valueType,
+    currentValue,
+  ]);
   const autoSend = data.primitiveAutoSend !== false;
 
   const color = PARAM_TYPE_COLORS[valueType] || "#9ca3af";
@@ -94,34 +100,36 @@ export function PrimitiveNode({
               options={TYPE_OPTIONS}
             />
           </NodeParamRow>
-          {valueType === "string" && (
-            <div className="mt-1">
-              <NodePillTextarea
-                value={String(currentValue)}
-                onChange={handleValueChange}
-                onSubmit={!autoSend ? handleSend : undefined}
-                placeholder="Enter text…"
-              />
-            </div>
-          )}
-          {valueType === "number" && (
-            <NodeParamRow label="Value">
-              <NodePillInput
-                type="number"
-                value={Number(currentValue)}
-                onChange={handleValueChange}
-                onSubmit={!autoSend ? handleSend : undefined}
-              />
-            </NodeParamRow>
-          )}
-          {valueType === "boolean" && (
-            <NodeParamRow label="Value">
-              <NodePillToggle
-                checked={Boolean(currentValue)}
-                onChange={handleValueChange}
-              />
-            </NodeParamRow>
-          )}
+          <div ref={setRowRef("value")}>
+            {valueType === "string" && (
+              <div className="mt-1">
+                <NodePillTextarea
+                  value={String(currentValue)}
+                  onChange={handleValueChange}
+                  onSubmit={!autoSend ? handleSend : undefined}
+                  placeholder="Enter text…"
+                />
+              </div>
+            )}
+            {valueType === "number" && (
+              <NodeParamRow label="Value">
+                <NodePillInput
+                  type="number"
+                  value={Number(currentValue)}
+                  onChange={handleValueChange}
+                  onSubmit={!autoSend ? handleSend : undefined}
+                />
+              </NodeParamRow>
+            )}
+            {valueType === "boolean" && (
+              <NodeParamRow label="Value">
+                <NodePillToggle
+                  checked={Boolean(currentValue)}
+                  onChange={handleValueChange}
+                />
+              </NodeParamRow>
+            )}
+          </div>
           {valueType !== "boolean" && (
             <div className="flex items-center gap-1 mt-1">
               {!autoSend && (
@@ -162,7 +170,7 @@ export function PrimitiveNode({
         style={
           collapsed
             ? collapsedHandleStyle("left")
-            : { top: 44, left: 0, backgroundColor: color }
+            : { top: rowPositions["value"] ?? 44, left: 0, backgroundColor: color }
         }
       />
       <Handle
@@ -173,7 +181,7 @@ export function PrimitiveNode({
         style={
           collapsed
             ? collapsedHandleStyle("right")
-            : { top: 44, right: 0, backgroundColor: color }
+            : { top: rowPositions["value"] ?? 44, right: 0, backgroundColor: color }
         }
       />
     </NodeCard>

--- a/frontend/src/components/graph/nodes/RerouteNode.tsx
+++ b/frontend/src/components/graph/nodes/RerouteNode.tsx
@@ -13,7 +13,7 @@ export function RerouteNode({ data, selected }: NodeProps<RerouteNodeType>) {
 
   return (
     <div
-      className={`flex items-center gap-0 ${selected ? "ring-2 ring-blue-400/50 rounded-full" : ""}`}
+      className={`flex items-center gap-0 ${selected ? "ring-2 ring-blue-400/80 rounded-full" : ""}`}
       style={{
         height: 18,
         minWidth: 36,

--- a/frontend/src/components/graph/nodes/SchedulerNode.tsx
+++ b/frontend/src/components/graph/nodes/SchedulerNode.tsx
@@ -423,13 +423,24 @@ export function SchedulerNode({
         <NodeBody withGap>
           {/* Transport row */}
           <div className="flex items-center gap-2 text-[10px]">
-            <label className="flex items-center gap-1 text-[#8c8c8d]">
-              <input
-                type="checkbox"
-                checked={loop}
-                onChange={toggleLoop}
-                className="w-3 h-3 accent-blue-500"
-              />
+            <label className="flex items-center gap-1.5 text-[#8c8c8d] cursor-pointer select-none">
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={loop}
+                onClick={toggleLoop}
+                className={`w-3.5 h-3.5 rounded-[3px] border flex items-center justify-center transition-colors ${
+                  loop
+                    ? "bg-blue-500 border-blue-500"
+                    : "bg-[#1a1a1a] border-[rgba(255,255,255,0.15)] hover:border-[rgba(255,255,255,0.3)]"
+                }`}
+              >
+                {loop && (
+                  <svg className="w-2.5 h-2.5 text-white" viewBox="0 0 12 12" fill="none">
+                    <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )}
+              </button>
               Loop
             </label>
             <span className="text-[#8c8c8d]">Duration:</span>
@@ -438,7 +449,7 @@ export function SchedulerNode({
               value={duration}
               onChange={e => updateDuration(parseFloat(e.target.value) || 1)}
               onPointerDown={e => e.stopPropagation()}
-              className="w-[50px] bg-[#1b1a1a] border border-[rgba(119,119,119,0.15)] rounded px-1.5 py-0.5 text-[10px] text-[#fafafa] text-center appearance-none focus:outline-none focus:ring-1 focus:ring-blue-400/50 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              className="w-[50px] bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded px-1.5 py-0.5 text-[10px] text-[#fafafa] text-center appearance-none focus:outline-none focus:ring-1 focus:ring-blue-400/60 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             />
             <span className="text-[#666]">s</span>
           </div>

--- a/frontend/src/components/graph/nodes/SchedulerNode.tsx
+++ b/frontend/src/components/graph/nodes/SchedulerNode.tsx
@@ -436,8 +436,18 @@ export function SchedulerNode({
                 }`}
               >
                 {loop && (
-                  <svg className="w-2.5 h-2.5 text-white" viewBox="0 0 12 12" fill="none">
-                    <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  <svg
+                    className="w-2.5 h-2.5 text-white"
+                    viewBox="0 0 12 12"
+                    fill="none"
+                  >
+                    <path
+                      d="M2.5 6L5 8.5L9.5 3.5"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
                   </svg>
                 )}
               </button>

--- a/frontend/src/components/graph/nodes/SinkNode.tsx
+++ b/frontend/src/components/graph/nodes/SinkNode.tsx
@@ -264,7 +264,7 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
   );
 
   return (
-    <NodeCard selected={selected} collapsed={collapsed}>
+    <NodeCard selected={selected} collapsed={collapsed} autoMinHeight={false}>
       <NodeHeader
         title={data.customTitle || "Sink"}
         onTitleChange={newTitle => updateData({ customTitle: newTitle })}

--- a/frontend/src/components/graph/nodes/SliderNode.tsx
+++ b/frontend/src/components/graph/nodes/SliderNode.tsx
@@ -54,6 +54,7 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
   const { setRowRef, rowPositions } = useHandlePositions([
     minIn.connected,
     maxIn.connected,
+    collapsed,
   ]);
 
   return (
@@ -71,6 +72,7 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
       {!collapsed && (
         <NodeBody withGap>
           {/* Slider track */}
+          <div ref={setRowRef("slider")}>
           <div
             ref={sliderRef}
             className="relative w-full h-5 rounded-full cursor-pointer select-none"
@@ -94,6 +96,7 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
                 boxShadow: `0 0 4px ${COLOR}`,
               }}
             />
+          </div>
           </div>
 
           {/* Current value display */}
@@ -149,7 +152,7 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
         style={
           collapsed
             ? collapsedHandleStyle("left")
-            : { top: 44, left: 0, backgroundColor: COLOR }
+            : { top: rowPositions["slider"] ?? 44, left: 0, backgroundColor: COLOR }
         }
       />
 
@@ -203,7 +206,7 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
         style={
           collapsed
             ? collapsedHandleStyle("right")
-            : { top: 44, right: 0, backgroundColor: COLOR }
+            : { top: rowPositions["slider"] ?? 44, right: 0, backgroundColor: COLOR }
         }
       />
     </NodeCard>

--- a/frontend/src/components/graph/nodes/SliderNode.tsx
+++ b/frontend/src/components/graph/nodes/SliderNode.tsx
@@ -73,30 +73,30 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
         <NodeBody withGap>
           {/* Slider track */}
           <div ref={setRowRef("slider")}>
-          <div
-            ref={sliderRef}
-            className="relative w-full h-5 rounded-full cursor-pointer select-none"
-            style={{
-              background: "#1b1a1a",
-              border: "1px solid rgba(119,119,119,0.15)",
-            }}
-            onPointerDown={handlePointerDown}
-          >
-            {/* Filled portion */}
             <div
-              className="absolute left-0 top-0 h-full rounded-full pointer-events-none"
-              style={{ width: `${pct}%`, background: COLOR, opacity: 0.35 }}
-            />
-            {/* Thumb */}
-            <div
-              className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full pointer-events-none"
+              ref={sliderRef}
+              className="relative w-full h-5 rounded-full cursor-pointer select-none"
               style={{
-                left: `calc(${pct}% - 6px)`,
-                background: COLOR,
-                boxShadow: `0 0 4px ${COLOR}`,
+                background: "#1b1a1a",
+                border: "1px solid rgba(119,119,119,0.15)",
               }}
-            />
-          </div>
+              onPointerDown={handlePointerDown}
+            >
+              {/* Filled portion */}
+              <div
+                className="absolute left-0 top-0 h-full rounded-full pointer-events-none"
+                style={{ width: `${pct}%`, background: COLOR, opacity: 0.35 }}
+              />
+              {/* Thumb */}
+              <div
+                className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full pointer-events-none"
+                style={{
+                  left: `calc(${pct}% - 6px)`,
+                  background: COLOR,
+                  boxShadow: `0 0 4px ${COLOR}`,
+                }}
+              />
+            </div>
           </div>
 
           {/* Current value display */}
@@ -152,7 +152,11 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
         style={
           collapsed
             ? collapsedHandleStyle("left")
-            : { top: rowPositions["slider"] ?? 44, left: 0, backgroundColor: COLOR }
+            : {
+                top: rowPositions["slider"] ?? 44,
+                left: 0,
+                backgroundColor: COLOR,
+              }
         }
       />
 
@@ -206,7 +210,11 @@ export function SliderNode({ id, data, selected }: NodeProps<SliderNodeType>) {
         style={
           collapsed
             ? collapsedHandleStyle("right")
-            : { top: rowPositions["slider"] ?? 44, right: 0, backgroundColor: COLOR }
+            : {
+                top: rowPositions["slider"] ?? 44,
+                right: 0,
+                backgroundColor: COLOR,
+              }
         }
       />
     </NodeCard>

--- a/frontend/src/components/graph/nodes/SourceNode.tsx
+++ b/frontend/src/components/graph/nodes/SourceNode.tsx
@@ -189,7 +189,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   }));
 
   return (
-    <NodeCard selected={selected} collapsed={collapsed}>
+    <NodeCard selected={selected} collapsed={collapsed} autoMinHeight={false}>
       <NodeHeader
         title={data.customTitle || "Source"}
         onTitleChange={newTitle => updateData({ customTitle: newTitle })}

--- a/frontend/src/components/graph/ui/NodeCard.tsx
+++ b/frontend/src/components/graph/ui/NodeCard.tsx
@@ -19,7 +19,7 @@ export function NodeCard({
   children,
   selected,
   className = "",
-  autoMinHeight = false,
+  autoMinHeight = true,
   minWidth = 240,
   minHeight: minHeightProp = 60,
   collapsed = false,
@@ -57,7 +57,7 @@ export function NodeCard({
   if (collapsed) {
     return (
       <div
-        className={`group bg-[#181717] border border-[rgba(119,119,119,0.55)] rounded-full relative flex flex-col ${
+        className={`group bg-[#1e1e1e] border border-[rgba(255,255,255,0.06)] rounded-full shadow-[0_1px_4px_rgba(0,0,0,0.25)] relative flex flex-col ${
           selected ? NODE_TOKENS.cardSelected : ""
         } ${className}`}
       >
@@ -80,7 +80,7 @@ export function NodeCard({
           autoMinHeight ? Math.max(minHeightProp, minH) : minHeightProp
         }
         lineClassName="!border-transparent"
-        handleClassName="!w-2 !h-2 !bg-transparent !border !border-blue-400/20 hover:!border-blue-400/40 !rounded-sm"
+        handleClassName="!w-2 !h-2 !bg-transparent !border !border-blue-400/30 hover:!border-blue-400/60 !rounded-sm"
       />
       {autoMinHeight ? (
         <div

--- a/frontend/src/components/graph/ui/NodeCard.tsx
+++ b/frontend/src/components/graph/ui/NodeCard.tsx
@@ -57,7 +57,7 @@ export function NodeCard({
   if (collapsed) {
     return (
       <div
-        className={`group bg-[#1e1e1e] border border-[rgba(255,255,255,0.06)] rounded-full shadow-[0_1px_4px_rgba(0,0,0,0.25)] relative flex flex-col ${
+        className={`group bg-[#1e1e1e] border-2 border-[rgba(255,255,255,0.06)] rounded-full shadow-[0_1px_4px_rgba(0,0,0,0.25)] relative flex flex-col ${
           selected ? NODE_TOKENS.cardSelected : ""
         } ${className}`}
       >
@@ -77,10 +77,10 @@ export function NodeCard({
         isVisible={!!selected}
         minWidth={minWidth}
         minHeight={
-          autoMinHeight ? Math.max(minHeightProp, minH) : minHeightProp
+          autoMinHeight ? Math.max(minHeightProp, minH + 4) : minHeightProp
         }
         lineClassName="!border-transparent"
-        handleClassName="!w-2 !h-2 !bg-transparent !border !border-blue-400/30 hover:!border-blue-400/60 !rounded-sm"
+        handleClassName="!w-3 !h-3 !bg-transparent !border-0"
       />
       {autoMinHeight ? (
         <div

--- a/frontend/src/components/graph/ui/NodeCard.tsx
+++ b/frontend/src/components/graph/ui/NodeCard.tsx
@@ -57,7 +57,7 @@ export function NodeCard({
   if (collapsed) {
     return (
       <div
-        className={`group bg-[#1e1e1e] border-2 border-[rgba(255,255,255,0.06)] rounded-full shadow-[0_1px_4px_rgba(0,0,0,0.25)] relative flex flex-col ${
+        className={`group bg-[#1e1e1e] border-2 border-transparent rounded-full shadow-[0_1px_4px_rgba(0,0,0,0.25)] relative flex flex-col ${
           selected ? NODE_TOKENS.cardSelected : ""
         } ${className}`}
       >

--- a/frontend/src/components/graph/ui/NodeHeader.tsx
+++ b/frontend/src/components/graph/ui/NodeHeader.tsx
@@ -108,7 +108,7 @@ export function NodeHeader({
               e.stopPropagation();
               onCollapseToggle();
             }}
-            className="shrink-0 text-[#666] hover:text-[#999] transition-colors"
+            className="shrink-0 text-[#555] hover:text-[#888] transition-colors"
           >
             {collapsed ? (
               <ChevronRight className="h-3.5 w-3.5" />
@@ -156,7 +156,7 @@ export function NodeHeader({
               className={`p-0.5 rounded transition-colors ${
                 locked
                   ? "text-amber-400 hover:text-amber-300"
-                  : "text-[#666] hover:text-[#999]"
+                  : "text-[#555] hover:text-[#888]"
               }`}
               title={locked ? "Unlock parameters" : "Lock parameters"}
             >
@@ -175,7 +175,7 @@ export function NodeHeader({
               className={`p-0.5 rounded transition-colors ${
                 pinned
                   ? "text-blue-400 hover:text-blue-300"
-                  : "text-[#666] hover:text-[#999]"
+                  : "text-[#555] hover:text-[#888]"
               }`}
               title={pinned ? "Unpin node" : "Pin node in place"}
             >

--- a/frontend/src/components/graph/ui/NodePillSearchableSelect.tsx
+++ b/frontend/src/components/graph/ui/NodePillSearchableSelect.tsx
@@ -107,7 +107,7 @@ export function NodePillSearchableSelect({
         createPortal(
           <div
             ref={dropdownRef}
-            className="fixed z-[9999] w-[200px] bg-[#1b1a1a] border border-[rgba(119,119,119,0.15)] rounded-lg shadow-lg max-h-[240px] overflow-hidden flex flex-col nowheel"
+            className="fixed z-[9999] w-[200px] bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md shadow-[0_4px_16px_rgba(0,0,0,0.4)] max-h-[240px] overflow-hidden flex flex-col nowheel"
             style={{ top: dropdownPos.top, left: dropdownPos.left }}
             onMouseDown={e => e.stopPropagation()}
             onWheel={e => e.stopPropagation()}
@@ -118,7 +118,7 @@ export function NodePillSearchableSelect({
               value={searchText}
               onChange={e => setSearchText(e.target.value)}
               placeholder={placeholder}
-              className="px-2 py-1 text-[10px] bg-[#2a2a2a] border-b border-[rgba(119,119,119,0.15)] text-[#fafafa] focus:outline-none focus:ring-1 focus:ring-blue-400/50"
+              className="px-2 py-1 text-[10px] bg-[#242424] border-b border-[rgba(255,255,255,0.06)] text-[#fafafa] focus:outline-none focus:ring-1 focus:ring-blue-400/60"
               onMouseDown={e => e.stopPropagation()}
               onWheel={e => e.stopPropagation()}
             />

--- a/frontend/src/components/graph/ui/NodePillTextarea.tsx
+++ b/frontend/src/components/graph/ui/NodePillTextarea.tsx
@@ -56,7 +56,7 @@ export function NodePillTextarea({
       disabled={disabled}
       placeholder={placeholder}
       rows={3}
-      className={`${NODE_TOKENS.pillInput} !rounded-md w-full min-w-[110px] resize-y min-h-[60px] max-h-full overflow-y-auto text-left py-1.5 leading-relaxed nowheel nodrag ${className}`}
+      className={`${NODE_TOKENS.pillInput} w-full min-w-[110px] resize-y min-h-[60px] max-h-full overflow-y-auto text-left py-1.5 leading-relaxed nowheel nodrag [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-white/30 ${className}`}
     />
   );
 }

--- a/frontend/src/components/graph/ui/NodePillToggle.tsx
+++ b/frontend/src/components/graph/ui/NodePillToggle.tsx
@@ -20,7 +20,7 @@ export function NodePillToggle({
       onClick={() => onChange(!checked)}
       className={`
         relative inline-flex h-[16px] w-[30px] shrink-0 cursor-pointer items-center
-        rounded-full border border-[rgba(119,119,119,0.15)] transition-colors duration-200
+        rounded-full border border-[rgba(255,255,255,0.06)] transition-colors duration-200
         focus:outline-none focus:ring-1 focus:ring-blue-400/50
         ${checked ? "bg-blue-500/80" : "bg-[#1b1a1a]"}
         ${disabled ? "opacity-50 cursor-not-allowed" : ""}

--- a/frontend/src/components/graph/ui/tokens.ts
+++ b/frontend/src/components/graph/ui/tokens.ts
@@ -1,5 +1,5 @@
 export const NODE_TOKENS = {
-  card: "bg-[#242424] border-2 border-[rgba(255,255,255,0.06)] rounded-lg shadow-[0_2px_8px_rgba(0,0,0,0.3)] min-w-[240px] relative w-full h-full flex flex-col",
+  card: "bg-[#242424] border-2 border-transparent rounded-lg shadow-[0_2px_8px_rgba(0,0,0,0.3)] min-w-[240px] relative w-full h-full flex flex-col",
   cardSelected: "[outline:0.5px_solid_white] [outline-offset:3px]",
   header:
     "bg-[#1e1e1e] border-b border-[rgba(255,255,255,0.04)] flex items-center gap-2 px-2.5 py-1 h-[30px] rounded-t-lg",

--- a/frontend/src/components/graph/ui/tokens.ts
+++ b/frontend/src/components/graph/ui/tokens.ts
@@ -1,6 +1,6 @@
 export const NODE_TOKENS = {
-  card: "bg-[#242424] border border-[rgba(255,255,255,0.06)] rounded-lg shadow-[0_2px_8px_rgba(0,0,0,0.3)] min-w-[240px] relative w-full h-full flex flex-col",
-  cardSelected: "ring-2 ring-blue-400/80",
+  card: "bg-[#242424] border-2 border-[rgba(255,255,255,0.06)] rounded-lg shadow-[0_2px_8px_rgba(0,0,0,0.3)] min-w-[240px] relative w-full h-full flex flex-col",
+  cardSelected: "[outline:0.5px_solid_white] [outline-offset:3px]",
   header:
     "bg-[#1e1e1e] border-b border-[rgba(255,255,255,0.04)] flex items-center gap-2 px-2.5 py-1 h-[30px] rounded-t-lg",
   body: "py-1 px-2.5",

--- a/frontend/src/components/graph/ui/tokens.ts
+++ b/frontend/src/components/graph/ui/tokens.ts
@@ -3,18 +3,18 @@ export const NODE_TOKENS = {
   cardSelected: "ring-2 ring-blue-400/80",
   header:
     "bg-[#1e1e1e] border-b border-[rgba(255,255,255,0.04)] flex items-center gap-2 px-2.5 py-1 h-[30px] rounded-t-lg",
-  body: "py-2 px-2.5",
-  bodyWithGap: "py-2 px-2.5 flex flex-col gap-1",
-  pill: "bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md px-2.5 py-1",
+  body: "py-1 px-2.5",
+  bodyWithGap: "py-1 px-2.5 flex flex-col gap-0.5",
+  pill: "bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md px-2.5 py-0.5",
   pillInput:
-    "bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md px-2.5 py-1 text-[#fafafa] text-[10px] appearance-none focus:outline-none focus:ring-1 focus:ring-blue-400/60 w-[110px]",
+    "bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md px-2.5 py-0.5 text-[#fafafa] text-[10px] appearance-none focus:outline-none focus:ring-1 focus:ring-blue-400/60 w-[110px]",
   pillInputText: "text-center",
   pillInputNumber:
     "text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
   labelText: "text-[#737373] text-[10px] font-normal tracking-wide",
   primaryText: "text-[#e8e8e8] text-[10px] font-medium",
   headerText: "text-[#f0f0f0] text-[11px] font-semibold tracking-tight",
-  paramRow: "flex items-center justify-between min-h-[22px]",
+  paramRow: "flex items-center justify-between min-h-[18px]",
   sectionTitle:
     "text-[9px] font-semibold text-[#666] uppercase tracking-widest mb-2",
   panelBackground: "bg-[#161616]",

--- a/frontend/src/components/graph/ui/tokens.ts
+++ b/frontend/src/components/graph/ui/tokens.ts
@@ -1,31 +1,32 @@
 export const NODE_TOKENS = {
-  card: "bg-[#2a2a2a] border border-[rgba(119,119,119,0.55)] rounded-xl min-w-[240px] relative w-full h-full flex flex-col",
-  cardSelected: "ring-2 ring-blue-400/50",
+  card: "bg-[#242424] border border-[rgba(255,255,255,0.06)] rounded-lg shadow-[0_2px_8px_rgba(0,0,0,0.3)] min-w-[240px] relative w-full h-full flex flex-col",
+  cardSelected: "ring-2 ring-blue-400/80",
   header:
-    "bg-[#181717] border-b border-[rgba(119,119,119,0.15)] flex items-center gap-2 px-2 py-1 h-[28px] rounded-t-xl",
-  body: "py-1.5 px-2",
-  bodyWithGap: "py-1.5 px-2 flex flex-col gap-1.5",
-  pill: "bg-[#1b1a1a] border border-[rgba(119,119,119,0.15)] rounded-full px-2 py-0.5",
+    "bg-[#1e1e1e] border-b border-[rgba(255,255,255,0.04)] flex items-center gap-2 px-2.5 py-1 h-[30px] rounded-t-lg",
+  body: "py-2 px-2.5",
+  bodyWithGap: "py-2 px-2.5 flex flex-col gap-1",
+  pill: "bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md px-2.5 py-1",
   pillInput:
-    "bg-[#1b1a1a] border border-[rgba(119,119,119,0.15)] rounded-full px-2 py-0.5 text-[#fafafa] text-[10px] appearance-none focus:outline-none focus:ring-1 focus:ring-blue-400/50 w-[110px]",
+    "bg-[#1a1a1a] border border-[rgba(255,255,255,0.06)] rounded-md px-2.5 py-1 text-[#fafafa] text-[10px] appearance-none focus:outline-none focus:ring-1 focus:ring-blue-400/60 w-[110px]",
   pillInputText: "text-center",
   pillInputNumber:
     "text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
-  labelText: "text-[#8c8c8d] text-[10px] font-normal",
-  primaryText: "text-[#fafafa] text-[10px] font-normal",
-  headerText: "text-[#fafafa] text-[12px] font-normal",
-  paramRow: "flex items-center justify-between h-[20px]",
-  sectionTitle: "text-[10px] font-normal text-[#8c8c8d] mb-2",
-  panelBackground: "bg-[#181717]",
-  panelBorder: "border-[rgba(119,119,119,0.15)]",
+  labelText: "text-[#737373] text-[10px] font-normal tracking-wide",
+  primaryText: "text-[#e8e8e8] text-[10px] font-medium",
+  headerText: "text-[#f0f0f0] text-[11px] font-semibold tracking-tight",
+  paramRow: "flex items-center justify-between min-h-[22px]",
+  sectionTitle:
+    "text-[9px] font-semibold text-[#666] uppercase tracking-widest mb-2",
+  panelBackground: "bg-[#161616]",
+  panelBorder: "border-[rgba(255,255,255,0.04)]",
   toolbar:
-    "flex items-stretch h-9 bg-[#181717] border-b border-[rgba(119,119,119,0.15)]",
+    "flex items-stretch h-9 bg-[#161616] border-b border-[rgba(255,255,255,0.06)]",
   toolbarMenuButton:
-    "inline-flex items-center gap-1.5 px-4 text-xs font-medium text-[#8c8c8d] hover:bg-[rgba(255,255,255,0.06)] hover:text-[#fafafa] transition-colors cursor-pointer select-none",
+    "inline-flex items-center gap-1.5 px-4 text-xs font-medium text-[#8c8c8d] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#fafafa] transition-colors cursor-pointer select-none",
   toolbarHeroRun:
-    "inline-flex items-center gap-1.5 px-5 text-xs font-semibold bg-emerald-600 text-white hover:bg-emerald-700 transition-colors cursor-pointer select-none",
+    "inline-flex items-center gap-1.5 px-5 text-xs font-semibold bg-emerald-600 text-white hover:bg-emerald-500 transition-colors cursor-pointer select-none",
   toolbarHeroStop:
-    "inline-flex items-center gap-1.5 px-5 text-xs font-semibold bg-red-600/80 text-white hover:bg-red-700 transition-colors cursor-pointer select-none",
+    "inline-flex items-center gap-1.5 px-5 text-xs font-semibold bg-red-600/90 text-white hover:bg-red-600 transition-colors cursor-pointer select-none",
   toolbarHeroBusy:
     "inline-flex items-center gap-1.5 px-5 text-xs font-semibold text-[#8c8c8d] opacity-60 cursor-not-allowed select-none",
   toolbarStatus: "text-xs text-[#8c8c8d] mr-3 self-center",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,6 +37,12 @@
   }
 }
 
+/* Translucent nodes while dragging */
+.react-flow__node.dragging {
+  opacity: 0.7;
+  transition: opacity 150ms ease;
+}
+
 /* Hide edge delete dots while streaming */
 .streaming .edge-delete-dot {
   display: none;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -58,9 +58,5 @@
     #000 3px,
     transparent 3.5px
   );
-  mask-image: radial-gradient(
-    circle at center,
-    #000 3px,
-    transparent 3.5px
-  );
+  mask-image: radial-gradient(circle at center, #000 3px, transparent 3.5px);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -48,3 +48,19 @@
   display: none;
   pointer-events: none;
 }
+
+/* Shrink the visible area of node handles while keeping the full hit area.
+   The Handle element stays 10x10 for easy edge drawing, but the mask limits
+   the visible background to a 6px circle centered on the border. */
+.react-flow__handle {
+  -webkit-mask-image: radial-gradient(
+    circle at center,
+    #000 3px,
+    transparent 3.5px
+  );
+  mask-image: radial-gradient(
+    circle at center,
+    #000 3px,
+    transparent 3.5px
+  );
+}


### PR DESCRIPTION
**Graph node visual redesign**                                                                                                                                                                                        
  - Refined node card palette: darker body (#242424), subtle rgba(255,255,255,0.06) borders, soft drop shadow, and rounded-lg corners replacing the previous #2a2a2a / heavier border look                        
  - Updated header styling with tighter typography (text-[11px] font-semibold tracking-tight)                                                                                                                       
  - Pills and inputs switched from rounded-full to rounded-md                                                                                                                   
  - Refined label/primary text colors and a new uppercase                                                                                                                      
                                                                                                                                                                                                                    
  **More compact parameter layout**                                                                                                                                                                                     
  - Reduced node body padding (py-2 → py-1) and inter-row gap (gap-1 → gap-0.5)                                                                                                                                     
  - Shorter parameter rows (min-h-[22px] → min-h-[18px]) and tighter pill padding (py-1 → py-0.5)                                                                                                                   
  - Nodes fit significantly more parameters in the same vertical space                                                                                                                                            
                                                                                                                                                                                                                    
  **Smaller connectors, same hit area**                                                                                                                                                                                 
  - Handle visuals shrunk from 10px to a 6px dot via a CSS radial-gradient mask in index.css                                                                                                                        
  - Full 10px hoverable/clickable area preserved, so drawing edges feels identical                                                                                                                                  
  - PrimitiveNode handles now anchor to their parameter row via useHandlePositions instead of a hardcoded offset                                                                                                  
                                                                                                                                                                                                                    
  **Edges & context menu polish**                                                                                                                                                                                       
  - Edge endpoint circles reduced (r=5 → r=4) with stronger stroke, and default edge color muted (#9ca3af → #6b7280)                                                                                                
  - Added LoRA edge coloring via new COLOR_LORA branch in getEdgeColor                                                                                                                                              
  - Context menu and submenus restyled: darker background (#141414), softer rgba(255,255,255,0.05) hover, and a larger drop shadow                                                                                  
                                                                                                                                                                                                                    
  **Toolbar updates**                                                                                                                                                                                                   
  - Slightly brighter toolbar hover, punchier Run/Stop hero button states                                                                                                                                           
  - New dev-only “Debug Nodes” menu entry that spawns one of every node type in a fixed reference layout for design QA