### PR TITLE
fix(frontend): auto-load sample video on graph source nodes

### DIFF
--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -180,6 +180,7 @@ interface GraphEditorProps {
   sinkStats?: Record<string, { fps: number; bitrate: number }>;
   onVideoFileUpload?: (file: File, nodeId?: string) => Promise<boolean>;
   onCycleSampleVideo?: (nodeId?: string) => void;
+  onInitSampleVideo?: (nodeId?: string) => void;
   isPlaying?: boolean;
   onStartStream?: () => void;
   onStopStream?: () => void;
@@ -231,6 +232,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
       sinkStats,
       onVideoFileUpload,
       onCycleSampleVideo,
+      onInitSampleVideo,
       isPlaying = true,
       onStartStream,
       onStopStream,
@@ -313,6 +315,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         onGraphClear,
         onVideoFileUpload,
         onCycleSampleVideo,
+        onInitSampleVideo,
         onSourceModeChange,
         onSpoutSourceChange,
         onNdiSourceChange,

--- a/frontend/src/components/graph/hooks/graph/useGraphState.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphState.ts
@@ -71,6 +71,7 @@ export interface GraphEditorCallbacks {
   onNdiSourceChange?: (identifier: string) => void;
   onSyphonSourceChange?: (identifier: string) => void;
   onCycleSampleVideo?: (nodeId?: string) => void;
+  onInitSampleVideo?: (nodeId?: string) => void;
   onOutputSinkChange?: (
     sinkType: string,
     config: { enabled: boolean; name: string }
@@ -226,6 +227,9 @@ export function useGraphState(
   const onCycleSampleVideoRef = useRef(callbacks.onCycleSampleVideo);
   onCycleSampleVideoRef.current = callbacks.onCycleSampleVideo;
 
+  const onInitSampleVideoRef = useRef(callbacks.onInitSampleVideo);
+  onInitSampleVideoRef.current = callbacks.onInitSampleVideo;
+
   const onOutputSinkChangeRef = useRef(callbacks.onOutputSinkChange);
   onOutputSinkChangeRef.current = callbacks.onOutputSinkChange;
 
@@ -288,6 +292,7 @@ export function useGraphState(
     onNdiSourceChangeRef,
     onSyphonSourceChangeRef,
     onCycleSampleVideoRef,
+    onInitSampleVideoRef,
     spoutAvailable: availability.spoutAvailable,
     ndiAvailable: availability.ndiAvailable,
     syphonAvailable: availability.syphonAvailable,

--- a/frontend/src/components/graph/nodes/SourceNode.tsx
+++ b/frontend/src/components/graph/nodes/SourceNode.tsx
@@ -56,6 +56,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const onCycleSampleVideo = data.onCycleSampleVideo as
     | (() => void)
     | undefined;
+  const onInitSampleVideo = data.onInitSampleVideo as (() => void) | undefined;
   const videoRef = useRef<HTMLVideoElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [ndiSources, setNdiSources] = useState<DiscoveredSource[]>([]);
@@ -68,6 +69,17 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
       videoRef.current.srcObject = localStream;
     }
   }, [localStream]);
+
+  // Auto-load the first sample video (test.mp4) when in file mode without a
+  // stream. Without this, freshly added source nodes — or nodes loaded after
+  // the global useVideoSource fallback was cleared (e.g. switching to
+  // Spout/NDI/Syphon globally) — would show "No video loaded" until the user
+  // manually clicked the cycle button. The init handler is idempotent.
+  useEffect(() => {
+    if (sourceMode === "video" && !localStream && onInitSampleVideo) {
+      onInitSampleVideo();
+    }
+  }, [sourceMode, localStream, onInitSampleVideo]);
 
   // Discover NDI sources
   useEffect(() => {

--- a/frontend/src/components/graph/utils/nodeEnrichment.ts
+++ b/frontend/src/components/graph/utils/nodeEnrichment.ts
@@ -41,6 +41,9 @@ export interface EnrichNodesDeps {
   onCycleSampleVideoRef: React.RefObject<
     ((nodeId?: string) => void) | undefined
   >;
+  onInitSampleVideoRef: React.RefObject<
+    ((nodeId?: string) => void) | undefined
+  >;
   spoutAvailable: boolean;
   ndiAvailable: boolean;
   syphonAvailable: boolean;
@@ -175,6 +178,7 @@ export function enrichNodes(
           onSyphonSourceChange: (identifier: string) =>
             deps.onSyphonSourceChangeRef.current?.(identifier),
           onCycleSampleVideo: () => deps.onCycleSampleVideoRef.current?.(n.id),
+          onInitSampleVideo: () => deps.onInitSampleVideoRef.current?.(n.id),
           isStreaming: deps.isStreaming,
         },
       };

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -198,6 +198,8 @@ export interface FlowNodeData {
   onSyphonSourceChange?: (identifier: string) => void;
   /** For source nodes: callback to cycle through sample videos */
   onCycleSampleVideo?: () => void;
+  /** For source nodes: callback to initialize the first sample video (test.mp4) */
+  onInitSampleVideo?: () => void;
   /** For sink nodes: remote output stream */
   remoteStream?: MediaStream | null;
   /** For sink nodes: per-sink WebRTC stats (FPS, bitrate) */

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -882,11 +882,13 @@ export function StreamPage() {
     [handleVideoFileUpload]
   );
 
-  // Track per-node sample video cycle index (start at 0 so first cycle advances to 1,
-  // avoiding a no-op when the node already shows the default test.mp4)
+  // Track per-node sample video cycle index. After init this holds the index
+  // currently shown so the next cycle advances to the following sample.
   const nodeSampleVideoIndexRef = useRef<Record<string, number>>({});
   // Track per-node <video> elements so we can clean up the previous one on each cycle
   const nodeVideoElementsRef = useRef<Record<string, HTMLVideoElement>>({});
+  // Track in-flight init calls so a re-render doesn't kick off duplicate loads
+  const nodeInitInFlightRef = useRef<Set<string>>(new Set());
 
   // Handle per-node sample video cycling in graph mode
   const handlePerNodeCycleSampleVideo = useCallback(
@@ -928,6 +930,44 @@ export function StreamPage() {
     },
     [cycleSampleVideo]
   );
+
+  // Initialize a per-node sample video stream with the first sample (test.mp4).
+  // Idempotent: no-op if the node already has a stream or an init is in flight.
+  // Used by SourceNode to ensure file-mode source nodes always show a video,
+  // even when the global useVideoSource fallback isn't available.
+  const handlePerNodeInitSampleVideo = useCallback(async (nodeId?: string) => {
+    if (!nodeId) return;
+    if (nodeLocalStreamsRef.current[nodeId]) return;
+    if (nodeInitInFlightRef.current.has(nodeId)) return;
+    nodeInitInFlightRef.current.add(nodeId);
+    try {
+      const url = SAMPLE_VIDEOS[0];
+      const video = document.createElement("video");
+      video.src = url;
+      video.loop = true;
+      video.muted = true;
+      video.playsInline = true;
+      await video.play();
+      // Clean up any prior element (defensive — shouldn't happen since
+      // we only init when there's no stream, but be safe)
+      const oldVideo = nodeVideoElementsRef.current[nodeId];
+      if (oldVideo) {
+        oldVideo.pause();
+        oldVideo.removeAttribute("src");
+        oldVideo.load();
+      }
+      nodeVideoElementsRef.current[nodeId] = video;
+      nodeSampleVideoIndexRef.current[nodeId] = 0;
+      const stream = (
+        video as HTMLVideoElement & { captureStream(): MediaStream }
+      ).captureStream();
+      setNodeLocalStreams(prev => ({ ...prev, [nodeId]: stream }));
+    } catch (e) {
+      console.error(`Failed to init sample video for node ${nodeId}:`, e);
+    } finally {
+      nodeInitInFlightRef.current.delete(nodeId);
+    }
+  }, []);
 
   // Track the last stream track ID sent per node so we only call
   // updateSourceNodeTrack when the track actually changed.
@@ -3260,6 +3300,7 @@ export function StreamPage() {
             sinkStats={perSinkStats}
             onVideoFileUpload={handlePerNodeVideoFileUpload}
             onCycleSampleVideo={handlePerNodeCycleSampleVideo}
+            onInitSampleVideo={handlePerNodeInitSampleVideo}
             isPlaying={!settings.paused}
             onStartStream={() => handleStartStream()}
             onStopStream={stopStream}


### PR DESCRIPTION
## Summary
- Graph source nodes in File mode would sometimes render "No video loaded" and required a click on the cycle button to populate. This happened whenever the global `useVideoSource` fallback was null — e.g. after globally switching to Spout/NDI/Syphon, or during the initial mount race before the fallback finished loading.
- Added an idempotent per-node init handler (`handlePerNodeInitSampleVideo`) that loads `test.mp4` into `nodeLocalStreams` on first mount. It seeds `nodeSampleVideoIndexRef` to `0` so the subsequent cycle click correctly advances to `test1.mp4`.
- Wired the callback through `GraphEditor` → `useGraphState` → `nodeEnrichment`, and added a `useEffect` in `SourceNode` that triggers it when `sourceMode === "video"` and no `localStream` is available.

## Test plan
- [ ] Open graph mode, add a fresh Source node → verify `test.mp4` plays without manual intervention.
- [ ] Globally switch to Spout/NDI/Syphon in perform mode, return to graph mode → verify existing source nodes re-populate with `test.mp4`.
- [ ] Click the cycle button on a freshly initialized source node → verify it advances to `test1.mp4`, then `test2.mp4`, then back to `test.mp4`.
- [ ] Upload a custom video on a source node → verify the custom video remains (not overwritten by init).
- [ ] Load a saved graph containing source nodes → verify they all auto-populate with `test.mp4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)