### PR TITLE
fix(frontend): auto-load sample video on workflow-loaded source nodes

### DIFF
--- a/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
@@ -351,6 +351,12 @@ export function useGraphPersistence({
       setStatus(`Imported from ${fileName}`);
       setFitViewTrigger(c => c + 1);
 
+      // Restore non-default source modes that need external setup
+      // (camera permission, Spout/NDI/Syphon hardware connection). File mode
+      // ("video") is the default and is handled by SourceNode's auto-init
+      // effect — re-dispatching it here would race with and cancel the init
+      // since handlePerNodeSourceModeChange unconditionally stops any existing
+      // stream for the node.
       const sourceNodes = flowNodes.filter(n => n.data.nodeType === "source");
       const modesToRestore = sourceNodes
         .map(n => ({
@@ -358,7 +364,8 @@ export function useGraphPersistence({
           nodeId: n.id,
         }))
         .filter(
-          (entry): entry is { mode: string; nodeId: string } => !!entry.mode
+          (entry): entry is { mode: string; nodeId: string } =>
+            !!entry.mode && entry.mode !== "video"
         );
       if (modesToRestore.length > 0) {
         setTimeout(() => {


### PR DESCRIPTION
## Summary

Follow-up to #887. That PR added an auto-init effect in `SourceNode` so file-mode source nodes always end up with `test.mp4` loaded, but the fix did not trigger for nodes deserialized from a workflow JSON — they persistently showed "No video loaded", and clicking Run silently failed with `Video input required but no local stream available`.

**Root cause:** `loadGraphFromParsed` schedules a `setTimeout(0)` that re-dispatches every source node's stored `source_mode` through `handlePerNodeSourceModeChange`. That handler unconditionally stops and deletes any per-node stream, including the one that `SourceNode`'s auto-init effect has just created. For `newMode === "video"` when not streaming, the handler then does nothing to replace it, leaving the node stream-less.

**Fix:** Skip `"video"` in the restoration loop. File mode is the default and needs no external setup — the auto-init effect already handles it. `camera`, `spout`, `ndi`, and `syphon` restorations are unchanged.

## Test plan

- [x] Load Mythical Creature via onboarding (Simple mode, Cloud) → Source node auto-loads `test.mp4` on mount (verified: shows the cat-in-grass sample frame, no manual cycle click needed)
- [ ] Load Dissolving Sunflower the same way → Source auto-loads
- [ ] Load LTX 2.3 (text-to-video, no source node) → no regression
- [ ] Import a workflow JSON that has a camera/Spout/NDI/Syphon source → mode still restored via the setTimeout path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
