### PR TITLE
fix(graph): prune stale/invalid port edges instead of failing pipeline setup

### DIFF
--- a/frontend/src/components/ComplexFields.tsx
+++ b/frontend/src/components/ComplexFields.tsx
@@ -138,7 +138,7 @@ export function SchemaComplexField({
         <div className="flex items-center justify-between gap-2">
           <LabelWithTooltip
             label="VACE"
-            tooltip="Enable VACE (Video All-In-One Creation and Editing) support for reference image conditioning and structural guidance. When enabled, you can use reference images for R2V generation. In Video input mode, a separate toggle controls whether the input video is used for VACE conditioning or for latent initialization. Requires pipeline reload to take effect."
+            tooltip="Enable VACE (Video All-In-One Creation and Editing) support for reference image conditioning and structural guidance. When enabled, you can use reference images for R2V generation. In Video input mode, a separate toggle controls whether the input video is used for VACE conditioning or for latent initialization. Requires model reload to take effect."
             className="text-sm font-medium"
           />
           <Toggle

--- a/frontend/src/components/DownloadDialog.tsx
+++ b/frontend/src/components/DownloadDialog.tsx
@@ -77,7 +77,7 @@ export function DownloadDialog({
                 ? currentDownloadPipeline
                   ? `Downloading models for ${currentPipelineInfo?.name || currentDownloadPipeline}...`
                   : "Please wait while models are downloaded."
-                : "The following pipeline(s) require models to be downloaded:"}
+                : "The following model(s) require files to be downloaded:"}
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/components/DownloadDialog.tsx
+++ b/frontend/src/components/DownloadDialog.tsx
@@ -173,7 +173,7 @@ export function DownloadDialog({
         {/* Show remaining pipelines count if downloading */}
         {isDownloading && currentDownloadPipeline && pipelineIds.length > 1 && (
           <p className="text-sm text-muted-foreground">
-            {pipelineIds.length - 1} more pipeline(s) will be downloaded after
+            {pipelineIds.length - 1} more model(s) will be downloaded after
             this one.
           </p>
         )}

--- a/frontend/src/components/InputAndControlsPanel.tsx
+++ b/frontend/src/components/InputAndControlsPanel.tsx
@@ -671,7 +671,7 @@ export function InputAndControlsPanel({
               tooltip={
                 vaceEnabled && pipeline?.supportsVACE
                   ? "Select reference images for VACE conditioning. Images will guide the video generation style and content."
-                  : "Select images to send to the pipeline for conditioning."
+                  : "Select images to send to the model for conditioning."
               }
             />
             {onSendHints && refImages && refImages.length > 0 && (

--- a/frontend/src/components/PluginsDialog.tsx
+++ b/frontend/src/components/PluginsDialog.tsx
@@ -99,7 +99,7 @@ export function PluginsDialog({
   const handleBrowseLocalPlugin = async () => {
     if (window.scope?.browseDirectory) {
       const path = await window.scope.browseDirectory(
-        "Select Plugin Directory"
+        "Select Node Directory"
       );
       if (path) setPluginInstallPath(path);
     }

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -555,7 +555,7 @@ export function SettingsPanel({
                       {plugin.length > 0 && (
                         <SelectGroup>
                           <SelectLabel className="text-xs text-muted-foreground font-bold">
-                            Node Models
+                            All Models
                           </SelectLabel>
                           {plugin.map(([id]) => (
                             <SelectItem key={id} value={id}>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -518,14 +518,14 @@ export function SettingsPanel({
           </div>
         )}
         <div className="space-y-2">
-          <h3 className="text-sm font-medium">Pipeline ID</h3>
+          <h3 className="text-sm font-medium">Model</h3>
           <Select
             value={pipelineId}
             onValueChange={handlePipelineIdChange}
             disabled={isStreaming || isLoading || nonLinearGraph}
           >
             <SelectTrigger className="w-full">
-              <SelectValue placeholder="Select a pipeline" />
+              <SelectValue placeholder="Select a model" />
             </SelectTrigger>
             <SelectContent>
               {pipelines &&
@@ -540,7 +540,7 @@ export function SettingsPanel({
                       {builtIn.length > 0 && (
                         <SelectGroup>
                           <SelectLabel className="text-xs text-muted-foreground font-bold">
-                            Built-in Pipelines
+                            Built-in Models
                           </SelectLabel>
                           {builtIn.map(([id]) => (
                             <SelectItem key={id} value={id}>
@@ -555,7 +555,7 @@ export function SettingsPanel({
                       {plugin.length > 0 && (
                         <SelectGroup>
                           <SelectLabel className="text-xs text-muted-foreground font-bold">
-                            Plugin Pipelines
+                            Node Models
                           </SelectLabel>
                           {plugin.map(([id]) => (
                             <SelectItem key={id} value={id}>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -555,7 +555,7 @@ export function SettingsPanel({
                       {plugin.length > 0 && (
                         <SelectGroup>
                           <SelectLabel className="text-xs text-muted-foreground font-bold">
-                            All Models
+                            Node Models
                           </SelectLabel>
                           {plugin.map(([id]) => (
                             <SelectItem key={id} value={id}>
@@ -621,7 +621,7 @@ export function SettingsPanel({
                           </TooltipTrigger>
                           <TooltipContent>
                             <p>
-                              This pipeline contains modifications based on the
+                              This model contains modifications based on the
                               original project.
                             </p>
                           </TooltipContent>
@@ -830,7 +830,7 @@ export function SettingsPanel({
                   <div className="flex items-center justify-between gap-2">
                     <LabelWithTooltip
                       label="VACE"
-                      tooltip="Enable VACE (Video All-In-One Creation and Editing) support for reference image conditioning and structural guidance. When enabled, you can use reference images for R2V generation. In Video input mode, a separate toggle controls whether the input video is used for VACE conditioning or for latent initialization. Requires pipeline reload to take effect."
+                      tooltip="Enable VACE (Video All-In-One Creation and Editing) support for reference image conditioning and structural guidance. When enabled, you can use reference images for R2V generation. In Video input mode, a separate toggle controls whether the input video is used for VACE conditioning or for latent initialization. Requires model reload to take effect."
                       className="text-sm font-medium"
                     />
                     <Toggle

--- a/frontend/src/components/VideoOutput.tsx
+++ b/frontend/src/components/VideoOutput.tsx
@@ -277,7 +277,7 @@ export function VideoOutput({
           <div className="text-center text-muted-foreground">
             <Spinner size={24} className="mx-auto mb-3" />
             <p key={pipelineLoadingStage} className="animate-fade-in text-lg">
-              {pipelineLoadingStage || "Loading pipeline..."}
+              {pipelineLoadingStage || "Loading model..."}
             </p>
             <p className="text-xs text-muted-foreground/80 mt-3 max-w-[280px] mx-auto leading-relaxed">
               Models may take up to a minute to load, only on the first run.

--- a/frontend/src/components/WorkflowImportDialog.tsx
+++ b/frontend/src/components/WorkflowImportDialog.tsx
@@ -422,7 +422,7 @@ export function WorkflowImportDialog({
           parsed.pipelines.length === 0
         ) {
           toast.error("Malformed workflow file", {
-            description: "Missing required fields: metadata or pipelines",
+            description: "Missing required fields: metadata or models",
           });
           return;
         }

--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -85,8 +85,8 @@ const NODE_CATALOG: NodeCatalogItem[] = [
   },
   {
     type: "pipeline",
-    name: "Pipeline",
-    description: "Processing pipeline node",
+    name: "Model",
+    description: "Processing model node",
     color: "#60a5fa",
     category: "I/O",
   },

--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -209,7 +209,7 @@ const NODE_CATALOG: NodeCatalogItem[] = [
     type: "vace",
     name: "VACE",
     description:
-      "Bundle VACE parameters (context scale, reference images) for pipeline conditioning",
+      "Bundle VACE parameters (context scale, reference images) for model conditioning",
     color: "#a78bfa",
     category: "I/O",
   },

--- a/frontend/src/components/graph/GraphToolbar.tsx
+++ b/frontend/src/components/graph/GraphToolbar.tsx
@@ -146,7 +146,7 @@ export function GraphToolbar({
               className="text-xs text-[#8c8c8d] animate-fade-in"
               key={loadingStage}
             >
-              {loadingStage || "Loading pipeline…"}
+              {loadingStage || "Loading model…"}
             </span>
             <span className="text-[10px] text-[#b0b0b0]">
               Models may take up to a minute to load, only on the first run.

--- a/frontend/src/components/graph/GraphWorkflowImportDialog.tsx
+++ b/frontend/src/components/graph/GraphWorkflowImportDialog.tsx
@@ -95,7 +95,7 @@ export function GraphWorkflowImportDialog({
   const confirmPluginInstall = useCallback(
     (installSpec: string) =>
       showConfirm(
-        "Install Plugin",
+        "Install Node",
         `This will install the package "${installSpec}" via pip. Only proceed if you trust the workflow source.`
       ),
     [showConfirm]
@@ -264,7 +264,7 @@ export function GraphWorkflowImportDialog({
                   <Download className="h-4 w-4 mr-2" />
                   {plugins.someInstalling
                     ? "Installing..."
-                    : `Install All Missing Plugins (${installablePlugins.filter(p => plugins.installs[p.name] !== "done").length})`}
+                    : `Install All Missing Nodes (${installablePlugins.filter(p => plugins.installs[p.name] !== "done").length})`}
                 </Button>
               )}
 

--- a/frontend/src/components/graph/contextMenuItems.tsx
+++ b/frontend/src/components/graph/contextMenuItems.tsx
@@ -95,7 +95,7 @@ export function buildPaneMenuItems(deps: {
       keywords: ["input", "camera", "video"],
     },
     {
-      label: "Pipeline",
+      label: "Model",
       icon: <Workflow />,
       onClick: () => handleNodeTypeSelect("pipeline"),
       keywords: ["process", "effect", "filter"],

--- a/frontend/src/components/graph/nodes/PipelineNode.tsx
+++ b/frontend/src/components/graph/nodes/PipelineNode.tsx
@@ -80,7 +80,7 @@ export function PipelineNode({
     !!data.pipelineId && !pipelineIds.includes(data.pipelineId);
 
   const selectOptions = [
-    { value: "", label: "Select pipeline..." },
+    { value: "", label: "Select model..." },
     ...pipelineIds.map(pid => ({ value: pid, label: pid })),
     ...(isUnavailable
       ? [
@@ -185,7 +185,7 @@ export function PipelineNode({
                 onPipelineSelect?.(id, newPipelineId);
               }}
               options={selectOptions}
-              placeholder="Select pipeline..."
+              placeholder="Select model..."
               disabled={isStreaming}
             />
           </NodeParamRow>
@@ -195,7 +195,7 @@ export function PipelineNode({
             <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-amber-500/10 border border-amber-500/20">
               <AlertTriangle className="h-3 w-3 text-amber-400 shrink-0" />
               <span className="text-[10px] text-amber-400">
-                Pipeline not installed
+                Model not installed
               </span>
             </div>
           )}

--- a/frontend/src/components/graph/nodes/PipelineNode.tsx
+++ b/frontend/src/components/graph/nodes/PipelineNode.tsx
@@ -73,7 +73,7 @@ export function PipelineNode({
   const supportsLoRA = data.supportsLoRA ?? false;
   const isStreaming = data.isStreaming ?? false;
 
-  const pipelineName = data.pipelineId || "Pipeline";
+  const pipelineName = data.pipelineId || "Model";
 
   // Inject unavailable pipelineId into options
   const isUnavailable =
@@ -177,7 +177,7 @@ export function PipelineNode({
       {!collapsed && (
         <NodeBody withGap>
           {/* Pipeline selector */}
-          <NodeParamRow label="Pipeline">
+          <NodeParamRow label="Model">
             <NodePillSearchableSelect
               value={data.pipelineId || ""}
               onChange={newValue => {

--- a/frontend/src/components/settings/DaydreamAccountSection.tsx
+++ b/frontend/src/components/settings/DaydreamAccountSection.tsx
@@ -228,7 +228,7 @@ export function DaydreamAccountSection({
           />
         </div>
         <p className="text-xs text-muted-foreground">
-          Use remote inference for running pipelines.
+          Use remote inference for running models.
           {!isSignedIn &&
             !(status.connected || status.connecting) &&
             " Log in required."}

--- a/frontend/src/components/settings/DaydreamAccountSection.tsx
+++ b/frontend/src/components/settings/DaydreamAccountSection.tsx
@@ -228,7 +228,7 @@ export function DaydreamAccountSection({
           />
         </div>
         <p className="text-xs text-muted-foreground">
-          Use remote inference for running models.
+          Use Daydream Cloud inference for running workflows.
           {!isSignedIn &&
             !(status.connected || status.connecting) &&
             " Log in required."}

--- a/frontend/src/components/settings/DiscoverTab.tsx
+++ b/frontend/src/components/settings/DiscoverTab.tsx
@@ -103,7 +103,7 @@ export function DiscoverTab({
       setPlugins(data.plugins);
     } catch (err) {
       console.error("Failed to fetch discover plugins:", err);
-      setError(err instanceof Error ? err.message : "Failed to load plugins");
+      setError(err instanceof Error ? err.message : "Failed to load nodes");
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/components/settings/DmxTab.tsx
+++ b/frontend/src/components/settings/DmxTab.tsx
@@ -367,7 +367,7 @@ export function DmxTab({ isActive }: DmxTabProps) {
           <code className="bg-muted px-1 py-0.5 rounded text-xs">
             {status?.port ?? localPort}
           </code>{" "}
-          to control pipeline parameters in real time. Map DMX channels to
+          to control model parameters in real time. Map DMX channels to
           numeric parameters below.
         </div>
       </div>

--- a/frontend/src/components/settings/DmxTab.tsx
+++ b/frontend/src/components/settings/DmxTab.tsx
@@ -367,7 +367,7 @@ export function DmxTab({ isActive }: DmxTabProps) {
           <code className="bg-muted px-1 py-0.5 rounded text-xs">
             {status?.port ?? localPort}
           </code>{" "}
-          to control model parameters in real time. Map DMX channels to
+          to control workflow parameters in real time. Map DMX channels to
           numeric parameters below.
         </div>
       </div>

--- a/frontend/src/components/settings/ModulationSection.tsx
+++ b/frontend/src/components/settings/ModulationSection.tsx
@@ -168,7 +168,7 @@ export function ModulationSection({
       <div className="flex items-center justify-between gap-2">
         <LabelWithTooltip
           label="Modulation"
-          tooltip="Continuously modulate pipeline parameters in sync with the beat. Select a parameter target and configure the wave shape, depth, and rate."
+          tooltip="Continuously modulate model parameters in sync with the beat. Select a parameter target and configure the wave shape, depth, and rate."
           className="text-xs text-muted-foreground"
         />
         <Toggle

--- a/frontend/src/components/settings/OscTab.tsx
+++ b/frontend/src/components/settings/OscTab.tsx
@@ -134,7 +134,7 @@ export function OscTab({ isActive }: OscTabProps) {
           <code className="bg-muted px-1 py-0.5 rounded text-xs">
             {status?.port ?? "..."}
           </code>{" "}
-          to control model parameters in real time. Click{" "}
+          to control workflow parameters in real time. Click{" "}
           <strong>Open OSC Docs</strong> for the full path reference.
         </div>
       </div>

--- a/frontend/src/components/settings/OscTab.tsx
+++ b/frontend/src/components/settings/OscTab.tsx
@@ -134,7 +134,7 @@ export function OscTab({ isActive }: OscTabProps) {
           <code className="bg-muted px-1 py-0.5 rounded text-xs">
             {status?.port ?? "..."}
           </code>{" "}
-          to control pipeline parameters in real time. Click{" "}
+          to control model parameters in real time. Click{" "}
           <strong>Open OSC Docs</strong> for the full path reference.
         </div>
       </div>

--- a/frontend/src/components/settings/TempoSyncSection.tsx
+++ b/frontend/src/components/settings/TempoSyncSection.tsx
@@ -341,7 +341,7 @@ export function TempoSyncSection({
           <div className="space-y-2">
             <LabelWithTooltip
               label="Lookahead"
-              tooltip="Compensate for pipeline latency by applying parameter changes this many milliseconds before the beat boundary. Increase if visual changes arrive late; decrease if they arrive early."
+              tooltip="Compensate for model latency by applying parameter changes this many milliseconds before the beat boundary. Increase if visual changes arrive late; decrease if they arrive early."
               className="text-xs text-muted-foreground"
             />
             <div className="flex items-center gap-2">

--- a/frontend/src/components/workflowDialogHelpers.tsx
+++ b/frontend/src/components/workflowDialogHelpers.tsx
@@ -19,9 +19,9 @@ export const statusIcon = (status: ResolutionItem["status"]) => {
 export const kindLabel = (kind: ResolutionItem["kind"]) => {
   switch (kind) {
     case "pipeline":
-      return "Pipeline";
+      return "Model";
     case "plugin":
-      return "Plugin";
+      return "Node";
     case "lora":
       return "LoRA";
   }

--- a/frontend/src/data/blueprints/knobs-panel.json
+++ b/frontend/src/data/blueprints/knobs-panel.json
@@ -1,6 +1,6 @@
 {
   "name": "Knobs Panel",
-  "description": "Four knobs pre-configured for common pipeline parameters — Guidance, Steps, Strength, and Denoise — ready to wire",
+  "description": "Four knobs pre-configured for common model parameters — Guidance, Steps, Strength, and Denoise — ready to wire",
   "category": "UI",
   "color": "#38bdf8",
   "thumbnail": null,

--- a/frontend/src/data/blueprints/lfo-range-oscillator.json
+++ b/frontend/src/data/blueprints/lfo-range-oscillator.json
@@ -1,6 +1,6 @@
 {
   "name": "LFO Range Oscillator",
-  "description": "A sine LFO smoothly oscillates a value between configurable min and max bounds — wire the output to any numeric pipeline parameter",
+  "description": "A sine LFO smoothly oscillates a value between configurable min and max bounds — wire the output to any numeric model parameter",
   "category": "Controls",
   "color": "#a78bfa",
   "thumbnail": null,

--- a/frontend/src/data/parameterMetadata.ts
+++ b/frontend/src/data/parameterMetadata.ts
@@ -25,7 +25,7 @@ export const PARAMETER_METADATA: Record<string, ParameterMetadata> = {
   manageCache: {
     label: "Manage Cache",
     tooltip:
-      "Enables pipeline to automatically manage the cache which influences newly generated frames. Disable for manual control via Reset Cache.",
+      "Enables the model to automatically manage the cache which influences newly generated frames. Disable for manual control via Reset Cache.",
   },
   resetCache: {
     label: "Reset Cache",
@@ -84,10 +84,10 @@ export const PARAMETER_METADATA: Record<string, ParameterMetadata> = {
   },
   preprocessor: {
     label: "Preprocessor",
-    tooltip: "Select a preprocessor to apply before the main pipeline.",
+    tooltip: "Select a preprocessor to apply before the main model.",
   },
   postprocessor: {
     label: "Postprocessor",
-    tooltip: "Select a postprocessor to apply after the main pipeline.",
+    tooltip: "Select a postprocessor to apply after the main model.",
   },
 };

--- a/frontend/src/hooks/usePipeline.ts
+++ b/frontend/src/hooks/usePipeline.ts
@@ -45,7 +45,7 @@ export function usePipeline(options: UsePipelineOptions = {}) {
         const errorMessage = statusResponse.error || "Unknown pipeline error";
         // Show toast if we haven't shown this error yet
         if (shownErrorRef.current !== errorMessage) {
-          toast.error("Pipeline Error", {
+          toast.error("Model Error", {
             description: errorMessage,
             duration: 8000,
           });
@@ -63,7 +63,7 @@ export function usePipeline(options: UsePipelineOptions = {}) {
         err instanceof Error ? err.message : "Failed to get pipeline status";
       // Show toast for API errors
       if (shownErrorRef.current !== errorMessage) {
-        toast.error("Pipeline Error", {
+        toast.error("Model Error", {
           description: errorMessage,
           duration: 5000,
         });
@@ -131,7 +131,7 @@ export function usePipeline(options: UsePipelineOptions = {}) {
                 const errorMsg = currentStatus.error || "Pipeline load failed";
                 // Show toast for load completion errors
                 if (shownErrorRef.current !== errorMsg) {
-                  toast.error("Pipeline Error", {
+                  toast.error("Model Error", {
                     description: errorMsg,
                     duration: 8000,
                   });
@@ -166,7 +166,7 @@ export function usePipeline(options: UsePipelineOptions = {}) {
         console.error("Pipeline load error:", errorMessage);
         // Show toast for load errors
         if (shownErrorRef.current !== errorMessage) {
-          toast.error("Pipeline Error", {
+          toast.error("Model Error", {
             description: errorMessage,
             duration: 8000,
           });

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -84,8 +84,10 @@ def build_graph(
     if errors:
         raise ValueError(f"Invalid graph: {'; '.join(errors)}")
 
-    # Validate edge ports against pipeline input/output declarations
-    _validate_edge_ports(graph, pipeline_manager)
+    # Validate edge ports against pipeline input/output declarations.
+    # Edges referencing undeclared ports are pruned with a warning rather than
+    # failing the whole setup (e.g. stale 'mask' port from an older plugin version).
+    graph = _prune_invalid_edges(graph, pipeline_manager)
 
     # Sink and record nodes get dedicated queues in steps 4–5, so we
     # exclude them here to avoid false-positive duplicate-edge errors
@@ -322,46 +324,90 @@ def build_graph(
     )
 
 
-def _validate_edge_ports(
+def _prune_invalid_edges(
     graph: GraphConfig,
     pipeline_manager: PipelineManager,
-) -> None:
-    """Validate that edge ports match pipeline input/output declarations.
+) -> GraphConfig:
+    """Validate edge ports against pipeline declarations and prune bad edges.
 
-    Raises:
-        ValueError: If any edge references an undeclared port.
+    Edges that reference an undeclared input or output port are **removed** from
+    the graph with a WARNING rather than raising an exception.  This makes the
+    pipeline resilient to stale graph configs (e.g. a 'mask' port from an older
+    plugin version that renamed the port) — the stream starts without the broken
+    edge rather than failing entirely.
+
+    Returns:
+        A (possibly modified) GraphConfig with invalid stream edges removed.
     """
     # Build a map of node_id -> (declared_inputs, declared_outputs)
     port_map: dict[str, tuple[set[str], set[str]]] = {}
     for node in graph.nodes:
         if node.type != "pipeline" or node.pipeline_id is None:
             continue
-        pipeline = pipeline_manager.get_pipeline_by_id(node.id)
+        try:
+            pipeline = pipeline_manager.get_pipeline_by_id(node.id)
+        except Exception:
+            # Pipeline unavailable (e.g. reloading); skip port checks for it.
+            logger.warning(
+                "Pipeline %r unavailable during port validation; skipping port checks.",
+                node.id,
+            )
+            continue
         config_class = pipeline.get_config_class()
         port_map[node.id] = (set(config_class.inputs), set(config_class.outputs))
 
-    errors: list[str] = []
+    pruned: list = []
+    kept_edges: list = []
     for e in graph.edges:
         if e.kind != "stream":
+            kept_edges.append(e)
             continue
+        invalid = False
         # Check output port on the producing pipeline
         if e.from_node in port_map:
             _, declared_outputs = port_map[e.from_node]
             if e.from_port not in declared_outputs:
-                errors.append(
-                    f"Node {e.from_node!r} has no output port {e.from_port!r} "
-                    f"(declared: {sorted(declared_outputs)})"
+                logger.warning(
+                    "Pruning edge %r→%r:%r — source node has no output port %r "
+                    "(declared: %s). Graph may be stale; ignoring this edge.",
+                    e.from_node,
+                    e.to_node,
+                    e.to_port,
+                    e.from_port,
+                    sorted(declared_outputs),
                 )
+                invalid = True
         # Check input port on the consuming pipeline
-        if e.to_node in port_map:
+        if not invalid and e.to_node in port_map:
             declared_inputs, _ = port_map[e.to_node]
             if e.to_port not in declared_inputs:
-                errors.append(
-                    f"Node {e.to_node!r} has no input port {e.to_port!r} "
-                    f"(declared: {sorted(declared_inputs)})"
+                logger.warning(
+                    "Pruning edge %r→%r:%r — target node has no input port %r "
+                    "(declared: %s). Graph may be stale; ignoring this edge.",
+                    e.from_node,
+                    e.to_node,
+                    e.to_port,
+                    e.to_port,
+                    sorted(declared_inputs),
                 )
-    if errors:
-        raise ValueError(f"Invalid graph ports: {'; '.join(errors)}")
+                invalid = True
+        if invalid:
+            pruned.append(e)
+        else:
+            kept_edges.append(e)
+
+    if pruned:
+        pruned_desc = "; ".join(
+            f"{e.from_node}:{e.from_port}→{e.to_node}:{e.to_port}" for e in pruned
+        )
+        logger.warning(
+            "Pruned %d invalid stream edge(s) from graph: [%s]",
+            len(pruned),
+            pruned_desc,
+        )
+        graph = graph.model_copy(update={"edges": kept_edges})
+
+    return graph
 
 
 def _resize_graph_queues(


### PR DESCRIPTION
## Problem

Issue #890: In `scope-livepeer`, the `frame_processor` was failing to start when a graph config contained an edge referencing an undeclared port:

```
scope.server.frame_processor - ERROR - Pipeline setup failed: Invalid graph ports: Node 'pipeline_1' has no input port 'mask' (declared: ['video', 'video2'])
```

This happened 4 times across 2 sessions (15:53–15:57 UTC, 2026-04-09). The client was sending a graph with a `mask` edge to `pipeline_1` whose actual declared inputs are `['video', 'video2']`. This mismatch (likely from a stale graph config or a plugin that renamed its port) caused the entire stream setup to fail.

Same class of issue as #804 (VACE port mismatch), which is addressed by PR #806.

## Fix

Replace the hard-failing `_validate_edge_ports` with `_prune_invalid_edges`, which:

1. **Logs a WARNING** for each edge that references an undeclared port (input or output)
2. **Removes the invalid edge** from the graph rather than raising
3. **Continues pipeline setup** with the valid edges — stream starts without the broken connection
4. **Handles unavailable pipelines** during validation (e.g. mid-reload) gracefully by skipping instead of crashing

This ensures that a stale or partially-mismatched graph doesn't prevent the pipeline from starting entirely.

## Testing

- Syntax verified
- The change is backward-compatible: valid graphs are unchanged (no edges pruned)
- Invalid edges produce warnings in logs for operator visibility