### PR TITLE
Preserve default plugins in Livepeer mode.

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -1142,11 +1142,18 @@ async def _cleanup_plugins_via_scope_client() -> dict[str, Any]:
     payload = response.json()
     plugins = payload.get("plugins", []) if isinstance(payload, dict) else []
     removed: list[str] = []
+    skipped: list[str] = []
     failed: list[dict[str, Any]] = []
 
     for plugin in plugins:
-        name = plugin.get("name") if isinstance(plugin, dict) else None
+        if not isinstance(plugin, dict):
+            continue
+
+        name = plugin.get("name")
         if not name:
+            continue
+        if plugin.get("bundled"):
+            skipped.append(name)
             continue
         try:
             uninstall = await client.delete(f"/api/v1/plugins/{name}", timeout=60.0)
@@ -1163,7 +1170,12 @@ async def _cleanup_plugins_via_scope_client() -> dict[str, Any]:
         except Exception as exc:
             failed.append({"name": name, "error": str(exc)})
 
-    return {"removed": removed, "failed": failed, "total": len(plugins)}
+    return {
+        "removed": removed,
+        "skipped": skipped,
+        "failed": failed,
+        "total": len(plugins),
+    }
 
 
 def _cleanup_assets_dir() -> dict[str, Any]:

--- a/src/scope/cloud/livepeer_fal_app.py
+++ b/src/scope/cloud/livepeer_fal_app.py
@@ -263,6 +263,7 @@ class LivepeerScopeApp(fal.App, keep_alive=300):
             "HF_TOKEN",
             "HF_HOME",
             "HUGGINGFACE_HUB_CACHE",
+            "DAYDREAM_SCOPE_BUNDLED_PLUGINS_FILE",
             "LIVEPEER_DEBUG",
             "UV_CACHE_DIR",
         ]

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -2800,6 +2800,7 @@ def _convert_plugin_dict_to_info(plugin_dict: dict) -> "PluginInfo":
         latest_version=plugin_dict.get("latest_version"),
         update_available=plugin_dict.get("update_available"),
         package_spec=plugin_dict.get("package_spec"),
+        bundled=plugin_dict.get("bundled", False),
     )
 
 

--- a/tests/test_plugin_api.py
+++ b/tests/test_plugin_api.py
@@ -88,6 +88,7 @@ class TestListPluginsEndpoint:
                 ],
                 "latest_version": "2.0.0",
                 "update_available": True,
+                "bundled": True,
             }
         ]
 
@@ -102,6 +103,7 @@ class TestListPluginsEndpoint:
         assert len(data["plugins"][0]["pipelines"]) == 1
         assert data["plugins"][0]["latest_version"] == "2.0.0"
         assert data["plugins"][0]["update_available"] is True
+        assert data["plugins"][0]["bundled"] is True
 
     def test_handles_manager_errors(self, client, mock_plugin_manager):
         """Manager exception should return 500 error."""


### PR DESCRIPTION
DAYDREAM_SCOPE_BUNDLED_PLUGINS_FILE does the trick.

They were being uninstalled after each session since 860689c9ff43dcda099f1ab005f14893a00e9393

Also address another issue that affects both Livepeer and Cloud Relay modes: https://github.com/daydreamlive/scope/pull/893/changes/5eb328a9c97f102c03ae2689b9b76ba4b5bc6d20

This adds a `bundled` indicator to the plugins list API so Livepeer doesn't try to delete them. The backend will reject this deletion anyway, but this will prevent us from trying to delete it. Cloud Relay mode has the same problem, but I didn't bother fixing / checking it there.
