### PR TITLE
Reset stale WebRTC state after failed startup to allow retries

### DIFF
--- a/frontend/src/hooks/useUnifiedWebRTC.ts
+++ b/frontend/src/hooks/useUnifiedWebRTC.ts
@@ -88,6 +88,26 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
   /** Maps source node ID → RTCRtpSender for per-node track replacement */
   const sourceNodeSendersRef = useRef<Record<string, RTCRtpSender>>({});
 
+  const resetConnectionState = useCallback(() => {
+    if (peerConnectionRef.current) {
+      peerConnectionRef.current.close();
+      peerConnectionRef.current = null;
+    }
+
+    dataChannelRef.current = null;
+    currentStreamRef.current = null;
+    sessionIdRef.current = null;
+    queuedCandidatesRef.current = [];
+    sinkNodeIdsRef.current = [];
+    sinkMidMapRef.current = {};
+    sourceNodeSendersRef.current = {};
+
+    setRemoteStream(null);
+    setRemoteStreams({});
+    setConnectionState("new");
+    setIsStreaming(false);
+  }, []);
+
   // Helper to get ICE servers
   const fetchIceServers = useCallback(async (): Promise<RTCConfiguration> => {
     try {
@@ -575,14 +595,23 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
           });
         } catch (error) {
           console.error("[UnifiedWebRTC] Offer/answer exchange failed:", error);
+          resetConnectionState();
           setIsConnecting(false);
         }
       } catch (error) {
         console.error("[UnifiedWebRTC] Failed to start stream:", error);
+        resetConnectionState();
         setIsConnecting(false);
       }
     },
-    [isConnecting, options, fetchIceServers, sendOffer, sendIceCandidate]
+    [
+      isConnecting,
+      options,
+      fetchIceServers,
+      sendOffer,
+      sendIceCandidate,
+      resetConnectionState,
+    ]
   );
 
   const updateVideoTrack = useCallback(
@@ -708,23 +737,8 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
   );
 
   const stopStream = useCallback(() => {
-    if (peerConnectionRef.current) {
-      peerConnectionRef.current.close();
-      peerConnectionRef.current = null;
-    }
-
-    dataChannelRef.current = null;
-    currentStreamRef.current = null;
-    sessionIdRef.current = null;
-    queuedCandidatesRef.current = [];
-    sinkNodeIdsRef.current = [];
-    sinkMidMapRef.current = {};
-
-    setRemoteStream(null);
-    setRemoteStreams({});
-    setConnectionState("new");
-    setIsStreaming(false);
-  }, []);
+    resetConnectionState();
+  }, [resetConnectionState]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
A failed offer/answer exchange left partially-initialized WebRTC state. In particular, peerConnectionRef.current was not cleared while isConnecting was reset, so subsequent Run attempts hit the early guard and returned before sending a new offer. This caused the UI to remain in the “Run” state while pipeline load requests continued without an active WebRTC session.

### Root cause
- Failed startup path did not fully tear down WebRTC state
- `peerConnectionRef.current` remained non-null
- Retry attempts short-circuited before offer creation

### Changes
- Introduce `resetConnectionState()` to centralize full teardown:
  - Close and clear `peerConnectionRef`
  - Reset data channel, session ID, ICE queue, sender maps, and stream refs
  - Clear remote stream state and connection flags
- Invoke `resetConnectionState()` on:
  - Offer/answer exchange failure
  - General startup failure
  - `stopStream()` (deduplicates prior teardown logic)

### Result
- Failed startup leaves no residual state
- Subsequent `Run` attempts correctly initiate a new WebRTC session
- UI state accurately reflects connection status

### Notes
- Eliminates duplicated teardown logic in `stopStream`
- Prevents silent no-op retries due to stale peer connection refs