### PR TITLE
Stabilize Livepeer output pacing with cumulative drift control

### DIFF
--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -7,6 +7,7 @@ simple frame/parameter methods used by the relay manager.
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import logging
 import os
@@ -30,6 +31,7 @@ from livepeer_gateway.media_publish import (
 from livepeer_gateway.scope import StartJobRequest, start_scope
 
 from .cloud_webrtc_client import AudioOutputHandler, FrameOutputHandler
+from .pacing import MediaPacingDecision, MediaPacingState, compute_pacing_decision
 
 logger = logging.getLogger(__name__)
 LIVEPEER_ORCH_URL_ENV = "LIVEPEER_ORCH_URL"
@@ -114,6 +116,19 @@ class LivepeerClient:
             "connected_at": None,
             "api_requests_sent": 0,
             "api_requests_successful": 0,
+            "pacing": {
+                "observations": 0,
+                "valid_timestamp_frames": 0,
+                "hard_resets": 0,
+                "soft_reanchors": 0,
+                "sleep_total_s": 0.0,
+                "drift_samples": 0,
+                "drift_abs_sum_s": 0.0,
+                "drift_max_abs_s": 0.0,
+                "stall_positive_samples": 0,
+                "stall_positive_sum_s": 0.0,
+                "stall_positive_max_s": 0.0,
+            },
         }
 
     @property
@@ -506,8 +521,7 @@ class LivepeerClient:
         media_kind: str,
     ) -> None:
         """Consume output frames from Livepeer and notify callbacks."""
-        prev_video_ts: float | None = None
-        prev_dispatch_time: float | None = None
+        pacing = MediaPacingState()
         unexpected_reason: str | None = None
         try:
             async for decoded in output.frames():
@@ -524,23 +538,24 @@ class LivepeerClient:
                 if decoded_kind != "video":
                     continue
 
-                # Hack: Sleep here to pace output (pts based)
                 time_base = getattr(frame, "time_base", None)
                 video_ts = (
                     frame.pts * float(time_base)
                     if time_base is not None and frame.pts is not None
                     else None
                 )
-                now_monotonic = time.monotonic()
-                if prev_video_ts is not None and video_ts is not None:
-                    seconds_delta = video_ts - prev_video_ts
-                    if seconds_delta > 0 and prev_dispatch_time is not None:
-                        elapsed = now_monotonic - prev_dispatch_time
-                        wait = seconds_delta - elapsed
-                        if wait > 0:
-                            await asyncio.sleep(wait)
-                prev_video_ts = video_ts
-                prev_dispatch_time = time.monotonic()
+                decision = compute_pacing_decision(
+                    pacing,
+                    media_ts=video_ts,
+                    now_monotonic=time.monotonic(),
+                )
+                # Keep observability in lock-step with every pacing decision.
+                self._record_pacing_observation(decision)
+                if decision.sleep_s > 0:
+                    await asyncio.sleep(decision.sleep_s)
+                # Track actual dispatch time (after optional sleep) so the next
+                # wall_delta reflects real scheduling delay.
+                pacing.prev_wall_monotonic = time.monotonic()
                 if 0 <= output_track_index < len(self.output_handlers):
                     self.output_handlers[output_track_index].handle_frame(frame)
                 else:
@@ -829,10 +844,38 @@ class LivepeerClient:
         await self._shutdown()
 
     def get_stats(self) -> dict[str, Any]:
-        stats = dict(self._stats)
+        stats = copy.deepcopy(self._stats)
         if stats["connected_at"] is not None:
             stats["uptime_seconds"] = time.time() - stats["connected_at"]
         return stats
+
+    def _record_pacing_observation(self, decision: MediaPacingDecision) -> None:
+        pacing = self._stats.get("pacing")
+        if not isinstance(pacing, dict):
+            return
+        pacing["observations"] += 1
+        if decision.has_valid_ts:
+            pacing["valid_timestamp_frames"] += 1
+        if decision.hard_reset:
+            pacing["hard_resets"] += 1
+        if decision.soft_reanchor:
+            pacing["soft_reanchors"] += 1
+        pacing["sleep_total_s"] += decision.sleep_s
+
+        if decision.drift_s is not None:
+            abs_drift = abs(decision.drift_s)
+            pacing["drift_samples"] += 1
+            pacing["drift_abs_sum_s"] += abs_drift
+            pacing["drift_max_abs_s"] = max(pacing["drift_max_abs_s"], abs_drift)
+
+        # Positive stall_delta captures per-frame wall-clock stalls even when
+        # cumulative drift stays bounded by later catch-up.
+        if decision.stall_delta_s is not None and decision.stall_delta_s > 0:
+            pacing["stall_positive_samples"] += 1
+            pacing["stall_positive_sum_s"] += decision.stall_delta_s
+            pacing["stall_positive_max_s"] = max(
+                pacing["stall_positive_max_s"], decision.stall_delta_s
+            )
 
     async def _shutdown(
         self,

--- a/src/scope/server/pacing.py
+++ b/src/scope/server/pacing.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Defaults tuned for realtime media pacing.
+DEFAULT_DRIFT_TOLERANCE_S = 0.010
+DEFAULT_SOFT_REANCHOR_DRIFT_S = 0.50
+DEFAULT_DISCONTINUITY_MIN_S = 0.25
+DEFAULT_DISCONTINUITY_MULTIPLIER = 8.0
+DEFAULT_EXPECTED_DELTA_ALPHA = 0.20
+
+
+@dataclass(slots=True)
+class MediaPacingConfig:
+    drift_tolerance_s: float = DEFAULT_DRIFT_TOLERANCE_S
+    soft_reanchor_drift_s: float = DEFAULT_SOFT_REANCHOR_DRIFT_S
+    discontinuity_min_s: float = DEFAULT_DISCONTINUITY_MIN_S
+    discontinuity_multiplier: float = DEFAULT_DISCONTINUITY_MULTIPLIER
+    expected_delta_alpha: float = DEFAULT_EXPECTED_DELTA_ALPHA
+
+
+@dataclass(slots=True)
+class MediaPacingState:
+    start_media_ts: float | None = None
+    start_wall_monotonic: float | None = None
+    prev_media_ts: float | None = None
+    prev_wall_monotonic: float | None = None
+    expected_media_delta: float | None = None
+
+
+@dataclass(slots=True)
+class MediaPacingDecision:
+    sleep_s: float
+    hard_reset: bool = False
+    soft_reanchor: bool = False
+    has_valid_ts: bool = False
+    drift_s: float | None = None
+    media_delta_s: float | None = None
+    wall_delta_s: float | None = None
+    stall_delta_s: float | None = None
+
+
+def reset_pacing_state(state: MediaPacingState) -> None:
+    state.start_media_ts = None
+    state.start_wall_monotonic = None
+    state.prev_media_ts = None
+    state.prev_wall_monotonic = None
+    state.expected_media_delta = None
+
+
+def anchor_pacing_state(
+    state: MediaPacingState,
+    *,
+    media_ts: float,
+    now_monotonic: float,
+    reset_expected_delta: bool = False,
+) -> None:
+    state.start_media_ts = media_ts
+    state.start_wall_monotonic = now_monotonic
+    state.prev_media_ts = media_ts
+    state.prev_wall_monotonic = now_monotonic
+    if reset_expected_delta:
+        state.expected_media_delta = None
+
+
+def _update_expected_media_delta(
+    expected_media_delta: float | None,
+    media_delta: float,
+    *,
+    alpha: float,
+) -> float:
+    if expected_media_delta is None:
+        return media_delta
+    return (1.0 - alpha) * expected_media_delta + alpha * media_delta
+
+
+def compute_pacing_decision(
+    state: MediaPacingState,
+    *,
+    media_ts: float | None,
+    now_monotonic: float,
+    config: MediaPacingConfig | None = None,
+) -> MediaPacingDecision:
+    cfg = config or MediaPacingConfig()
+    # Missing timestamps mean we cannot align media time to wall time; reset
+    # pacing state and hand off immediately.
+    if media_ts is None:
+        reset_pacing_state(state)
+        return MediaPacingDecision(sleep_s=0.0, hard_reset=True, has_valid_ts=False)
+
+    # First valid timestamp establishes the stream anchor for cumulative drift.
+    if state.start_media_ts is None or state.start_wall_monotonic is None:
+        anchor_pacing_state(state, media_ts=media_ts, now_monotonic=now_monotonic)
+        return MediaPacingDecision(sleep_s=0.0, has_valid_ts=True, drift_s=0.0)
+
+    media_delta = (
+        media_ts - state.prev_media_ts if state.prev_media_ts is not None else None
+    )
+    wall_delta = (
+        now_monotonic - state.prev_wall_monotonic
+        if state.prev_wall_monotonic is not None
+        else None
+    )
+    stall_delta = (
+        wall_delta - media_delta
+        if wall_delta is not None and media_delta is not None
+        else None
+    )
+
+    # Non-monotonic media timestamps indicate a timeline break; hard-reset.
+    if media_delta is None or media_delta <= 0:
+        anchor_pacing_state(
+            state,
+            media_ts=media_ts,
+            now_monotonic=now_monotonic,
+            reset_expected_delta=True,
+        )
+        return MediaPacingDecision(
+            sleep_s=0.0,
+            hard_reset=True,
+            has_valid_ts=True,
+            media_delta_s=media_delta,
+            wall_delta_s=wall_delta,
+            stall_delta_s=stall_delta,
+        )
+
+    # Detect large media-time jumps relative to recent cadence and treat them as
+    # discontinuities rather than attempting to "catch up" by pacing math.
+    if state.expected_media_delta is not None:
+        discontinuity_s = max(
+            cfg.discontinuity_min_s,
+            state.expected_media_delta * cfg.discontinuity_multiplier,
+        )
+        if media_delta >= discontinuity_s:
+            anchor_pacing_state(
+                state,
+                media_ts=media_ts,
+                now_monotonic=now_monotonic,
+                reset_expected_delta=True,
+            )
+            return MediaPacingDecision(
+                sleep_s=0.0,
+                hard_reset=True,
+                has_valid_ts=True,
+                media_delta_s=media_delta,
+                wall_delta_s=wall_delta,
+                stall_delta_s=stall_delta,
+            )
+
+    media_elapsed = media_ts - state.start_media_ts
+    wall_elapsed = now_monotonic - state.start_wall_monotonic
+    drift = wall_elapsed - media_elapsed
+
+    # For extreme positive drift (wall-clock far behind media timeline), soften
+    # the debt instead of fast-forward draining bursty payloads.
+    if drift >= cfg.soft_reanchor_drift_s:
+        anchor_pacing_state(
+            state,
+            media_ts=media_ts,
+            now_monotonic=now_monotonic,
+            reset_expected_delta=False,
+        )
+        state.expected_media_delta = _update_expected_media_delta(
+            state.expected_media_delta,
+            media_delta,
+            alpha=cfg.expected_delta_alpha,
+        )
+        return MediaPacingDecision(
+            sleep_s=0.0,
+            soft_reanchor=True,
+            has_valid_ts=True,
+            drift_s=drift,
+            media_delta_s=media_delta,
+            wall_delta_s=wall_delta,
+            stall_delta_s=stall_delta,
+        )
+
+    # Core pacing: negative drift means we're ahead of media time, so sleep;
+    # positive drift means we're behind, so send immediately.
+    sleep_s = max(0.0, -drift)
+    # Deadband: ignore tiny (<=10ms) drift to avoid 1-2ms micro-sleeps and
+    # scheduler-noise jitter on realtime streams.
+    if abs(drift) <= cfg.drift_tolerance_s:
+        sleep_s = 0.0
+
+    state.prev_media_ts = media_ts
+    state.expected_media_delta = _update_expected_media_delta(
+        state.expected_media_delta,
+        media_delta,
+        alpha=cfg.expected_delta_alpha,
+    )
+    return MediaPacingDecision(
+        sleep_s=sleep_s,
+        has_valid_ts=True,
+        drift_s=drift,
+        media_delta_s=media_delta,
+        wall_delta_s=wall_delta,
+        stall_delta_s=stall_delta,
+    )

--- a/tests/test_livepeer_client_pacing.py
+++ b/tests/test_livepeer_client_pacing.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from scope.server.pacing import MediaPacingState, compute_pacing_decision
+
+
+def _dispatch(state: MediaPacingState, dispatch_monotonic: float) -> None:
+    state.prev_wall_monotonic = dispatch_monotonic
+
+
+def test_pacing_absorbs_small_oversleep_without_growing_delay():
+    state = MediaPacingState()
+    frame_interval = 1.0 / 30.0
+    scheduler_oversleep = 0.001
+
+    # First frame anchors media and wall clocks.
+    first = compute_pacing_decision(state, media_ts=0.0, now_monotonic=0.0)
+    assert first.sleep_s == 0.0
+    _dispatch(state, dispatch_monotonic=0.0)
+
+    # Subsequent frames are available immediately from a backlog.
+    now = 0.0
+    sleeps: list[float] = []
+    for i in range(1, 10):
+        decision = compute_pacing_decision(
+            state,
+            media_ts=i * frame_interval,
+            now_monotonic=now,
+        )
+        sleeps.append(decision.sleep_s)
+        now = now + decision.sleep_s + scheduler_oversleep
+        _dispatch(state, dispatch_monotonic=now)
+
+    assert max(sleeps) - min(sleeps) < 0.003
+    assert abs(sleeps[-1] - (frame_interval - scheduler_oversleep)) < 0.003
+
+
+def test_wall_clock_stall_with_continuous_pts_catches_up_without_hard_reset():
+    state = MediaPacingState()
+    frame_interval = 1.0 / 30.0
+
+    first = compute_pacing_decision(state, media_ts=0.0, now_monotonic=0.0)
+    assert first.sleep_s == 0.0
+    _dispatch(state, dispatch_monotonic=0.0)
+
+    second = compute_pacing_decision(
+        state,
+        media_ts=frame_interval,
+        now_monotonic=0.0,
+    )
+    _dispatch(state, dispatch_monotonic=second.sleep_s)
+
+    stalled_now = second.sleep_s + 0.25
+    third = compute_pacing_decision(
+        state,
+        media_ts=2.0 * frame_interval,
+        now_monotonic=stalled_now,
+    )
+
+    assert third.hard_reset is False
+    assert third.soft_reanchor is False
+    assert third.sleep_s == 0.0
+    assert third.drift_s is not None and third.drift_s > 0
+    assert third.stall_delta_s is not None and third.stall_delta_s > 0
+
+
+def test_extreme_wall_clock_debt_triggers_soft_reanchor():
+    state = MediaPacingState()
+    frame_interval = 1.0 / 30.0
+
+    compute_pacing_decision(state, media_ts=0.0, now_monotonic=0.0)
+    _dispatch(state, dispatch_monotonic=0.0)
+
+    second = compute_pacing_decision(
+        state,
+        media_ts=frame_interval,
+        now_monotonic=0.0,
+    )
+    _dispatch(state, dispatch_monotonic=second.sleep_s)
+
+    delayed_now = second.sleep_s + 0.9
+    third = compute_pacing_decision(
+        state,
+        media_ts=2.0 * frame_interval,
+        now_monotonic=delayed_now,
+    )
+
+    assert third.soft_reanchor is True
+    assert third.hard_reset is False
+    assert third.sleep_s == 0.0
+
+
+def test_large_media_discontinuity_triggers_hard_reset():
+    state = MediaPacingState()
+    frame_interval = 1.0 / 30.0
+
+    compute_pacing_decision(state, media_ts=0.0, now_monotonic=0.0)
+    _dispatch(state, dispatch_monotonic=0.0)
+
+    second = compute_pacing_decision(
+        state,
+        media_ts=frame_interval,
+        now_monotonic=0.0,
+    )
+    _dispatch(state, dispatch_monotonic=second.sleep_s)
+
+    # Build expected delta history.
+    third = compute_pacing_decision(
+        state,
+        media_ts=2.0 * frame_interval,
+        now_monotonic=second.sleep_s,
+    )
+    _dispatch(state, dispatch_monotonic=second.sleep_s + third.sleep_s)
+
+    jump = 2.0 * frame_interval + 1.0
+    reset = compute_pacing_decision(
+        state,
+        media_ts=jump,
+        now_monotonic=second.sleep_s + third.sleep_s + 0.01,
+    )
+
+    assert reset.hard_reset is True
+    assert reset.soft_reanchor is False
+    assert reset.sleep_s == 0.0
+
+
+def test_missing_timestamp_is_hard_reset():
+    state = MediaPacingState()
+    compute_pacing_decision(state, media_ts=0.0, now_monotonic=0.0)
+    _dispatch(state, dispatch_monotonic=0.0)
+
+    decision = compute_pacing_decision(
+        state,
+        media_ts=None,
+        now_monotonic=0.2,
+    )
+    assert decision.hard_reset is True
+    assert decision.has_valid_ts is False
+    assert decision.sleep_s == 0.0


### PR DESCRIPTION
## Problem
Livepeer output could accumulate wall-clock drift over long runs because pacing was based on only adjacent frame timing and did not preserve cumulative schedule error. This caused steady lag growth even with consistent timestamps, usually around 1 frame every 30 seconds (losing ~4 seconds an hour at 30fps).

## Approach
Replace the per-frame pacing logic in `livepeer_client` with a reusable media pacing module that tracks a running media/wall anchor, computes cumulative drift, and applies bounded correction. Add explicit reset/re-anchor rules for timestamp discontinuities vs wall-clock stalls, plus pacing observability (drift, stall signal, reset/re-anchor counts, sleep totals).

## Changes
- Extracted generic pacing logic to `src/scope/server/pacing.py`
- Updated `LivepeerClient._receive_loop()` to use the shared pacing decision path
- Added pacing stats aggregation in `LivepeerClient` for runtime diagnosis
- Switched `get_stats()` to deep-copy nested stats safely
- Added focused tests in `tests/test_livepeer_client_pacing.py` for:
  - scheduler slip stability
  - wall-clock stall catch-up without hard reset
  - soft re-anchor on extreme wall-clock debt
  - hard reset on media discontinuity and missing timestamps

## Algorithm Outline
1. Anchor timing on the first valid frame and emit immediately.
2. On each frame, compare media progression vs wall-clock progression.
3. Hard-reset only for true timeline breaks (invalid/non-monotonic/large timestamp jumps).
4. Otherwise correct pacing from cumulative drift with a small deadband.
5. If lateness becomes extreme, soft re-anchor instead of forcing aggressive catch-up.
6. Track per-frame stall signal and cumulative drift for observability.

## Additional Notes
Video only for now; will probably add audio later.