### PR TITLE
feat(backend): NodeProcessor runtime for custom-node graphs

### DIFF
--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -2821,10 +2821,13 @@ export function StreamPage() {
         );
       }
 
-      const loadSuccess = await loadPipeline(loadItems);
-      if (!loadSuccess) {
-        console.error("Failed to load pipeline, cannot start stream");
-        return false;
+      // Node-only graphs (no pipeline nodes) skip the pipeline load step.
+      if (loadItems.length > 0) {
+        const loadSuccess = await loadPipeline(loadItems);
+        if (!loadSuccess) {
+          console.error("Failed to load pipeline, cannot start stream");
+          return false;
+        }
       }
 
       // Check video requirements based on input mode.

--- a/src/scope/core/nodes/base.py
+++ b/src/scope/core/nodes/base.py
@@ -110,15 +110,32 @@ class BaseNode(ABC):
     """Abstract base class for all backend node types.
 
     Subclasses must set ``node_type_id`` as a ``ClassVar`` and implement
-    ``get_definition()``. Execution contracts (e.g. ``execute(inputs)`` for
-    pull-based execution, or ``setup(emit_output) / update_input(...)`` for
-    event-driven execution) are defined by concrete execution backends and
-    not by this base class.
+    ``get_definition()`` and ``execute()``. Nodes run inside a
+    :class:`NodeProcessor` in the pipeline graph: input port values arrive
+    in the ``inputs`` dict and the return dict fans out to downstream
+    nodes or pipelines via queue edges.
+
+    Example::
+
+        class MyNode(BaseNode):
+            node_type_id: ClassVar[str] = "my-plugin.my-node"
+
+            @classmethod
+            def get_definition(cls) -> NodeDefinition:
+                return NodeDefinition(
+                    node_type_id=cls.node_type_id,
+                    display_name="My Node",
+                    inputs=[NodePort(name="audio", port_type="audio")],
+                    outputs=[NodePort(name="audio", port_type="audio")],
+                )
+
+            def execute(self, inputs, **kwargs):
+                return {"audio": inputs["audio"]}
     """
 
     node_type_id: ClassVar[str]
 
-    def __init__(self, node_id: str, config: dict[str, Any] | None = None):
+    def __init__(self, node_id: str = "", config: dict[str, Any] | None = None):
         self.node_id = node_id
         self.config = config or {}
 
@@ -126,3 +143,29 @@ class BaseNode(ABC):
     @abstractmethod
     def get_definition(cls) -> NodeDefinition:
         """Return static metadata for this node type."""
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Execute the node with the given inputs.
+
+        Plain backend nodes (scheduled by ``NodeProcessor``) override
+        this. :class:`Pipeline` subclasses inherit the default because
+        they're driven by ``__call__`` from ``PipelineProcessor`` and
+        never reach this code path.
+
+        Args:
+            inputs: Dict mapping input port names to their values.
+                Audio ports receive ``(tensor, sample_rate)`` tuples.
+                Video ports receive frame tensors.
+            **kwargs: Additional context (pipeline parameters, etc.)
+
+        Returns:
+            Dict mapping output port names to their values.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must override execute() or be invoked "
+            "via PipelineProcessor (Pipeline subclass) instead of NodeProcessor."
+        )

--- a/src/scope/core/nodes/processor.py
+++ b/src/scope/core/nodes/processor.py
@@ -43,6 +43,11 @@ class NodeProcessor:
 
         definition = node.get_definition()
 
+        # Consumed by FrameProcessor.get_audio_packet() on the sink feeder.
+        # Kept here (even without a routing implementation) so a NodeProcessor
+        # can stand in as the sink's feeder without crashing the audio path.
+        self.audio_output_queue: queue.Queue = queue.Queue(maxsize=10)
+
         self.worker_thread: threading.Thread | None = None
         self.shutdown_event = threading.Event()
         self.running = False

--- a/src/scope/core/nodes/processor.py
+++ b/src/scope/core/nodes/processor.py
@@ -1,0 +1,174 @@
+"""Node processor — wraps a BaseNode for execution in the pipeline graph.
+
+Adapts the node interface (typed I/O ports) to the pipeline processor
+interface (input/output queues, worker thread).
+"""
+
+import logging
+import queue
+import threading
+from typing import Any
+
+from .base import BaseNode
+
+logger = logging.getLogger(__name__)
+
+SLEEP_TIME = 0.01
+
+
+class NodeProcessor:
+    """Runs a BaseNode in a dedicated thread. Input queues feed the node,
+    output queues fan out its results to downstream nodes.
+
+    Source nodes (no inputs) execute once by default; nodes marked
+    ``continuous=True`` in their definition re-execute on every tick so
+    streaming sources and sinks stay alive.
+    """
+
+    def __init__(
+        self,
+        node: BaseNode,
+        node_id: str,
+        initial_parameters: dict | None = None,
+    ):
+        self.node = node
+        self.node_id = node_id
+        self.parameters = initial_parameters or {}
+
+        # Port-based queues wired by the graph executor
+        self.input_queues: dict[str, queue.Queue] = {}
+        self.output_queues: dict[str, list[queue.Queue]] = {}
+        self.input_queue_lock = threading.Lock()
+        self.external_queue_refs: list[tuple[dict, str]] = []
+
+        definition = node.get_definition()
+
+        self.worker_thread: threading.Thread | None = None
+        self.shutdown_event = threading.Event()
+        self.running = False
+
+        # Execution state
+        self._source_executed = False
+        self._has_executed = False
+        self._continuous = definition.continuous
+
+        # PipelineProcessor interface compatibility: graph_executor populates
+        # this for every processor; kept as an empty dict so that write is safe.
+        self.output_consumers: dict[str, list] = {}
+        self.paused = False
+
+    @property
+    def output_queue(self) -> queue.Queue | None:
+        qs = self.output_queues.get("video")
+        return qs[0] if qs else None
+
+    def start(self) -> None:
+        if self.running:
+            return
+        self.running = True
+        self.shutdown_event.clear()
+        self.worker_thread = threading.Thread(
+            target=self._worker_loop, daemon=True, name=f"NodeProcessor[{self.node_id}]"
+        )
+        self.worker_thread.start()
+
+    def stop(self) -> None:
+        if not self.running:
+            return
+        self.running = False
+        self.shutdown_event.set()
+        if self.worker_thread is not None:
+            self.worker_thread.join(timeout=5.0)
+        logger.info("NodeProcessor stopped: %s", self.node_id)
+
+    def update_parameters(self, parameters: dict[str, Any]) -> None:
+        self.parameters.update(parameters)
+
+    def set_beat_cache_reset_rate(self, rate):  # PipelineProcessor compat
+        pass
+
+    def get_fps(self) -> float:
+        return 30.0
+
+    def _worker_loop(self) -> None:
+        while not self.shutdown_event.is_set():
+            try:
+                self._process_once()
+            except Exception:
+                logger.exception("Error in node processor %s", self.node_id)
+                with self.input_queue_lock:
+                    is_source = not self.input_queues
+                if is_source:
+                    # Avoid infinite retry on failing source nodes
+                    self._source_executed = True
+                    self._continuous = False
+                self.shutdown_event.wait(SLEEP_TIME)
+
+    def _process_once(self) -> None:
+        if self.paused:
+            self.shutdown_event.wait(SLEEP_TIME)
+            return
+
+        with self.input_queue_lock:
+            all_queues = dict(self.input_queues)
+
+        is_source_node = not all_queues
+
+        # Source nodes execute once; continuous=True nodes re-execute every
+        # tick (for streaming I/O).
+        if is_source_node and self._source_executed and not self._continuous:
+            self.shutdown_event.wait(1.0)
+            return
+
+        # Gather inputs. Continuous nodes consume whatever's available
+        # (empty inputs stay absent). Non-continuous nodes wait until every
+        # input queue has data, so they execute with a complete input set.
+        inputs: dict[str, Any] = {}
+        if all_queues:
+            if self._continuous:
+                for port_name, q in all_queues.items():
+                    try:
+                        inputs[port_name] = q.get_nowait()
+                    except queue.Empty:
+                        pass
+            else:
+                if any(q.empty() for q in all_queues.values()):
+                    self.shutdown_event.wait(SLEEP_TIME)
+                    return
+                inputs = {name: q.get_nowait() for name, q in all_queues.items()}
+
+        # Non-continuous nodes skip re-execution when no new inputs arrived
+        # and they already have a cached output.
+        if self._has_executed and not inputs and not self._continuous:
+            self.shutdown_event.wait(SLEEP_TIME)
+            return
+
+        outputs = self.node.execute(inputs, **self.parameters)
+
+        if is_source_node:
+            self._source_executed = True
+
+        if not outputs:
+            self.shutdown_event.wait(SLEEP_TIME)
+            return
+
+        self._has_executed = True
+        self._route_outputs(outputs)
+
+    def _route_outputs(self, outputs: dict[str, Any]) -> None:
+        for port_name, value in outputs.items():
+            if value is None:
+                continue
+
+            # Fan out to all downstream queues on this port. Block briefly
+            # when queues are full so producers throttle to consumer pace
+            # and GPU tensors don't pile up in memory.
+            out_queues = self.output_queues.get(port_name)
+            if out_queues:
+                for oq in out_queues:
+                    while not self.shutdown_event.is_set():
+                        try:
+                            oq.put(value, timeout=0.1)
+                            break
+                        except queue.Full:
+                            continue

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -1182,22 +1182,26 @@ async def handle_webrtc_offer(
         # Local mode: ensure pipeline is loaded before proceeding.
         # Node-only graphs (no pipeline nodes) skip this check — the graph
         # executor handles custom nodes directly without loading pipelines.
+        # Mixed graphs (pipeline + custom node) still require loaded pipelines.
         graph_data = (
             request.initialParameters.graph if request.initialParameters else None
         )
-        has_graph_nodes = False
+        has_pipeline_nodes = False
         if graph_data is not None:
             nodes = (
                 graph_data.get("nodes", [])
                 if isinstance(graph_data, dict)
                 else getattr(graph_data, "nodes", [])
             )
-            has_graph_nodes = any(
+            has_pipeline_nodes = any(
                 (n.get("type") if isinstance(n, dict) else getattr(n, "type", None))
-                == "node"
+                == "pipeline"
                 for n in nodes
             )
-        if not has_graph_nodes:
+        # Skip the check only for node-only graphs (graph present, no pipeline
+        # nodes). When no graph is sent at all, fall back to the legacy check.
+        is_node_only_graph = graph_data is not None and not has_pipeline_nodes
+        if not is_node_only_graph:
             status_info = await pipeline_manager.get_status_info_async()
             if status_info["status"] != "loaded":
                 raise HTTPException(

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -1179,13 +1179,31 @@ async def handle_webrtc_offer(
             logger.info("Using relay mode - video will flow through backend to cloud")
             return await webrtc_manager.handle_offer_with_relay(request, cloud_manager)
 
-        # Local mode: ensure pipeline is loaded before proceeding
-        status_info = await pipeline_manager.get_status_info_async()
-        if status_info["status"] != "loaded":
-            raise HTTPException(
-                status_code=400,
-                detail="Pipeline not loaded. Please load pipeline first.",
+        # Local mode: ensure pipeline is loaded before proceeding.
+        # Node-only graphs (no pipeline nodes) skip this check — the graph
+        # executor handles custom nodes directly without loading pipelines.
+        graph_data = (
+            request.initialParameters.graph if request.initialParameters else None
+        )
+        has_graph_nodes = False
+        if graph_data is not None:
+            nodes = (
+                graph_data.get("nodes", [])
+                if isinstance(graph_data, dict)
+                else getattr(graph_data, "nodes", [])
             )
+            has_graph_nodes = any(
+                (n.get("type") if isinstance(n, dict) else getattr(n, "type", None))
+                == "node"
+                for n in nodes
+            )
+        if not has_graph_nodes:
+            status_info = await pipeline_manager.get_status_info_async()
+            if status_info["status"] != "loaded":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Pipeline not loaded. Please load pipeline first.",
+                )
 
         return await webrtc_manager.handle_offer(
             request, pipeline_manager, tempo_sync=tempo_sync

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -218,8 +218,25 @@ class FrameProcessor:
             )
             return
 
-        # Local mode: setup pipeline graph
-        if not self.pipeline_ids:
+        # Local mode: setup pipeline graph.
+        # Node-only graphs (custom nodes, audio-only workflows) are allowed
+        # to start without any pipeline IDs — the graph executor still runs
+        # custom nodes via NodeProcessor and the audio path works through
+        # the standard audio_output_queue.
+        graph_param = (self.parameters or {}).get("graph")
+        _has_custom_nodes = False
+        if graph_param is not None:
+            _nodes = (
+                graph_param.get("nodes", [])
+                if isinstance(graph_param, dict)
+                else getattr(graph_param, "nodes", [])
+            )
+            _has_custom_nodes = any(
+                (n.get("type") if isinstance(n, dict) else getattr(n, "type", None))
+                == "node"
+                for n in _nodes
+            )
+        if not self.pipeline_ids and not _has_custom_nodes:
             error_msg = "No pipeline IDs provided, cannot start"
             logger.error(error_msg)
             self.running = False

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -12,6 +12,8 @@ import queue
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from scope.core.nodes.registry import NodeRegistry
+
 from .graph_schema import GraphConfig
 from .pipeline_processor import PipelineProcessor
 
@@ -92,7 +94,11 @@ def build_graph(
     # when multiple pipelines fan-in to the same sink.
     _sink_record_ids = {n.id for n in graph.nodes if n.type in ("sink", "record")}
 
-    # 1) Create one queue per edge (all edges are stream; frame-by-frame)
+    # 1) Create one queue per edge (all edges are stream; frame-by-frame).
+    # Node→node edges use maxsize=1 so the DAG executes one cycle at a
+    # time and large tensors don't pile up in memory; pipeline edges use
+    # the larger default so video chunks can accumulate.
+    _node_ids = {n.id for n in graph.nodes if n.type == "node"}
     stream_queues: dict[tuple[str, str], queue.Queue] = {}
     for e in graph.edges:
         if e.kind == "stream":
@@ -105,10 +111,12 @@ def build_graph(
                     f"node={e.to_node!r}, port={e.to_port!r}. "
                     f"Fan-in to a single port is not supported."
                 )
-            stream_queues[key] = queue.Queue(maxsize=DEFAULT_INPUT_QUEUE_MAXSIZE)
+            both_nodes = e.from_node in _node_ids and e.to_node in _node_ids
+            size = 1 if both_nodes else DEFAULT_INPUT_QUEUE_MAXSIZE
+            stream_queues[key] = queue.Queue(maxsize=size)
 
-    # 2) Create a processor per pipeline node and wire input_queues per port
-    node_processors: dict[str, PipelineProcessor] = {}
+    # 2) Create a processor per pipeline/custom node and wire input_queues
+    node_processors: dict[str, Any] = {}  # PipelineProcessor | NodeProcessor
     pipeline_ids: list[str] = []
 
     # Per-pipeline tempo: if any node explicitly opts in via tempo_sync=True,
@@ -118,24 +126,46 @@ def build_graph(
     any_node_has_tempo = any(n.tempo_sync for n in graph.nodes if n.type == "pipeline")
 
     for node in graph.nodes:
-        if node.type != "pipeline" or node.pipeline_id is None:
+        if node.type == "pipeline" and node.pipeline_id is not None:
+            node_gets_tempo = node.tempo_sync or not any_node_has_tempo
+            pipeline = pipeline_manager.get_pipeline_by_id(node.id)
+            processor = PipelineProcessor(
+                pipeline=pipeline,
+                pipeline_id=node.pipeline_id,
+                initial_parameters=initial_parameters.copy(),
+                session_id=session_id,
+                user_id=user_id,
+                connection_id=connection_id,
+                connection_info=connection_info,
+                tempo_sync=tempo_sync if node_gets_tempo else None,
+                modulation_engine=modulation_engine if node_gets_tempo else None,
+                node_id=node.id,
+            )
+            node_processors[node.id] = processor
+            pipeline_ids.append(node.pipeline_id)
+        elif node.type == "node" and node.node_type_id is not None:
+            from scope.core.nodes.processor import NodeProcessor
+
+            node_cls = NodeRegistry.get(node.node_type_id)
+            if node_cls is None:
+                raise ValueError(
+                    f"Unknown node type '{node.node_type_id}' for node '{node.id}'"
+                )
+            node_instance = node_cls(node_id=node.id)
+            # Merge per-node params (from workflow) with global initial params.
+            # Per-node values take precedence (e.g. "steps": 8 on DiffusionConfig).
+            node_params = {**initial_parameters}
+            if node.params:
+                node_params.update(node.params)
+            processor = NodeProcessor(
+                node=node_instance,
+                node_id=node.id,
+                initial_parameters=node_params,
+            )
+            node_processors[node.id] = processor
+            pipeline_ids.append(f"node:{node.node_type_id}")
+        else:
             continue
-        node_gets_tempo = node.tempo_sync or not any_node_has_tempo
-        pipeline = pipeline_manager.get_pipeline_by_id(node.id)
-        processor = PipelineProcessor(
-            pipeline=pipeline,
-            pipeline_id=node.pipeline_id,
-            initial_parameters=initial_parameters.copy(),
-            session_id=session_id,
-            user_id=user_id,
-            connection_id=connection_id,
-            connection_info=connection_info,
-            tempo_sync=tempo_sync if node_gets_tempo else None,
-            modulation_engine=modulation_engine if node_gets_tempo else None,
-            node_id=node.id,
-        )
-        node_processors[node.id] = processor
-        pipeline_ids.append(node.pipeline_id)
 
         for e in graph.edges_to(node.id):
             if e.kind != "stream":
@@ -146,7 +176,7 @@ def build_graph(
 
     # 3) Set each producer's output_queues per port
     for node in graph.nodes:
-        if node.type != "pipeline" or node.id not in node_processors:
+        if node.type not in ("pipeline", "node") or node.id not in node_processors:
             continue
         proc = node_processors[node.id]
         out_by_port: dict[str, list[queue.Queue]] = {}
@@ -334,11 +364,21 @@ def _validate_edge_ports(
     # Build a map of node_id -> (declared_inputs, declared_outputs)
     port_map: dict[str, tuple[set[str], set[str]]] = {}
     for node in graph.nodes:
-        if node.type != "pipeline" or node.pipeline_id is None:
-            continue
-        pipeline = pipeline_manager.get_pipeline_by_id(node.id)
-        config_class = pipeline.get_config_class()
-        port_map[node.id] = (set(config_class.inputs), set(config_class.outputs))
+        if node.type == "pipeline" and node.pipeline_id is not None:
+            pipeline = pipeline_manager.get_pipeline_by_id(node.id)
+            config_class = pipeline.get_config_class()
+            port_map[node.id] = (
+                set(config_class.inputs),
+                set(config_class.outputs),
+            )
+        elif node.type == "node" and node.node_type_id is not None:
+            node_cls = NodeRegistry.get(node.node_type_id)
+            if node_cls is not None:
+                defn = node_cls.get_definition()
+                port_map[node.id] = (
+                    {p.name for p in defn.inputs},
+                    {p.name for p in defn.outputs},
+                )
 
     errors: list[str] = []
     for e in graph.edges:

--- a/src/scope/server/mcp_router.py
+++ b/src/scope/server/mcp_router.py
@@ -261,10 +261,11 @@ async def start_stream(
                 detail=f"Invalid graph: {'; '.join(errors)}",
             )
         pipeline_ids = graph_config.get_pipeline_node_ids()
-        if not pipeline_ids:
+        backend_node_ids = graph_config.get_backend_node_ids()
+        if not pipeline_ids and not backend_node_ids:
             raise HTTPException(
                 status_code=400,
-                detail="Graph must contain at least one pipeline node",
+                detail="Graph must contain at least one pipeline or custom node",
             )
 
         pipeline_tuples = [
@@ -274,8 +275,9 @@ async def start_stream(
         ]
         pipeline_id_list = [t[1] for t in pipeline_tuples]
 
-        # Headless sessions run locally.
-        await pipeline_manager.load_pipelines(pipeline_tuples)
+        if pipeline_tuples:
+            # Skip load for node-only graphs.
+            await pipeline_manager.load_pipelines(pipeline_tuples)
 
         initial_params: dict = {
             "pipeline_ids": pipeline_id_list,


### PR DESCRIPTION
## Summary

Adds a **`NodeProcessor`** so the graph executor can schedule `type: "node"` backends (registered via `NodeRegistry`) alongside pipeline nodes in the same graph. Makes `BaseNode.execute(inputs, **kwargs)` the execution contract for plain backend nodes — `Pipeline` subclasses inherit a default that raises, since they're driven by `PipelineProcessor.__call__` instead. Updates session/WebRTC/MCP paths to allow **node-only graphs** (no pipeline load required).

This is runtime/plumbing only. No built-in nodes, audio routing, or WebRTC audio changes are included in this PR.

---

## Node runtime

- `core/nodes/base.py` — `BaseNode.execute(inputs, **kwargs) -> dict` is now a defined method with a `NotImplementedError` default. Plain nodes override it; `Pipeline` subclasses keep the default and are invoked via `__call__`. `node_id` default added so nodes can be instantiated without positional args.
- `core/nodes/processor.py` — new `NodeProcessor`: daemon worker thread (`NodeProcessor[<node_id>]`), per-port input/output queues, fan-out routing with back-pressure (`oq.put(value, timeout=0.1)`), source-once vs. `continuous=True` semantics, error-handling that stops runaway source retries, and `PipelineProcessor`-compatible surface (`output_queue`, `output_consumers`, `paused`, `update_parameters`, `set_beat_cache_reset_rate`, `get_fps`).

## Graph execution

- `server/graph_executor.py`
  - Instantiates `NodeProcessor` for `type="node"` nodes; looks up class via `NodeRegistry.get(node.node_type_id)` and raises on unknown types.
  - Merges per-node `params` from the workflow over `initial_parameters` (per-node values win).
  - Node→node stream edges use `maxsize=1` queues so the DAG executes one tick at a time and large tensors don't pile up; pipeline edges keep the default size.
  - `_validate_edge_ports` extended to validate custom-node ports via `NodeRegistry` definitions.
  - Output wiring loop now accepts both `pipeline` and `node` producers.

## Session / routing plumbing

- `server/frame_processor.py` — local-mode start no longer fails when `pipeline_ids` is empty if the graph has `type="node"` nodes.
- `server/mcp_router.py` — graph may be pipeline-only, custom-node-only, or mixed. Local `load_pipelines` is skipped when there are no pipeline tuples; error message updated.
- `server/app.py` — WebRTC offer path skips the "pipeline must be loaded" check when the incoming graph contains custom nodes.

## Frontend

- `frontend/src/pages/StreamPage.tsx` — skips the pipeline load step when `loadItems.length === 0` so node-only graphs can start.

---

## Test plan

- [ ] Mixed graph (pipeline + custom node on a supported port) — session starts, both processors run, frames flow.
- [ ] Node-only graph — session starts without loading any pipeline; WebRTC offer succeeds; frontend skips the load step.
- [ ] Unknown `node_type_id` — graph build raises a clear `ValueError` naming the node.
- [ ] Edge with a port not declared by the node definition — `_validate_edge_ports` rejects it with a descriptive error.
- [ ] Per-node `params` from workflow override `initial_parameters` inside the node's `execute()` kwargs.
- [ ] Continuous node — re-executes each tick; source (no inputs) node — executes once; failing source node doesn't spin.
