### PR TITLE
feat(nodes): add scheduler built-in node with dynamic trigger outputs

### DIFF
--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -414,10 +414,13 @@ export function AddNodeModal({
         if (controller.signal.aborted) return;
         // The unified endpoint returns both pipelines (pipeline_meta != null)
         // and plain custom nodes. Pipelines are still added via the hardcoded
-        // "Pipeline" catalog entry (placeholder + dropdown), so we filter
-        // them out of the plugin listing here to avoid duplication.
+        // "Pipeline" catalog entry (placeholder + dropdown); the scheduler
+        // has its own catalog entry with a bespoke widget. Filter both out
+        // of the plugin listing to avoid duplication.
         const items: NodeCatalogItem[] = (data.nodes ?? [])
-          .filter(n => n.pipeline_meta == null)
+          .filter(
+            n => n.pipeline_meta == null && n.node_type_id !== "scheduler"
+          )
           .map(n => ({
             type: "custom_node" as const,
             subType: n.node_type_id,

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -846,14 +846,40 @@ export function graphConfigToFlow(
             style: { width: n.w ?? undefined, height: n.h ?? undefined },
           }
         : {};
+    const position = {
+      x: savedX !== undefined ? savedX : START_X + COLUMN_GAP * 1.5,
+      y: savedY !== undefined ? savedY : START_Y + i * (NODE_HEIGHT + ROW_GAP),
+    };
+    // Scheduler has its own React renderer — rehydrate into its native
+    // nodeType so the bespoke widget (trigger list, transport controls)
+    // comes back after a round-trip, instead of the generic custom_node UI.
+    if (n.node_type_id === "scheduler") {
+      const params = (n.params ?? {}) as Record<string, unknown>;
+      nodes.push({
+        id: n.id,
+        type: "scheduler",
+        position,
+        ...sizeProps,
+        data: {
+          label: "Scheduler",
+          nodeType: "scheduler",
+          schedulerTriggers:
+            (params.triggers as Array<{ time: number; port_name: string }>) ??
+            [],
+          schedulerLoop: (params.loop as boolean) ?? false,
+          schedulerDuration: (params.duration as number) ?? 30,
+          schedulerElapsed: 0,
+          schedulerIsPlaying: false,
+          schedulerFireCounts: {},
+          schedulerTickCount: 0,
+        },
+      });
+      return;
+    }
     nodes.push({
       id: n.id,
       type: "custom_node",
-      position: {
-        x: savedX !== undefined ? savedX : START_X + COLUMN_GAP * 1.5,
-        y:
-          savedY !== undefined ? savedY : START_Y + i * (NODE_HEIGHT + ROW_GAP),
-      },
+      position,
       ...sizeProps,
       data: {
         label: n.node_type_id || n.id,
@@ -1024,7 +1050,6 @@ const FRONTEND_ONLY_TYPES = new Set<FlowNodeData["nodeType"]>([
   "tempo",
   "prompt_list",
   "prompt_blend",
-  "scheduler",
 ]);
 
 /** Fields in FlowNodeData that are non-serializable (functions, streams, etc.) */
@@ -1300,6 +1325,16 @@ export function flowToGraphConfig(
       n.height ??
       n.measured?.height ??
       (typeof n.style?.height === "number" ? n.style.height : undefined);
+    const isBackendNode =
+      n.data.nodeType === "custom_node" || n.data.nodeType === "scheduler";
+    const schedulerParams =
+      n.data.nodeType === "scheduler"
+        ? {
+            triggers: n.data.schedulerTriggers ?? [],
+            loop: n.data.schedulerLoop ?? false,
+            duration: n.data.schedulerDuration ?? 30,
+          }
+        : undefined;
     return {
       id: n.id,
       type:
@@ -1309,7 +1344,7 @@ export function flowToGraphConfig(
             ? "sink"
             : n.data.nodeType === "record"
               ? "record"
-              : n.data.nodeType === "custom_node"
+              : isBackendNode
                 ? "node"
                 : "pipeline",
       pipeline_id:
@@ -1319,11 +1354,13 @@ export function flowToGraphConfig(
       node_type_id:
         n.data.nodeType === "custom_node"
           ? (n.data.customNodeTypeId ?? null)
-          : undefined,
+          : n.data.nodeType === "scheduler"
+            ? "scheduler"
+            : undefined,
       params:
         n.data.nodeType === "custom_node" && n.data.customNodeParams
           ? n.data.customNodeParams
-          : undefined,
+          : schedulerParams,
       x: n.position.x,
       y: n.position.y,
       w: w && !Number.isNaN(w) ? w : undefined,

--- a/src/scope/core/nodes/__init__.py
+++ b/src/scope/core/nodes/__init__.py
@@ -9,17 +9,13 @@ the frontend via ``GET /api/v1/nodes/definitions``.
 """
 
 from .base import BaseNode, NodeDefinition, NodeParam, NodePort
+from .builtins import SchedulerNode
 from .registry import NodeRegistry
 
 
 def register_builtin_nodes() -> None:
-    """Register all built-in node types.
-
-    This is a no-op on branches that do not ship any built-in nodes; the
-    specialized branches (execution-scheduler, ACEStep) override or extend
-    this list.
-    """
-    return None
+    """Register all built-in node types shipped with the foundation."""
+    NodeRegistry.register(SchedulerNode)
 
 
 __all__ = [
@@ -28,5 +24,6 @@ __all__ = [
     "NodeParam",
     "NodePort",
     "NodeRegistry",
+    "SchedulerNode",
     "register_builtin_nodes",
 ]

--- a/src/scope/core/nodes/base.py
+++ b/src/scope/core/nodes/base.py
@@ -144,6 +144,26 @@ class BaseNode(ABC):
     def get_definition(cls) -> NodeDefinition:
         """Return static metadata for this node type."""
 
+    @classmethod
+    def get_dynamic_output_ports(cls, params: dict[str, Any]) -> set[str]:
+        """Return output port names that depend on runtime params.
+
+        Used by the graph executor to accept edges from ports that are
+        not declared statically in :meth:`get_definition` — e.g. the
+        scheduler node derives one output port per user-configured
+        trigger. The default returns an empty set; nodes with dynamic
+        outputs override.
+        """
+        return set()
+
+    def shutdown(self) -> None:  # noqa: B027 — intentional no-op hook
+        """Release any resources held by the node.
+
+        Called by :class:`NodeProcessor` when the graph is torn down.
+        The default is a no-op; nodes that start background threads or
+        hold OS handles override.
+        """
+
     def execute(
         self,
         inputs: dict[str, Any],

--- a/src/scope/core/nodes/builtins/__init__.py
+++ b/src/scope/core/nodes/builtins/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in nodes shipped with the foundation abstraction."""
+
+from .scheduler import SchedulerNode
+
+__all__ = ["SchedulerNode"]

--- a/src/scope/core/nodes/builtins/scheduler.py
+++ b/src/scope/core/nodes/builtins/scheduler.py
@@ -1,0 +1,310 @@
+"""Scheduler node — time-based trigger sequencer.
+
+Fires named triggers at specified times. Supports looping, dynamic
+output ports derived from the trigger list, and an internal monotonic
+clock running at ~200 Hz for sub-frame timing accuracy.
+
+Port semantics
+--------------
+- Static inputs:  ``start`` (trigger), ``reset`` (trigger)
+- Static outputs: ``tick`` (number), ``elapsed`` (number), ``is_playing`` (boolean)
+- Dynamic outputs: one per unique trigger ``port_name``, emitting an
+  incrementing counter each time the trigger fires.  Counters (rather
+  than booleans) allow downstream nodes to detect every firing even
+  when multiple events coincide within a single frame.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, ClassVar, TypedDict
+
+from ..base import BaseNode, NodeDefinition, NodeParam, NodePort
+
+# Internal tick interval — 5 ms gives ~200 Hz resolution while keeping
+# CPU usage negligible.
+_TICK_INTERVAL = 0.005
+
+# Throttle elapsed-time broadcasts to avoid flooding downstream nodes.
+_ELAPSED_BROADCAST_INTERVAL = 0.05  # 50 ms → ~20 Hz
+
+
+class TriggerSpec(TypedDict):
+    time: float
+    port_name: str
+
+
+class SchedulerNode(BaseNode):
+    """Time-based trigger scheduler.
+
+    Configured via the ``triggers``, ``loop``, and ``duration`` parameters.
+    Each trigger has a ``time`` (seconds) and ``port_name`` (output port).
+    When elapsed time reaches a trigger's time the corresponding output
+    fires with an incrementing counter.
+    """
+
+    node_type_id: ClassVar[str] = "scheduler"
+
+    def __init__(self, node_id: str, config: dict[str, Any] | None = None):
+        super().__init__(node_id, config)
+        # Single lock guards all mutable state (including _pending_outputs)
+        # so lock ordering can never deadlock.
+        self._lock = threading.Lock()
+        self._playing = False
+        self._start_time: float | None = None
+        self._elapsed = 0.0
+        self._tick_count = 0
+        self._fire_counts: dict[str, int] = {}
+        self._fired_keys: set[tuple[str, float]] = set()
+        self._triggers: list[TriggerSpec] = []
+        self._loop = False
+        self._duration = 0.0
+        self._last_elapsed_broadcast = 0.0
+        self._timer_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        # Accumulated outputs drained on next execute(). Only populated
+        # when something has actually changed so downstream queues don't
+        # get flooded with unchanged state.
+        self._pending_outputs: dict[str, Any] = {}
+        # Previous counter values on edge-triggered inputs. Any strict
+        # increment toggles the corresponding action; a stale value
+        # sitting on the queue is ignored. Seeded at 0 so the first
+        # positive counter delivered from upstream is treated as a fire.
+        self._prev_start_counter: int = 0
+        self._prev_reset_counter: int = 0
+        # Auto-start fires once per node lifetime, regardless of later
+        # stale zeros observed on start/reset inputs.
+        self._auto_start_done = False
+
+    @classmethod
+    def get_definition(cls) -> NodeDefinition:
+        return NodeDefinition(
+            node_type_id=cls.node_type_id,
+            display_name="Scheduler",
+            category="timing",
+            description=(
+                "Time-based trigger scheduler. Add trigger points and "
+                "connect them to other nodes to drive timed actions."
+            ),
+            continuous=True,
+            inputs=[
+                NodePort(
+                    name="start",
+                    port_type="trigger",
+                    required=False,
+                    description="Play / pause toggle",
+                ),
+                NodePort(
+                    name="reset",
+                    port_type="trigger",
+                    required=False,
+                    description="Reset elapsed time and trigger state",
+                ),
+            ],
+            outputs=[
+                NodePort(name="tick", port_type="number", description="Tick counter"),
+                NodePort(
+                    name="elapsed",
+                    port_type="number",
+                    description="Elapsed time (seconds)",
+                ),
+                NodePort(
+                    name="is_playing",
+                    port_type="boolean",
+                    description="Whether the scheduler is playing",
+                ),
+            ],
+            params=[
+                NodeParam(
+                    name="triggers",
+                    param_type="string",
+                    default=[],
+                    description="List of { time, port_name } trigger points",
+                    ui={"widget": "trigger_list"},
+                    convertible_to_input=False,
+                ),
+                NodeParam(
+                    name="loop",
+                    param_type="boolean",
+                    default=False,
+                    description="Loop when duration is reached",
+                ),
+                NodeParam(
+                    name="duration",
+                    param_type="number",
+                    default=30.0,
+                    description="Total duration (s); 0 disables auto-stop",
+                    ui={"min": 0, "max": 3600, "step": 0.1},
+                ),
+            ],
+        )
+
+    @classmethod
+    def get_dynamic_output_ports(cls, params: dict[str, Any]) -> set[str]:
+        triggers = params.get("triggers") or []
+        if not isinstance(triggers, list):
+            return set()
+        names: set[str] = set()
+        for trig in triggers:
+            if isinstance(trig, dict):
+                name = trig.get("port_name")
+                if isinstance(name, str) and name:
+                    names.add(name)
+        return names
+
+    # ------------------------------------------------------------------
+    # Internal timer
+    # ------------------------------------------------------------------
+
+    def _start_timer(self) -> None:
+        if self._timer_thread is not None and self._timer_thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._timer_thread = threading.Thread(
+            target=self._timer_loop,
+            daemon=True,
+            name=f"SchedulerNode[{self.node_id}]",
+        )
+        self._timer_thread.start()
+
+    def _stop_timer(self) -> None:
+        self._stop_event.set()
+        t = self._timer_thread
+        self._timer_thread = None
+        if t is not None and t is not threading.current_thread():
+            t.join(timeout=1.0)
+
+    def _timer_loop(self) -> None:
+        """Background thread: checks triggers at ~200 Hz."""
+        while not self._stop_event.is_set():
+            with self._lock:
+                if self._playing and self._start_time is not None:
+                    self._elapsed = time.monotonic() - self._start_time
+                    self._check_triggers()
+            self._stop_event.wait(_TICK_INTERVAL)
+
+    def _check_triggers(self) -> None:
+        """Fire any triggers whose time has been reached. Caller holds ``_lock``."""
+        for trig in self._triggers:
+            t = float(trig["time"])
+            port = trig["port_name"]
+            key = (port, t)
+            if t <= self._elapsed and key not in self._fired_keys:
+                self._fired_keys.add(key)
+                self._fire_counts[port] = self._fire_counts.get(port, 0) + 1
+                self._tick_count += 1
+                self._pending_outputs[port] = self._fire_counts[port]
+                self._pending_outputs["tick"] = self._tick_count
+
+        # Broadcast elapsed at a throttled rate so downstream nodes see
+        # a heartbeat without being flooded.
+        now = time.monotonic()
+        if now - self._last_elapsed_broadcast >= _ELAPSED_BROADCAST_INTERVAL:
+            self._last_elapsed_broadcast = now
+            self._pending_outputs["elapsed"] = round(self._elapsed, 3)
+            self._pending_outputs["is_playing"] = self._playing
+
+        # Handle loop / auto-stop
+        if self._duration > 0 and self._elapsed >= self._duration:
+            if self._loop:
+                self._reset_state()
+                self._start_time = time.monotonic()
+            else:
+                all_fired = all(
+                    (t["port_name"], float(t["time"])) in self._fired_keys
+                    for t in self._triggers
+                )
+                if all_fired:
+                    self._playing = False
+                    self._pending_outputs["is_playing"] = False
+
+    def _reset_state(self) -> None:
+        """Reset elapsed time and trigger state. Caller holds ``_lock``."""
+        self._elapsed = 0.0
+        self._fired_keys.clear()
+        self._fire_counts.clear()
+        self._tick_count = 0
+
+    # ------------------------------------------------------------------
+    # Node interface
+    # ------------------------------------------------------------------
+
+    def execute(self, inputs: dict[str, Any], **kwargs) -> dict[str, Any]:
+        triggers = kwargs.get("triggers", self.config.get("triggers", []))
+        loop = kwargs.get("loop", self.config.get("loop", False))
+        duration = kwargs.get("duration", self.config.get("duration", 0.0))
+
+        # Edge-detect start/reset counters so stale values on the input
+        # queue don't retrigger actions. Prev counters seeded at 0 in
+        # __init__ so the first positive pulse from upstream fires.
+        start_val = _as_counter(inputs.get("start"))
+        reset_val = _as_counter(inputs.get("reset"))
+        start_fired = start_val is not None and start_val > self._prev_start_counter
+        reset_fired = reset_val is not None and reset_val > self._prev_reset_counter
+        if start_val is not None:
+            self._prev_start_counter = start_val
+        if reset_val is not None:
+            self._prev_reset_counter = reset_val
+
+        with self._lock:
+            normalized_triggers: list[TriggerSpec] = []
+            if isinstance(triggers, list):
+                for t in triggers:
+                    if not isinstance(t, dict):
+                        continue
+                    port = t.get("port_name")
+                    time_val = t.get("time")
+                    if isinstance(port, str) and port and time_val is not None:
+                        normalized_triggers.append(
+                            {"time": float(time_val), "port_name": port}
+                        )
+            self._triggers = normalized_triggers
+            self._loop = bool(loop)
+            self._duration = float(duration)
+
+            if reset_fired:
+                self._reset_state()
+                self._start_time = time.monotonic() if self._playing else None
+
+            if start_fired:
+                self._playing = not self._playing
+                self._pending_outputs["is_playing"] = self._playing
+                if self._playing:
+                    self._start_time = time.monotonic() - self._elapsed
+                    self._start_timer()
+
+            # Auto-start on first execute so wiring the node into a graph
+            # drives downstream triggers without requiring an explicit start
+            # pulse. Gated by an explicit flag so a later stale zero on
+            # start/reset can't accidentally re-arm it.
+            if (
+                not self._auto_start_done
+                and not self._playing
+                and self._start_time is None
+                and self._triggers
+            ):
+                self._auto_start_done = True
+                self._playing = True
+                self._start_time = time.monotonic()
+                self._pending_outputs["is_playing"] = True
+                self._start_timer()
+
+            if not self._pending_outputs:
+                return {}
+
+            outputs = self._pending_outputs
+            self._pending_outputs = {}
+            return outputs
+
+    def shutdown(self) -> None:
+        self._stop_timer()
+
+
+def _as_counter(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/scope/core/nodes/builtins/scheduler.py
+++ b/src/scope/core/nodes/builtins/scheduler.py
@@ -223,11 +223,15 @@ class SchedulerNode(BaseNode):
                     self._pending_outputs["is_playing"] = False
 
     def _reset_state(self) -> None:
-        """Reset elapsed time and trigger state. Caller holds ``_lock``."""
+        """Reset elapsed time and trigger state. Caller holds ``_lock``.
+
+        Fire counts and tick count are kept monotonic across resets so
+        downstream edge-triggered consumers (which only fire on strict
+        counter increments) still see each subsequent firing. Same
+        rationale as the loop re-arm path in ``_check_triggers``.
+        """
         self._elapsed = 0.0
         self._fired_keys.clear()
-        self._fire_counts.clear()
-        self._tick_count = 0
 
     # ------------------------------------------------------------------
     # Node interface

--- a/src/scope/core/nodes/builtins/scheduler.py
+++ b/src/scope/core/nodes/builtins/scheduler.py
@@ -208,7 +208,10 @@ class SchedulerNode(BaseNode):
         # Handle loop / auto-stop
         if self._duration > 0 and self._elapsed >= self._duration:
             if self._loop:
-                self._reset_state()
+                # Re-arm triggers but keep fire counts / tick monotonic so
+                # downstream edge-triggered nodes see each new firing.
+                self._elapsed = 0.0
+                self._fired_keys.clear()
                 self._start_time = time.monotonic()
             else:
                 all_fired = all(

--- a/src/scope/core/nodes/processor.py
+++ b/src/scope/core/nodes/processor.py
@@ -84,6 +84,10 @@ class NodeProcessor:
         self.shutdown_event.set()
         if self.worker_thread is not None:
             self.worker_thread.join(timeout=5.0)
+        try:
+            self.node.shutdown()
+        except Exception:
+            logger.exception("Error shutting down node %s", self.node_id)
         logger.info("NodeProcessor stopped: %s", self.node_id)
 
     def update_parameters(self, parameters: dict[str, Any]) -> None:

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -375,9 +375,11 @@ def _validate_edge_ports(
             node_cls = NodeRegistry.get(node.node_type_id)
             if node_cls is not None:
                 defn = node_cls.get_definition()
+                static_outputs = {p.name for p in defn.outputs}
+                dynamic_outputs = node_cls.get_dynamic_output_ports(node.params or {})
                 port_map[node.id] = (
                     {p.name for p in defn.inputs},
-                    {p.name for p in defn.outputs},
+                    static_outputs | dynamic_outputs,
                 )
 
     errors: list[str] = []


### PR DESCRIPTION
## Summary

Adds **`SchedulerNode`** (`node_type_id`: `scheduler`) — a time-based trigger sequencer registered via `register_builtin_nodes()` — and wires it end-to-end through the backend graph execution runtime and the frontend workflow builder. Stacks on top of `rafal/node-backend-execution-2`.

The node runs a daemon thread driving a ~200 Hz monotonic clock (`_TICK_INTERVAL = 5 ms`), fires named triggers at configured times, and emits incrementing counters per trigger so downstream nodes never miss a firing.

## Ports & parameters

| | |
|--|--|
| **Inputs** | `start` (trigger — toggles play/pause), `reset` (trigger — clears fired state / elapsed) |
| **Static outputs** | `tick`, `elapsed`, `is_playing` |
| **Dynamic outputs** | One counter output per unique `port_name` in `triggers`, declared via `get_dynamic_output_ports()` so graph validation accepts edges from them |
| **Params (declared as `NodeParam`)** | `triggers` (list of `{time, port_name}`), `loop`, `duration` |

## Behaviour

- **Auto-start**: If `triggers` is non-empty and nothing has started yet, the first `execute()` arms the timer thread without requiring a `start` pulse. Guarded by an explicit `_auto_start_done` flag so a stale zero on `start`/`reset` cannot re-arm it.
- **Edge-triggered start/reset**: Actions fire on strict counter increments, so stale values on the input queue do not retoggle. Prev counters seed at 0 so the first positive pulse still fires.
- **Pause broadcast**: `is_playing` is staged into pending outputs on both pause and auto-start, so downstream sees the transition without waiting for the elapsed heartbeat.
- **Loop / duration**: When `duration > 0` and `loop` is true, state resets at `elapsed >= duration`. When not looping, playback stops after all triggers have fired.
- **Idle pacing**: `execute()` returns `{}` when nothing changed and relies on `NodeProcessor`'s built-in idle handling instead of busy-looping.

## Runtime / framework changes

- **`BaseNode`**: adds `get_dynamic_output_ports()` and `shutdown()` hooks.
- **`graph_executor._validate_edge_ports`**: unions static + dynamic outputs so dynamic per-trigger ports pass edge validation.
- **`NodeProcessor.stop()`**: calls `node.shutdown()` during teardown so the scheduler's timer thread is joined cleanly.

## Frontend wiring

- **`graphUtils`**: drops `scheduler` from `FRONTEND_ONLY_TYPES`, emits it as `type=node` / `node_type_id=scheduler` with params, and rehydrates it back into the native scheduler `nodeType` on graph load so the bespoke widget survives a round-trip.
- **`AddNodeModal`**: skips `scheduler` in the discovered Plugins list to avoid duplicating the existing catalog entry.

## Files

- `src/scope/core/nodes/builtins/scheduler.py` — implementation
- `src/scope/core/nodes/builtins/__init__.py`, `src/scope/core/nodes/__init__.py` — export + `NodeRegistry.register`
- `src/scope/core/nodes/base.py` — `get_dynamic_output_ports()` / `shutdown()` hooks
- `src/scope/core/nodes/processor.py` — invoke `shutdown()` on stop
- `src/scope/server/graph_executor.py` — union dynamic outputs during edge validation
- `frontend/src/lib/graphUtils.ts` — round-trip scheduler through backend node format
- `frontend/src/components/graph/AddNodeModal.tsx` — de-dupe scheduler in plugins list

## Test plan

- [ ] Drop a scheduler into the workflow builder with `duration=5`, `loop=true`, multiple `triggers`; confirm fires at expected times.
- [ ] Wire `tick` / `elapsed` / `is_playing` downstream and confirm values update live.
- [ ] Wire a per-trigger counter output downstream and confirm graph validation accepts the edge.
- [ ] Pulse `reset` while playing and when stopped; confirm elapsed / fired state clears.
- [ ] Toggle `start` repeatedly; confirm play/pause semantics and that `is_playing` broadcasts immediately.
- [ ] Stop the graph; confirm the scheduler's timer thread exits (no leaked daemon).
- [ ] Reload a graph containing a scheduler and confirm the node rehydrates with its widget and params intact.
