### PR TITLE
feat: unified node abstraction with custom node catalog

### DIFF
--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import {
   Dialog,
   DialogContent,
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "../ui/dialog";
+import type { FlowNodeData } from "../../lib/graphUtils";
 
 interface AddNodeModalProps {
   open: boolean;
@@ -36,8 +37,10 @@ interface AddNodeModalProps {
       | "tempo"
       | "prompt_list"
       | "prompt_blend"
-      | "scheduler",
-    subType?: string
+      | "scheduler"
+      | "custom_node",
+    subType?: string,
+    extraData?: Partial<FlowNodeData>
   ) => void;
 }
 
@@ -67,12 +70,15 @@ interface NodeCatalogItem {
     | "tempo"
     | "prompt_list"
     | "prompt_blend"
-    | "scheduler";
+    | "scheduler"
+    | "custom_node";
   subType?: string;
   name: string;
   description: string;
   color: string;
   category: string;
+  /** Full definition for custom nodes (inputs/outputs/params). */
+  customNodeDef?: Record<string, unknown>;
 }
 
 const NODE_CATALOG: NodeCatalogItem[] = [
@@ -294,7 +300,15 @@ const NODE_CATALOG: NodeCatalogItem[] = [
   },
 ];
 
-const CATEGORIES = ["All", "I/O", "Values", "Controls", "UI", "Utility"];
+const CATEGORIES = [
+  "All",
+  "I/O",
+  "Values",
+  "Controls",
+  "UI",
+  "Utility",
+  "Plugins",
+];
 
 interface TooltipState {
   text: string;
@@ -388,10 +402,45 @@ export function AddNodeModal({
 }: AddNodeModalProps) {
   const [searchText, setSearchText] = useState("");
   const [activeCategory, setActiveCategory] = useState("All");
+  const [customNodes, setCustomNodes] = useState<NodeCatalogItem[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    fetch("/api/v1/nodes/definitions")
+      .then(r => r.json())
+      .then(data => {
+        // The unified endpoint returns both pipelines (pipeline_meta != null)
+        // and plain custom nodes. Pipelines are still added via the hardcoded
+        // "Pipeline" catalog entry (placeholder + dropdown), so we filter
+        // them out of the plugin listing here to avoid duplication.
+        const items: NodeCatalogItem[] = (data.nodes ?? [])
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .filter((n: any) => n.pipeline_meta == null)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .map((n: any) => ({
+            type: "custom_node" as const,
+            subType: n.node_type_id,
+            name: n.display_name || n.node_type_id,
+            description: n.description || "",
+            color: "#9ca3af",
+            category: "Plugins",
+            customNodeDef: n,
+          }));
+        setCustomNodes(items);
+      })
+      .catch(() => {
+        /* ignore — custom nodes just won't appear */
+      });
+  }, [open]);
+
+  const fullCatalog = useMemo(
+    () => [...NODE_CATALOG, ...customNodes],
+    [customNodes]
+  );
 
   const filteredItems = useMemo(() => {
     const lowerSearch = searchText.toLowerCase();
-    return NODE_CATALOG.filter(item => {
+    return fullCatalog.filter(item => {
       const matchesSearch =
         !lowerSearch ||
         item.name.toLowerCase().includes(lowerSearch) ||
@@ -400,14 +449,37 @@ export function AddNodeModal({
         activeCategory === "All" || item.category === activeCategory;
       return matchesSearch && matchesCategory;
     });
-  }, [searchText, activeCategory]);
+  }, [searchText, activeCategory, fullCatalog]);
 
-  const handleSelect = (item: NodeCatalogItem) => {
-    onSelectNodeType(item.type, item.subType);
-    onClose();
-    setSearchText("");
-    setActiveCategory("All");
-  };
+  const handleSelect = useCallback(
+    (item: NodeCatalogItem) => {
+      if (item.type === "custom_node" && item.customNodeDef) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const def = item.customNodeDef as any;
+        onSelectNodeType("custom_node", item.subType, {
+          customNodeTypeId: def.node_type_id,
+          customNodeDisplayName: def.display_name || def.node_type_id,
+          customNodeCategory: def.category || "",
+          customNodeInputs: def.inputs || [],
+          customNodeOutputs: def.outputs || [],
+          customNodeParamDefs: def.params || [],
+          customNodeParams: Object.fromEntries(
+            (def.params || [])
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .filter((p: any) => p.default != null)
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .map((p: any) => [p.name, p.default])
+          ),
+        });
+      } else {
+        onSelectNodeType(item.type, item.subType);
+      }
+      onClose();
+      setSearchText("");
+      setActiveCategory("All");
+    },
+    [onSelectNodeType, onClose]
+  );
 
   const handleClose = () => {
     onClose();

--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -7,6 +7,8 @@ import {
   DialogDescription,
 } from "../ui/dialog";
 import type { FlowNodeData } from "../../lib/graphUtils";
+import type { NodeDefinitionDto } from "../../lib/api";
+import { fetchNodeDefinitions } from "../../lib/api";
 
 interface AddNodeModalProps {
   open: boolean;
@@ -78,7 +80,7 @@ interface NodeCatalogItem {
   color: string;
   category: string;
   /** Full definition for custom nodes (inputs/outputs/params). */
-  customNodeDef?: Record<string, unknown>;
+  customNodeDef?: NodeDefinitionDto;
 }
 
 const NODE_CATALOG: NodeCatalogItem[] = [
@@ -406,18 +408,17 @@ export function AddNodeModal({
 
   useEffect(() => {
     if (!open) return;
-    fetch("/api/v1/nodes/definitions")
-      .then(r => r.json())
+    const controller = new AbortController();
+    fetchNodeDefinitions({ signal: controller.signal })
       .then(data => {
+        if (controller.signal.aborted) return;
         // The unified endpoint returns both pipelines (pipeline_meta != null)
         // and plain custom nodes. Pipelines are still added via the hardcoded
         // "Pipeline" catalog entry (placeholder + dropdown), so we filter
         // them out of the plugin listing here to avoid duplication.
         const items: NodeCatalogItem[] = (data.nodes ?? [])
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .filter((n: any) => n.pipeline_meta == null)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .map((n: any) => ({
+          .filter(n => n.pipeline_meta == null)
+          .map(n => ({
             type: "custom_node" as const,
             subType: n.node_type_id,
             name: n.display_name || n.node_type_id,
@@ -428,9 +429,13 @@ export function AddNodeModal({
           }));
         setCustomNodes(items);
       })
-      .catch(() => {
-        /* ignore — custom nodes just won't appear */
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        // Custom nodes won't appear, but log so plugin-registration
+        // regressions don't disappear silently.
+        console.warn("Failed to fetch custom node definitions:", err);
       });
+    return () => controller.abort();
   }, [open]);
 
   const fullCatalog = useMemo(
@@ -454,8 +459,7 @@ export function AddNodeModal({
   const handleSelect = useCallback(
     (item: NodeCatalogItem) => {
       if (item.type === "custom_node" && item.customNodeDef) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const def = item.customNodeDef as any;
+        const def = item.customNodeDef;
         onSelectNodeType("custom_node", item.subType, {
           customNodeTypeId: def.node_type_id,
           customNodeDisplayName: def.display_name || def.node_type_id,
@@ -465,10 +469,8 @@ export function AddNodeModal({
           customNodeParamDefs: def.params || [],
           customNodeParams: Object.fromEntries(
             (def.params || [])
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              .filter((p: any) => p.default != null)
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              .map((p: any) => [p.name, p.default])
+              .filter(p => p.default != null)
+              .map(p => [p.name, p.default])
           ),
         });
       } else {

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -55,6 +55,7 @@ import { TempoNode } from "./nodes/TempoNode";
 import { PromptListNode } from "./nodes/PromptListNode";
 import { PromptBlendNode } from "./nodes/PromptBlendNode";
 import { SchedulerNode } from "./nodes/SchedulerNode";
+import { CustomNode } from "./nodes/CustomNode";
 import { CustomEdge } from "./CustomEdge";
 import { ContextMenu } from "./ContextMenu";
 import { AddNodeModal } from "./AddNodeModal";
@@ -130,6 +131,7 @@ const nodeTypes = {
   prompt_list: PromptListNode,
   prompt_blend: PromptBlendNode,
   scheduler: SchedulerNode,
+  custom_node: CustomNode,
 };
 
 const edgeTypes = {

--- a/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
@@ -7,8 +7,8 @@ import {
   parseHandleId,
 } from "../../../../lib/graphUtils";
 import type { FlowNodeData } from "../../../../lib/graphUtils";
-import type { PluginInfo } from "../../../../lib/api";
-import { resolveWorkflow } from "../../../../lib/api";
+import type { PluginInfo, NodeDefinitionDto } from "../../../../lib/api";
+import { resolveWorkflow, fetchNodeDefinitions } from "../../../../lib/api";
 import type {
   ScopeWorkflow,
   WorkflowResolutionPlan,
@@ -63,6 +63,72 @@ function clearGraphFromLocalStorage(): void {
   } catch {
     // ignore
   }
+}
+
+/**
+ * After loading or importing a workflow, fetch `/api/v1/nodes/definitions`
+ * and hydrate each custom_node flow node with its inputs/outputs/params/
+ * display metadata. Saved workflows only persist `node_type_id` and
+ * `params`, so the port definitions have to be re-attached before render.
+ * User-supplied param values override the defaults from the definition.
+ *
+ * Accepts an AbortSignal so rapid reloads / unmounts can cancel an
+ * in-flight fetch before its setNodes callback stomps on newer state.
+ */
+function hydrateCustomNodeDefinitions(
+  nodes: Node<FlowNodeData>[],
+  setNodes: React.Dispatch<React.SetStateAction<Node<FlowNodeData>[]>>,
+  signal: AbortSignal
+): void {
+  const customFlowNodes = nodes.filter(
+    n => n.data.nodeType === "custom_node" && !n.data.customNodeInputs
+  );
+  if (customFlowNodes.length === 0) return;
+  fetchNodeDefinitions({ signal })
+    .then(data => {
+      if (signal.aborted) return;
+      const defMap = new Map<string, NodeDefinitionDto>(
+        data.nodes.map(d => [d.node_type_id, d])
+      );
+      setNodes(prev => {
+        if (signal.aborted) return prev;
+        return prev.map(n => {
+          if (
+            n.data.nodeType !== "custom_node" ||
+            !n.data.customNodeTypeId ||
+            n.data.customNodeInputs
+          ) {
+            return n;
+          }
+          const def = defMap.get(n.data.customNodeTypeId);
+          if (!def) return n;
+          return {
+            ...n,
+            data: {
+              ...n.data,
+              customNodeDisplayName: def.display_name,
+              customNodeCategory: def.category,
+              customNodeInputs: def.inputs ?? [],
+              customNodeOutputs: def.outputs ?? [],
+              customNodeParamDefs: def.params ?? [],
+              customNodeParams: {
+                ...Object.fromEntries(
+                  (def.params ?? [])
+                    .filter(p => p.default != null)
+                    .map(p => [p.name, p.default] as const)
+                ),
+                // User-edited values take precedence over definition defaults
+                ...(n.data.customNodeParams || {}),
+              },
+            },
+          };
+        });
+      });
+    })
+    .catch((err: unknown) => {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      // custom nodes just won't be hydrated; render falls back to placeholders
+    });
 }
 
 interface UseGraphPersistenceArgs {
@@ -129,6 +195,25 @@ export function useGraphPersistence({
   // to localStorage so we skip the expensive save when nothing changed.
   const lastSavedJsonRef = useRef<string>("");
 
+  // AbortController for in-flight custom-node hydration fetches. Aborted
+  // before each new hydrate and on unmount so a stale /api/v1/nodes/definitions
+  // response can't overwrite newer nodes state.
+  const hydrateAbortRef = useRef<AbortController | null>(null);
+  const startHydrate = useCallback(
+    (initialNodes: Node<FlowNodeData>[]) => {
+      hydrateAbortRef.current?.abort();
+      const controller = new AbortController();
+      hydrateAbortRef.current = controller;
+      hydrateCustomNodeDefinitions(initialNodes, setNodes, controller.signal);
+    },
+    [setNodes]
+  );
+  useEffect(() => {
+    return () => {
+      hydrateAbortRef.current?.abort();
+    };
+  }, []);
+
   const loadGraph = useCallback(() => {
     if (Object.keys(portsMap).length === 0) return;
     resetNavigationRef.current?.();
@@ -182,6 +267,8 @@ export function useGraphPersistence({
           }, 0);
         }
 
+        startHydrate(enriched);
+
         // Allow async side-effects (e.g. source mode restore) to settle
         // before re-enabling change notifications.
         setTimeout(() => {
@@ -202,6 +289,7 @@ export function useGraphPersistence({
     setEdges,
     setNodeParams,
     setNodes,
+    startHydrate,
   ]);
 
   useEffect(() => {
@@ -374,6 +462,8 @@ export function useGraphPersistence({
           }
         }, 0);
       }
+
+      startHydrate(enriched);
     },
     [
       portsMap,
@@ -384,6 +474,7 @@ export function useGraphPersistence({
       setNodeParams,
       enrichDepsRef,
       resetNavigationRef,
+      startHydrate,
     ]
   );
 

--- a/frontend/src/components/graph/hooks/node/useNodeFactories.ts
+++ b/frontend/src/components/graph/hooks/node/useNodeFactories.ts
@@ -45,7 +45,8 @@ type NodeTypeKey =
   | "tempo"
   | "prompt_list"
   | "prompt_blend"
-  | "scheduler";
+  | "scheduler"
+  | "custom_node";
 
 interface NodeDefaults {
   /** The React Flow node `type` */
@@ -471,6 +472,15 @@ const NODE_DEFAULTS: Record<NodeTypeKey, NodeDefaults> = {
       ],
     },
   },
+  custom_node: {
+    type: "custom_node",
+    idPrefix: "custom",
+    defaultX: 300,
+    data: {
+      label: "Custom Node",
+      nodeType: "custom_node" as const,
+    },
+  },
 };
 
 interface UseNodeFactoriesArgs {
@@ -566,8 +576,10 @@ export function useNodeFactories({
         | "tempo"
         | "prompt_list"
         | "prompt_blend"
-        | "scheduler",
-      subType?: string
+        | "scheduler"
+        | "custom_node",
+      subType?: string,
+      extraData?: Partial<FlowNodeData>
     ) => {
       if (!pendingNodePosition) return;
 
@@ -597,6 +609,12 @@ export function useNodeFactories({
         addNode("output", pendingNodePosition, {
           outputSinkType: defaultType,
           outputSinkName: defaultNames[defaultType] || "Scope",
+        });
+      } else if (type === "custom_node") {
+        addNode("custom_node", pendingNodePosition, {
+          customNodeTypeId: subType,
+          label: subType || "Custom Node",
+          ...extraData,
         });
       } else {
         addNode(type as NodeTypeKey, pendingNodePosition);

--- a/frontend/src/components/graph/nodes/CustomNode.tsx
+++ b/frontend/src/components/graph/nodes/CustomNode.tsx
@@ -1,0 +1,257 @@
+import { Handle, Position } from "@xyflow/react";
+import type { NodeProps, Node } from "@xyflow/react";
+import type { FlowNodeData } from "../../../lib/graphUtils";
+import { buildHandleId } from "../../../lib/graphUtils";
+import { useNodeData } from "../hooks/node/useNodeData";
+import { useNodeCollapse } from "../hooks/node/useNodeCollapse";
+import { useHandlePositions } from "../hooks/node/useHandlePositions";
+import { NodeCard, NodeHeader, NodeBody, collapsedHandleStyle } from "../ui";
+
+type CustomNodeType = Node<FlowNodeData, "custom_node">;
+
+/* Port type -> color mapping for custom types */
+const PORT_COLORS: Record<string, string> = {
+  audio: "#22c55e",
+  video: "#eeeeee",
+  number: "#38bdf8",
+  string: "#fbbf24",
+  boolean: "#34d399",
+  trigger: "#f97316",
+  latent: "#a855f7",
+  model: "#f59e0b",
+  vae: "#f59e0b",
+  clip: "#f59e0b",
+  conditioning: "#3b82f6",
+  semantic_hints: "#06b6d4",
+  config: "#6b7280",
+  curve: "#ec4899",
+  mask: "#ef4444",
+  lora: "#f472b6",
+};
+
+function portColor(portType: string): string {
+  return PORT_COLORS[portType] ?? "#9ca3af";
+}
+
+export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
+  const { updateData } = useNodeData(id);
+  const { collapsed, toggleCollapse } = useNodeCollapse();
+
+  const inputs = data.customNodeInputs ?? [];
+  const outputs = data.customNodeOutputs ?? [];
+  const params = data.customNodeParamDefs ?? [];
+  const displayName =
+    data.customTitle ||
+    data.customNodeDisplayName ||
+    data.customNodeTypeId ||
+    "Custom Node";
+  const category = data.customNodeCategory ?? "";
+
+  // Measure each port row so handles can be positioned from DOM offsetTop
+  // rather than hard-coded pixel math. Re-measures when port lists change.
+  const { setRowRef, rowPositions } = useHandlePositions([
+    collapsed,
+    category,
+    inputs.map(p => p.name).join("|"),
+    outputs.map(p => p.name).join("|"),
+    params.length,
+  ]);
+
+  return (
+    <NodeCard
+      selected={selected}
+      collapsed={collapsed}
+      autoMinHeight={!collapsed}
+    >
+      <NodeHeader
+        title={displayName}
+        onTitleChange={t => updateData({ customTitle: t })}
+        collapsed={collapsed}
+        onCollapseToggle={toggleCollapse}
+      />
+      {!collapsed && (
+        <NodeBody>
+          {/* Show category badge */}
+          {category && (
+            <div className="px-2 pb-1">
+              <span className="text-[10px] text-zinc-500 uppercase tracking-wider">
+                {category}
+              </span>
+            </div>
+          )}
+          {/* Show input ports */}
+          {inputs.length > 0 && (
+            <div className="flex flex-col gap-0.5 px-2 py-1">
+              {inputs.map(p => (
+                <div
+                  key={p.name}
+                  ref={setRowRef(`in_${p.name}`)}
+                  className="text-[11px] text-zinc-400 flex items-center gap-1"
+                >
+                  <span
+                    className="w-2 h-2 rounded-full inline-block"
+                    style={{ backgroundColor: portColor(p.port_type) }}
+                  />
+                  {p.name}
+                  <span className="text-zinc-600 text-[9px]">
+                    {p.port_type}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+          {/* Show output ports */}
+          {outputs.length > 0 && (
+            <div className="flex flex-col gap-0.5 px-2 py-1">
+              {outputs.map(p => (
+                <div
+                  key={p.name}
+                  ref={setRowRef(`out_${p.name}`)}
+                  className="text-[11px] text-zinc-400 flex items-center gap-1 justify-end"
+                >
+                  <span className="text-zinc-600 text-[9px]">
+                    {p.port_type}
+                  </span>
+                  {p.name}
+                  <span
+                    className="w-2 h-2 rounded-full inline-block"
+                    style={{ backgroundColor: portColor(p.port_type) }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          {/* Parameter widgets (ComfyUI-style editable params) */}
+          {params.length > 0 && (
+            <div className="flex flex-col gap-1 px-2 py-1 border-t border-zinc-800">
+              {params.map(p => {
+                const val = data.customNodeParams?.[p.name] ?? p.default ?? "";
+                return (
+                  <div
+                    key={p.name}
+                    className="flex items-center justify-between gap-2 text-[11px]"
+                  >
+                    <span
+                      className="text-zinc-500 shrink-0"
+                      title={p.description || p.name}
+                    >
+                      {p.description || p.name}
+                    </span>
+                    {p.param_type === "select" &&
+                    Array.isArray(p.ui?.options) ? (
+                      <select
+                        className="bg-zinc-900 text-zinc-200 rounded px-1 py-0.5 text-[11px] max-w-[130px]"
+                        value={String(val)}
+                        onChange={e =>
+                          updateData({
+                            customNodeParams: {
+                              ...data.customNodeParams,
+                              [p.name]: e.target.value,
+                            },
+                          })
+                        }
+                      >
+                        {(p.ui?.options as string[]).map(o => (
+                          <option key={o} value={o}>
+                            {o}
+                          </option>
+                        ))}
+                      </select>
+                    ) : p.param_type === "boolean" ? (
+                      <input
+                        type="checkbox"
+                        checked={Boolean(val)}
+                        onChange={e =>
+                          updateData({
+                            customNodeParams: {
+                              ...data.customNodeParams,
+                              [p.name]: e.target.checked,
+                            },
+                          })
+                        }
+                        className="accent-blue-500"
+                      />
+                    ) : p.param_type === "number" ? (
+                      <input
+                        type="number"
+                        className="bg-zinc-900 text-zinc-200 rounded px-1 py-0.5 text-[11px] w-[80px]"
+                        value={Number(val)}
+                        min={(p.ui?.min as number | undefined) ?? undefined}
+                        max={(p.ui?.max as number | undefined) ?? undefined}
+                        step={(p.ui?.step as number | undefined) ?? undefined}
+                        onChange={e =>
+                          updateData({
+                            customNodeParams: {
+                              ...data.customNodeParams,
+                              [p.name]: Number(e.target.value),
+                            },
+                          })
+                        }
+                      />
+                    ) : (
+                      <input
+                        type="text"
+                        className="bg-zinc-900 text-zinc-200 rounded px-1 py-0.5 text-[11px] max-w-[130px]"
+                        value={String(val)}
+                        onChange={e =>
+                          updateData({
+                            customNodeParams: {
+                              ...data.customNodeParams,
+                              [p.name]: e.target.value,
+                            },
+                          })
+                        }
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </NodeBody>
+      )}
+
+      {/* Input handles (left side). When expanded, positions come from the
+          port row's measured offsetTop; when collapsed, all handles overlap
+          at the vertical centre of the collapsed pill. */}
+      {inputs.map(p => (
+        <Handle
+          key={`in-${p.name}`}
+          type="target"
+          position={Position.Left}
+          id={buildHandleId("stream", p.name)}
+          style={
+            collapsed
+              ? { ...collapsedHandleStyle("left"), width: 8, height: 8 }
+              : {
+                  background: portColor(p.port_type),
+                  top: rowPositions[`in_${p.name}`] ?? 0,
+                  width: 8,
+                  height: 8,
+                }
+          }
+        />
+      ))}
+
+      {/* Output handles (right side). */}
+      {outputs.map(p => (
+        <Handle
+          key={`out-${p.name}`}
+          type="source"
+          position={Position.Right}
+          id={buildHandleId("stream", p.name)}
+          style={
+            collapsed
+              ? { ...collapsedHandleStyle("right"), width: 8, height: 8 }
+              : {
+                  background: portColor(p.port_type),
+                  top: rowPositions[`out_${p.name}`] ?? 0,
+                  width: 8,
+                  height: 8,
+                }
+          }
+        />
+      ))}
+    </NodeCard>
+  );
+}

--- a/frontend/src/components/graph/nodes/CustomNode.tsx
+++ b/frontend/src/components/graph/nodes/CustomNode.tsx
@@ -1,7 +1,10 @@
 import { Handle, Position } from "@xyflow/react";
 import type { NodeProps, Node } from "@xyflow/react";
 import type { FlowNodeData } from "../../../lib/graphUtils";
-import { buildHandleId } from "../../../lib/graphUtils";
+import {
+  customNodeInputHandleId,
+  customNodeOutputHandleId,
+} from "../../../lib/graphUtils";
 import { useNodeData } from "../hooks/node/useNodeData";
 import { useNodeCollapse } from "../hooks/node/useNodeCollapse";
 import { useHandlePositions } from "../hooks/node/useHandlePositions";
@@ -219,7 +222,7 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
           key={`in-${p.name}`}
           type="target"
           position={Position.Left}
-          id={buildHandleId("stream", p.name)}
+          id={customNodeInputHandleId(p.name)}
           style={
             collapsed
               ? { ...collapsedHandleStyle("left"), width: 8, height: 8 }
@@ -239,7 +242,7 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
           key={`out-${p.name}`}
           type="source"
           position={Position.Right}
-          id={buildHandleId("stream", p.name)}
+          id={customNodeOutputHandleId(p.name)}
           style={
             collapsed
               ? { ...collapsedHandleStyle("right"), width: 8, height: 8 }

--- a/frontend/src/components/graph/utils/connectionValidation.ts
+++ b/frontend/src/components/graph/utils/connectionValidation.ts
@@ -6,7 +6,10 @@
  */
 
 import type { Connection, Edge, Node } from "@xyflow/react";
-import { parseHandleId } from "../../../lib/graphUtils";
+import {
+  parseHandleId,
+  stripCustomNodeDirection,
+} from "../../../lib/graphUtils";
 import type { FlowNodeData } from "../../../lib/graphUtils";
 import { resolveSourceType } from "./typeResolution";
 import { BOUNDARY_INPUT_ID, BOUNDARY_OUTPUT_ID } from "./subgraphSerialization";
@@ -319,13 +322,17 @@ export function validateConnection(
     // or typo'd port id). `customNodeInputs`/`customNodeOutputs` is
     // set to an array — possibly empty — exactly when the node has
     // been hydrated from /api/v1/nodes/definitions.
+    // CustomNode handles are namespaced as stream:in:<name> / stream:out:<name>
+    // so port names in handle IDs carry an in:/out: prefix; strip it before
+    // matching against the declared port list.
     let srcType: string | undefined;
     if (srcIsCustom) {
       const outputs = sourceNode.data.customNodeOutputs;
       if (outputs === undefined) {
         // Not hydrated yet — fall through to the compatible path.
       } else {
-        const port = outputs.find(p => p.name === sourceParsed.name);
+        const portName = stripCustomNodeDirection(sourceParsed.name);
+        const port = outputs.find(p => p.name === portName);
         if (!port) return false;
         srcType = port.port_type;
       }
@@ -337,7 +344,8 @@ export function validateConnection(
       if (inputs === undefined) {
         // Not hydrated yet — fall through to the compatible path.
       } else {
-        const port = inputs.find(p => p.name === targetParsed.name);
+        const portName = stripCustomNodeDirection(targetParsed.name);
+        const port = inputs.find(p => p.name === portName);
         if (!port) return false;
         tgtType = port.port_type;
       }

--- a/frontend/src/components/graph/utils/connectionValidation.ts
+++ b/frontend/src/components/graph/utils/connectionValidation.ts
@@ -313,18 +313,38 @@ export function validateConnection(
     const tgtIsCustom = targetNode.data.nodeType === "custom_node";
     if (!srcIsCustom && !tgtIsCustom) return true;
 
-    const srcType = srcIsCustom
-      ? sourceNode.data.customNodeOutputs?.find(
-          p => p.name === sourceParsed.name
-        )?.port_type
-      : undefined;
-    const tgtType = tgtIsCustom
-      ? targetNode.data.customNodeInputs?.find(
-          p => p.name === targetParsed.name
-        )?.port_type
-      : undefined;
+    // For each custom endpoint, look up the declared port. We need to
+    // distinguish "ports not hydrated yet" (allow, optimistic) from
+    // "ports hydrated but this port is missing" (reject, stale wire
+    // or typo'd port id). `customNodeInputs`/`customNodeOutputs` is
+    // set to an array — possibly empty — exactly when the node has
+    // been hydrated from /api/v1/nodes/definitions.
+    let srcType: string | undefined;
+    if (srcIsCustom) {
+      const outputs = sourceNode.data.customNodeOutputs;
+      if (outputs === undefined) {
+        // Not hydrated yet — fall through to the compatible path.
+      } else {
+        const port = outputs.find(p => p.name === sourceParsed.name);
+        if (!port) return false;
+        srcType = port.port_type;
+      }
+    }
 
-    // If we can't look up both types, allow (assume compatible).
+    let tgtType: string | undefined;
+    if (tgtIsCustom) {
+      const inputs = targetNode.data.customNodeInputs;
+      if (inputs === undefined) {
+        // Not hydrated yet — fall through to the compatible path.
+      } else {
+        const port = inputs.find(p => p.name === targetParsed.name);
+        if (!port) return false;
+        tgtType = port.port_type;
+      }
+    }
+
+    // One side is a built-in (untyped stream) or not yet hydrated —
+    // we can't compare types, so allow.
     if (!srcType || !tgtType) return true;
     return srcType === tgtType;
   }

--- a/frontend/src/components/graph/utils/connectionValidation.ts
+++ b/frontend/src/components/graph/utils/connectionValidation.ts
@@ -302,9 +302,32 @@ export function validateConnection(
     return true;
   }
 
-  // Stream ↔ stream always ok
-  if (sourceParsed.kind === "stream" && targetParsed.kind === "stream")
-    return true;
+  // Stream ↔ stream: for custom_node edges, enforce port-type matching
+  // against the node's declared inputs/outputs. For built-in source /
+  // pipeline / sink nodes, streams are untyped (video) and always ok.
+  if (sourceParsed.kind === "stream" && targetParsed.kind === "stream") {
+    const sourceNode = nodes.find(n => n.id === connection.source);
+    const targetNode = nodes.find(n => n.id === connection.target);
+    if (!sourceNode || !targetNode) return true;
+    const srcIsCustom = sourceNode.data.nodeType === "custom_node";
+    const tgtIsCustom = targetNode.data.nodeType === "custom_node";
+    if (!srcIsCustom && !tgtIsCustom) return true;
+
+    const srcType = srcIsCustom
+      ? sourceNode.data.customNodeOutputs?.find(
+          p => p.name === sourceParsed.name
+        )?.port_type
+      : undefined;
+    const tgtType = tgtIsCustom
+      ? targetNode.data.customNodeInputs?.find(
+          p => p.name === targetParsed.name
+        )?.port_type
+      : undefined;
+
+    // If we can't look up both types, allow (assume compatible).
+    if (!srcType || !tgtType) return true;
+    return srcType === tgtType;
+  }
 
   // Param ↔ param
   if (sourceParsed.kind === "param" && targetParsed.kind === "param") {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -913,8 +913,12 @@ export const deleteApiKey = async (
 
 export interface GraphNode {
   id: string;
-  type: "source" | "pipeline" | "sink" | "record";
+  type: "source" | "pipeline" | "sink" | "record" | "node";
   pipeline_id?: string | null;
+  /** Node type ID (NodeRegistry key) when type is "node" */
+  node_type_id?: string | null;
+  /** Per-node parameter values for custom nodes */
+  params?: Record<string, unknown> | null;
   x?: number | null;
   y?: number | null;
   w?: number | null;
@@ -926,6 +930,63 @@ export interface GraphNode {
   sink_mode?: string | null;
   sink_name?: string | null;
 }
+
+export interface NodePortDef {
+  name: string;
+  port_type: string;
+  required?: boolean;
+  description?: string;
+  default_value?: unknown;
+}
+
+export interface NodeParamDef {
+  name: string;
+  param_type: "number" | "string" | "boolean" | "select";
+  default?: unknown;
+  description?: string;
+  /**
+   * Free-form widget hints (``min``/``max``/``step`` for number,
+   * ``options`` for select, …). Keeps widget-specific fields off the
+   * base schema; the frontend renderer dispatches on ``param_type``
+   * and reads whichever ``ui`` keys apply.
+   */
+  ui?: Record<string, unknown> | null;
+  convertible_to_input?: boolean;
+}
+
+export interface NodeDefinitionDto {
+  node_type_id: string;
+  display_name: string;
+  category: string;
+  description: string;
+  inputs: NodePortDef[];
+  outputs: NodePortDef[];
+  params: NodeParamDef[];
+  continuous: boolean;
+  /**
+   * Rich pipeline-only metadata (config_schema, mode_defaults,
+   * supports_lora, supports_vace, etc.) populated for entries whose
+   * underlying class is a Pipeline subclass. ``null`` for plain nodes.
+   */
+  pipeline_meta?: Record<string, unknown> | null;
+}
+
+export interface NodeDefinitionsResponse {
+  nodes: NodeDefinitionDto[];
+}
+
+export const fetchNodeDefinitions = async (
+  options: { signal?: AbortSignal } = {}
+): Promise<NodeDefinitionsResponse> => {
+  const response = await fetch("/api/v1/nodes/definitions", {
+    method: "GET",
+    signal: options.signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch node definitions: ${response.statusText}`);
+  }
+  return response.json();
+};
 
 export interface GraphEdge {
   from: string;

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -5,6 +5,8 @@ import type {
   GraphEdge,
   PipelineSchemaInfo,
   LoRAFileInfo,
+  NodePortDef,
+  NodeParamDef,
 } from "./api";
 import { inferPrimitiveFieldType } from "./schemaSettings";
 import { resolveLoRAPath } from "./workflowSettings";
@@ -104,7 +106,8 @@ export interface FlowNodeData {
     | "prompt_list"
     | "prompt_blend"
     | "scheduler"
-    | "audio";
+    | "audio"
+    | "custom_node";
   availablePipelineIds?: string[];
   /** Declared input ports for the selected pipeline */
   streamInputs?: string[];
@@ -385,6 +388,22 @@ export interface FlowNodeData {
 
   /* ── Tempo beat count offset ── */
   tempoBeatCountOffset?: number;
+
+  /* ── Custom node fields ── */
+  /** For custom_node: the node_type_id from the backend registry */
+  customNodeTypeId?: string;
+  /** For custom_node: display name from node definition */
+  customNodeDisplayName?: string;
+  /** For custom_node: category from node definition */
+  customNodeCategory?: string;
+  /** For custom_node: input port definitions */
+  customNodeInputs?: NodePortDef[];
+  /** For custom_node: output port definitions */
+  customNodeOutputs?: NodePortDef[];
+  /** For custom_node: current parameter values (user-editable) */
+  customNodeParams?: Record<string, unknown>;
+  /** For custom_node: parameter definitions from API (widget metadata) */
+  customNodeParamDefs?: NodeParamDef[];
 
   /* ── Node lock / pin / collapse ── */
   /** When true, parameter inputs on this node are disabled (read-only). */
@@ -779,6 +798,40 @@ export function graphConfigToFlow(
       height: h,
       style: { width: w, height: h },
       data: { label: n.id, nodeType: "record" },
+    });
+  });
+
+  // Backend custom nodes (type="node"). Port metadata is hydrated later
+  // from GET /api/v1/nodes/definitions in useGraphPersistence.
+  const customNodes = graph.nodes.filter(
+    n => n.type === "node" && !isSubgraphInnerNode(n.id)
+  );
+  customNodes.forEach((n, i) => {
+    const savedX = n.x ?? undefined;
+    const savedY = n.y ?? undefined;
+    const sizeProps =
+      n.w != null || n.h != null
+        ? {
+            width: n.w ?? undefined,
+            height: n.h ?? undefined,
+            style: { width: n.w ?? undefined, height: n.h ?? undefined },
+          }
+        : {};
+    nodes.push({
+      id: n.id,
+      type: "custom_node",
+      position: {
+        x: savedX !== undefined ? savedX : START_X + COLUMN_GAP * 1.5,
+        y:
+          savedY !== undefined ? savedY : START_Y + i * (NODE_HEIGHT + ROW_GAP),
+      },
+      ...sizeProps,
+      data: {
+        label: n.node_type_id || n.id,
+        nodeType: "custom_node",
+        customNodeTypeId: n.node_type_id ?? undefined,
+        customNodeParams: (n.params as Record<string, unknown>) ?? undefined,
+      },
     });
   });
 
@@ -1211,10 +1264,20 @@ export function flowToGraphConfig(
             ? "sink"
             : n.data.nodeType === "record"
               ? "record"
-              : "pipeline",
+              : n.data.nodeType === "custom_node"
+                ? "node"
+                : "pipeline",
       pipeline_id:
         n.data.nodeType === "pipeline"
           ? (n.data.pipelineId ?? null)
+          : undefined,
+      node_type_id:
+        n.data.nodeType === "custom_node"
+          ? (n.data.customNodeTypeId ?? null)
+          : undefined,
+      params:
+        n.data.nodeType === "custom_node" && n.data.customNodeParams
+          ? n.data.customNodeParams
           : undefined,
       x: n.position.x,
       y: n.position.y,

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -443,6 +443,35 @@ export function buildHandleId(kind: "stream" | "param", name: string): string {
 }
 
 /**
+ * CustomNode handles are namespaced with a direction prefix so input and
+ * output ports that share the same name (e.g. "video" passthrough) don't
+ * collide on handle id. Edges store only the bare port name on the wire
+ * format, so consumers strip the prefix before looking up the port and
+ * re-add it when rebuilding handles from saved graphs.
+ */
+const CUSTOM_NODE_IN_PREFIX = "in:";
+const CUSTOM_NODE_OUT_PREFIX = "out:";
+
+export function customNodeInputHandleId(portName: string): string {
+  return buildHandleId("stream", `${CUSTOM_NODE_IN_PREFIX}${portName}`);
+}
+
+export function customNodeOutputHandleId(portName: string): string {
+  return buildHandleId("stream", `${CUSTOM_NODE_OUT_PREFIX}${portName}`);
+}
+
+/** Strip the ``in:``/``out:`` prefix that CustomNode adds to handle names. */
+export function stripCustomNodeDirection(name: string): string {
+  if (name.startsWith(CUSTOM_NODE_IN_PREFIX)) {
+    return name.slice(CUSTOM_NODE_IN_PREFIX.length);
+  }
+  if (name.startsWith(CUSTOM_NODE_OUT_PREFIX)) {
+    return name.slice(CUSTOM_NODE_OUT_PREFIX.length);
+  }
+  return name;
+}
+
+/**
  * Build a map of pipeline_id -> { inputs, outputs } from schemas.
  */
 export function buildPipelinePortsMap(
@@ -837,6 +866,18 @@ export function graphConfigToFlow(
 
   // Convert edges - add stream: prefix to handle IDs
   // Skip edges that reference flattened inner subgraph nodes
+  // Custom nodes namespace their handles with in:/out: so the same port
+  // name on both sides doesn't collide; restore that prefix here when
+  // rebuilding handles for edges touching a custom_node.
+  const customNodeIds = new Set(
+    customNodes
+      .map(n => n.id)
+      .concat(
+        // Also include custom_node entries that may have been pushed via
+        // other code paths (defensive, cheap).
+        nodes.filter(n => n.type === "custom_node").map(n => n.id)
+      )
+  );
   const edges: Edge[] = graph.edges
     .filter(
       e => !isSubgraphInnerNode(e.from) && !isSubgraphInnerNode(e.to_node)
@@ -845,11 +886,15 @@ export function graphConfigToFlow(
       const sourceHandle =
         e.kind === "parameter"
           ? buildHandleId("param", e.from_port)
-          : buildHandleId("stream", e.from_port);
+          : customNodeIds.has(e.from)
+            ? customNodeOutputHandleId(e.from_port)
+            : buildHandleId("stream", e.from_port);
       const targetHandle =
         e.kind === "parameter"
           ? buildHandleId("param", e.to_port)
-          : buildHandleId("stream", e.to_port);
+          : customNodeIds.has(e.to_node)
+            ? customNodeInputHandleId(e.to_port)
+            : buildHandleId("stream", e.to_port);
       return {
         id: `e-${i}-${e.from}-${e.to_node}`,
         source: e.from,
@@ -1327,6 +1372,8 @@ export function flowToGraphConfig(
   }
 
   // Filter edges to only include those where both source and target exist in graphNodes
+  // Strip the in:/out: prefix added to custom_node handles before writing
+  // the bare port name back to the wire format.
   const graphNodeIds = new Set(graphNodes.map(n => n.id));
   const graphEdges: GraphEdge[] = flatEdges
     .filter(e => graphNodeIds.has(e.source) && graphNodeIds.has(e.target))
@@ -1337,11 +1384,17 @@ export function flowToGraphConfig(
         sourceParsed?.kind === "param" && targetParsed?.kind === "param"
           ? "parameter"
           : "stream";
+      const fromName = sourceParsed?.name
+        ? stripCustomNodeDirection(sourceParsed.name)
+        : "video";
+      const toName = targetParsed?.name
+        ? stripCustomNodeDirection(targetParsed.name)
+        : "video";
       return {
         from: e.source,
-        from_port: sourceParsed?.name || "video",
+        from_port: fromName,
         to_node: e.target,
-        to_port: targetParsed?.name || "video",
+        to_port: toName,
         kind: kind as "stream" | "parameter",
       };
     });

--- a/src/scope/core/nodes/__init__.py
+++ b/src/scope/core/nodes/__init__.py
@@ -1,0 +1,32 @@
+"""Backend node system for Scope.
+
+Provides a base class and registry for defining fine-grained processing
+nodes that can be wired into pipeline graphs. Nodes are simpler than full
+pipelines — they declare typed input/output ports, editable parameters,
+and a small execution contract. Built-in nodes and custom nodes (from
+plugins or local packs) are discovered here and rendered generically by
+the frontend via ``GET /api/v1/nodes/definitions``.
+"""
+
+from .base import BaseNode, NodeDefinition, NodeParam, NodePort
+from .registry import NodeRegistry
+
+
+def register_builtin_nodes() -> None:
+    """Register all built-in node types.
+
+    This is a no-op on branches that do not ship any built-in nodes; the
+    specialized branches (execution-scheduler, ACEStep) override or extend
+    this list.
+    """
+    return None
+
+
+__all__ = [
+    "BaseNode",
+    "NodeDefinition",
+    "NodeParam",
+    "NodePort",
+    "NodeRegistry",
+    "register_builtin_nodes",
+]

--- a/src/scope/core/nodes/base.py
+++ b/src/scope/core/nodes/base.py
@@ -1,0 +1,128 @@
+"""Base classes for the Scope node system.
+
+Nodes are lightweight, fine-grained processing units that can be wired into
+pipeline graphs alongside pipelines. Each node type declares typed input/
+output ports and editable parameters, and subclasses implement their own
+execution contract (which may differ between execution backends).
+
+This module intentionally keeps ``BaseNode`` minimal — only a class-level
+identifier and a ``get_definition()`` classmethod are required. Concrete
+execution backends (graph executor integration, event-driven runtime, etc.)
+layer their own abstract methods on top.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+
+class NodePort(BaseModel):
+    """Describes an input or output port on a node."""
+
+    name: str = Field(..., description="Port identifier (used in edge wiring)")
+    port_type: str = Field(
+        ...,
+        description=(
+            "Type of data carried by this port. Built-in types: "
+            "'audio', 'video', 'number', 'string', 'boolean', 'trigger'. "
+            "Plugins may define custom types (e.g. 'latent', 'model')."
+        ),
+    )
+    required: bool = Field(default=True, description="Whether this input is required")
+    description: str = Field(default="", description="Human-readable description")
+    default_value: Any = Field(default=None, description="Default value for inputs")
+
+
+class NodeParam(BaseModel):
+    """Describes an editable parameter (widget) on a node.
+
+    Parameters are user-configurable values that live on the node card.
+    Like ComfyUI widgets, a parameter may be overridden by connecting
+    an incoming wire to the corresponding input port — the widget then
+    becomes an input and the default value is ignored.
+
+    Widget-specific hints (number min/max/step, select options, etc.)
+    go into the free-form ``ui`` dict so the base schema doesn't grow
+    as new widget kinds are added. The frontend renderer dispatches on
+    ``param_type`` and reads whichever ``ui`` keys apply.
+    """
+
+    name: str = Field(..., description="Parameter identifier")
+    param_type: Literal["number", "string", "boolean", "select"] = Field(
+        ..., description="Widget type for the frontend"
+    )
+    default: Any = Field(default=None, description="Default value")
+    description: str = Field(default="", description="Human-readable label")
+    ui: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Widget-specific hints consumed by the frontend renderer. "
+            "Number widgets read ``min``/``max``/``step``; select "
+            "widgets read ``options``; plugin-defined widget kinds may "
+            "use any keys they like."
+        ),
+    )
+    convertible_to_input: bool = Field(
+        default=True,
+        description=(
+            "If True, this parameter can be overridden by connecting an "
+            "input wire (ComfyUI-style widget-to-input conversion)."
+        ),
+    )
+
+
+class NodeDefinition(BaseModel):
+    """Static metadata describing a node type."""
+
+    node_type_id: str = Field(..., description="Unique node type identifier")
+    display_name: str = Field(..., description="Human-readable name")
+    category: str = Field(default="general", description="Category for grouping")
+    description: str = Field(default="", description="What this node does")
+    inputs: list[NodePort] = Field(default_factory=list)
+    outputs: list[NodePort] = Field(default_factory=list)
+    params: list[NodeParam] = Field(
+        default_factory=list,
+        description="Editable parameters (widgets) displayed on the node card.",
+    )
+    continuous: bool = Field(
+        default=False,
+        description=(
+            "If True, source nodes (no inputs) re-execute continuously "
+            "instead of executing once. Useful for streaming generators."
+        ),
+    )
+    pipeline_meta: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Rich pipeline-only metadata (config_schema, mode_defaults, "
+            "supports_lora, supports_vace, etc.) for nodes that are "
+            ":class:`Pipeline` subclasses. ``None`` for plain nodes. "
+            "Populated by ``Pipeline.get_definition()`` from the config "
+            "class's ``get_schema_with_metadata()``."
+        ),
+    )
+
+
+class BaseNode(ABC):
+    """Abstract base class for all backend node types.
+
+    Subclasses must set ``node_type_id`` as a ``ClassVar`` and implement
+    ``get_definition()``. Execution contracts (e.g. ``execute(inputs)`` for
+    pull-based execution, or ``setup(emit_output) / update_input(...)`` for
+    event-driven execution) are defined by concrete execution backends and
+    not by this base class.
+    """
+
+    node_type_id: ClassVar[str]
+
+    def __init__(self, node_id: str, config: dict[str, Any] | None = None):
+        self.node_id = node_id
+        self.config = config or {}
+
+    @classmethod
+    @abstractmethod
+    def get_definition(cls) -> NodeDefinition:
+        """Return static metadata for this node type."""

--- a/src/scope/core/nodes/registry.py
+++ b/src/scope/core/nodes/registry.py
@@ -1,0 +1,90 @@
+"""Unified registry for every node type on the graph (plain nodes + pipelines)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import BaseNode, NodeDefinition
+
+logger = logging.getLogger(__name__)
+
+
+def _derive_node_type_id(node_class: type) -> str | None:
+    """Return the registry key for a node class, or None if not derivable.
+
+    Plain nodes carry the id as the ``node_type_id`` classvar; pipelines
+    keep it on their config class as ``pipeline_id``.
+    """
+    node_type_id = getattr(node_class, "node_type_id", None)
+    if node_type_id is not None:
+        return node_type_id
+    # Lazy import: nodes.registry is loaded before pipelines.interface.
+    # Narrow to ImportError so real bugs (AttributeError on a broken
+    # config class, typos in pipeline_id, etc.) surface instead of being
+    # silently swallowed.
+    try:
+        from scope.core.pipelines.interface import Pipeline
+    except ImportError:
+        return None
+
+    if issubclass(node_class, Pipeline):
+        return node_class.get_config_class().pipeline_id
+    return None
+
+
+class NodeRegistry:
+    """Central registry for all available node types."""
+
+    _nodes: dict[str, type[BaseNode]] = {}
+
+    @classmethod
+    def register(cls, node_class: type[BaseNode]) -> None:
+        """Register a :class:`BaseNode` subclass (plain node or pipeline)."""
+        node_type_id = _derive_node_type_id(node_class)
+        if node_type_id is None:
+            raise ValueError(
+                f"Cannot determine node_type_id for {node_class.__name__}; "
+                "set a ClassVar[str] `node_type_id` on plain nodes or a "
+                "`pipeline_id` on the pipeline config class."
+            )
+        existing = cls._nodes.get(node_type_id)
+        if existing is not None and existing is not node_class:
+            logger.warning(
+                "Node type '%s' already registered by %s; overwriting with %s. "
+                "Check for duplicate register_nodes/register_pipelines hooks "
+                "or plugins registering the same class twice.",
+                node_type_id,
+                existing.__name__,
+                node_class.__name__,
+            )
+        cls._nodes[node_type_id] = node_class
+        logger.debug("Registered node type: %s", node_type_id)
+
+    @classmethod
+    def get(cls, node_type_id: str) -> type[BaseNode] | None:
+        return cls._nodes.get(node_type_id)
+
+    @classmethod
+    def is_registered(cls, node_type_id: str) -> bool:
+        return node_type_id in cls._nodes
+
+    @classmethod
+    def list_node_types(cls) -> list[str]:
+        return list(cls._nodes.keys())
+
+    @classmethod
+    def get_all_definitions(cls) -> list[NodeDefinition]:
+        return [nc.get_definition() for nc in cls._nodes.values()]
+
+    @classmethod
+    def unregister(cls, node_type_id: str) -> bool:
+        if node_type_id in cls._nodes:
+            del cls._nodes[node_type_id]
+            return True
+        return False
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._nodes.clear()

--- a/src/scope/core/pipelines/interface.py
+++ b/src/scope/core/pipelines/interface.py
@@ -1,12 +1,25 @@
-"""Base interface for all pipelines."""
+"""Base interface for all pipelines.
 
+A :class:`Pipeline` is a :class:`scope.core.nodes.BaseNode` subclass —
+the "heavy" kind that batches video frames, loads GPU models, and
+carries a rich Pydantic config class. The graph editor and user-facing
+docs call them *Nodes*; the name ``Pipeline`` survives as the
+implementation base class so existing subclasses and plugins keep
+working unchanged.
+"""
+
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from scope.core.nodes.base import BaseNode, NodeDefinition, NodePort
+
 if TYPE_CHECKING:
     from .schema import BasePipelineConfig
+
+logger = logging.getLogger(__name__)
 
 
 class Requirements(BaseModel):
@@ -15,49 +28,66 @@ class Requirements(BaseModel):
     input_size: int
 
 
-class Pipeline(ABC):
-    """Abstract base class for all pipelines.
+class Pipeline(BaseNode, ABC):
+    """Abstract base class for video-pipeline nodes.
 
-    Pipelines must implement get_config_class() to return their Pydantic config model.
-    This enables:
-    - Validation via model_validate() / model_validate_json()
-    - JSON Schema generation via model_json_schema()
-    - Type-safe configuration access
-    - API introspection and automatic UI generation
-
-    See schema.py for the BasePipelineConfig model and pipeline-specific configs.
-    For multi-mode pipeline support (text/video), pipelines use helper functions
-    from defaults.py (resolve_input_mode, apply_mode_defaults_to_state, etc.).
+    Subclasses implement ``__call__`` (the per-chunk processing
+    function) and ``get_config_class`` (returning a Pydantic config
+    that drives validation, JSON-schema generation, the parameter
+    panel, and parameter defaults). Everything else — registry,
+    plugin hook, graph editor — is the same as for plain nodes.
     """
 
     @classmethod
     def get_config_class(cls) -> type["BasePipelineConfig"]:
         """Return the Pydantic config class for this pipeline.
 
-        The config class should inherit from BasePipelineConfig and define:
-        - pipeline_id: Unique identifier
-        - pipeline_name: Human-readable name
-        - pipeline_description: Capabilities description
-        - pipeline_version: Version string
-        - Default parameter values for the pipeline
-
-        Returns:
-            Pydantic config model class
-
-        Note:
-            Subclasses should override this method to return their config class.
-            The default implementation returns BasePipelineConfig.
-
-        Example:
-            from .schema import LongLiveConfig
-
-            @classmethod
-            def get_config_class(cls) -> type[BasePipelineConfig]:
-                return LongLiveConfig
+        Subclasses override to return their concrete config; the
+        default returns ``BasePipelineConfig``.
         """
         from .schema import BasePipelineConfig
 
         return BasePipelineConfig
+
+    @classmethod
+    def get_definition(cls) -> NodeDefinition:
+        """Project the pipeline's config class into a :class:`NodeDefinition`.
+
+        Populates the compact node-catalog fields (id, ports, etc.)
+        and stuffs the full ``get_schema_with_metadata()`` output into
+        ``pipeline_meta``, which is the rich data ``PipelineNode.tsx``
+        renders in the parameter panel. ``params`` is left empty
+        because the Pydantic schema is too structured to flatten into
+        ``NodeParam[]`` widgets.
+        """
+        config = cls.get_config_class()
+        try:
+            pipeline_meta = config.get_schema_with_metadata()
+        except Exception as e:
+            logger.warning(
+                "Failed to build pipeline_meta for %s: %s. "
+                "Node will be exposed without full config metadata.",
+                getattr(config, "pipeline_id", cls.__name__),
+                e,
+            )
+            pipeline_meta = None
+        return NodeDefinition(
+            node_type_id=config.pipeline_id,
+            display_name=getattr(config, "pipeline_name", config.pipeline_id),
+            category="pipeline",
+            description=getattr(config, "pipeline_description", "") or "",
+            inputs=[
+                NodePort(name=name, port_type="video")
+                for name in (getattr(config, "inputs", ["video"]) or ["video"])
+            ],
+            outputs=[
+                NodePort(name=name, port_type="video")
+                for name in (getattr(config, "outputs", ["video"]) or ["video"])
+            ],
+            params=[],
+            continuous=False,
+            pipeline_meta=pipeline_meta,
+        )
 
     @abstractmethod
     def __call__(self, **kwargs) -> dict:

--- a/src/scope/core/pipelines/interface.py
+++ b/src/scope/core/pipelines/interface.py
@@ -64,13 +64,25 @@ class Pipeline(BaseNode, ABC):
         try:
             pipeline_meta = config.get_schema_with_metadata()
         except Exception as e:
-            logger.warning(
+            # Log at error level (+ traceback) so this doesn't silently
+            # hide a broken plugin, but still return a degraded stub so
+            # the pipeline stays visible in the catalog and the schemas
+            # endpoint doesn't 500 the whole registry for one bad entry.
+            logger.error(
                 "Failed to build pipeline_meta for %s: %s. "
-                "Node will be exposed without full config metadata.",
+                "Pipeline will be exposed with a degraded payload "
+                "(identity fields only, no config_schema).",
                 getattr(config, "pipeline_id", cls.__name__),
                 e,
+                exc_info=True,
             )
-            pipeline_meta = None
+            pipeline_meta = {
+                "id": getattr(config, "pipeline_id", cls.__name__),
+                "name": getattr(config, "pipeline_name", cls.__name__),
+                "description": getattr(config, "pipeline_description", "") or "",
+                "version": getattr(config, "pipeline_version", ""),
+                "schema_error": str(e),
+            }
         return NodeDefinition(
             node_type_id=config.pipeline_id,
             display_name=getattr(config, "pipeline_name", config.pipeline_id),

--- a/src/scope/core/pipelines/registry.py
+++ b/src/scope/core/pipelines/registry.py
@@ -1,8 +1,10 @@
-"""Pipeline registry for centralized pipeline management.
+"""Pipeline registry — a filtering view over :class:`NodeRegistry`.
 
-This module provides a registry pattern to eliminate if/elif chains when
-accessing pipelines by ID. It enables dynamic pipeline discovery and
-metadata retrieval.
+Pipelines and plain custom nodes share the same ``NodeRegistry._nodes``
+storage. ``PipelineRegistry`` projects that storage down to entries
+whose class is a :class:`Pipeline` subclass and exposes the same API
+the rest of the codebase always used, so existing call sites and
+plugins keep working unchanged.
 """
 
 import importlib
@@ -11,6 +13,8 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from scope.core.nodes.registry import NodeRegistry
+
 if TYPE_CHECKING:
     from .interface import Pipeline
     from .schema import BasePipelineConfig
@@ -18,83 +22,67 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class PipelineRegistry:
-    """Registry for managing available pipelines."""
+def _is_pipeline(node_class: object) -> bool:
+    """Return True when ``node_class`` is a :class:`Pipeline` subclass.
 
-    _pipelines: dict[str, type["Pipeline"]] = {}
+    Lazily imports :class:`Pipeline` to dodge the import cycle between
+    the pipelines and nodes packages at module load time.
+    """
+    from .interface import Pipeline
+
+    return isinstance(node_class, type) and issubclass(node_class, Pipeline)
+
+
+class PipelineRegistry:
+    """Filtering view over :class:`NodeRegistry` for pipeline classes."""
 
     @classmethod
     def register(cls, pipeline_id: str, pipeline_class: type["Pipeline"]) -> None:
-        """Register a pipeline class with its ID.
+        """Plant a pipeline class into the unified :class:`NodeRegistry`.
 
-        Args:
-            pipeline_id: Unique identifier for the pipeline
-            pipeline_class: Pipeline class to register
+        Delegates to ``NodeRegistry.register`` so the same logging and
+        id-derivation path runs for built-in pipelines and plugin nodes
+        alike. The explicit ``pipeline_id`` argument is asserted against
+        the derived id to catch drift between the registry key and the
+        config class's ``pipeline_id``.
         """
-        cls._pipelines[pipeline_id] = pipeline_class
+        config_pipeline_id = pipeline_class.get_config_class().pipeline_id
+        if pipeline_id != config_pipeline_id:
+            class_name = getattr(pipeline_class, "__name__", repr(pipeline_class))
+            raise ValueError(
+                f"Pipeline id mismatch: registered as '{pipeline_id}' but "
+                f"{class_name}.get_config_class().pipeline_id is "
+                f"'{config_pipeline_id}'."
+            )
+        NodeRegistry.register(pipeline_class)
 
     @classmethod
     def get(cls, pipeline_id: str) -> type["Pipeline"] | None:
-        """Get a pipeline class by its ID.
-
-        Args:
-            pipeline_id: Pipeline identifier
-
-        Returns:
-            Pipeline class if found, None otherwise
-        """
-        return cls._pipelines.get(pipeline_id)
+        node_class = NodeRegistry.get(pipeline_id)
+        return node_class if _is_pipeline(node_class) else None
 
     @classmethod
     def unregister(cls, pipeline_id: str) -> bool:
-        """Remove a pipeline from the registry.
-
-        Args:
-            pipeline_id: Pipeline identifier to remove
-
-        Returns:
-            True if pipeline was removed, False if not found
-        """
-        if pipeline_id in cls._pipelines:
-            del cls._pipelines[pipeline_id]
-            return True
-        return False
+        if cls.get(pipeline_id) is None:
+            return False
+        return NodeRegistry.unregister(pipeline_id)
 
     @classmethod
     def is_registered(cls, pipeline_id: str) -> bool:
-        """Check if a pipeline is registered.
-
-        Args:
-            pipeline_id: Pipeline identifier
-
-        Returns:
-            True if pipeline is registered, False otherwise
-        """
-        return pipeline_id in cls._pipelines
+        return cls.get(pipeline_id) is not None
 
     @classmethod
     def get_config_class(cls, pipeline_id: str) -> type["BasePipelineConfig"] | None:
-        """Get config class for a specific pipeline.
-
-        Args:
-            pipeline_id: Pipeline identifier
-
-        Returns:
-            Pydantic config class if found, None otherwise
-        """
         pipeline_class = cls.get(pipeline_id)
-        if pipeline_class is None:
-            return None
-        return pipeline_class.get_config_class()
+        return pipeline_class.get_config_class() if pipeline_class else None
 
     @classmethod
     def list_pipelines(cls) -> list[str]:
-        """Get list of all registered pipeline IDs.
-
-        Returns:
-            List of pipeline IDs
-        """
-        return list(cls._pipelines.keys())
+        return [
+            pid
+            for pid in NodeRegistry.list_node_types()
+            if _is_pipeline(NodeRegistry.get(pid))
+        ]
 
     @classmethod
     def chain_produces_video(cls, pipeline_ids: list[str]) -> bool:
@@ -246,28 +234,41 @@ def _register_pipelines():
 
 
 def _initialize_registry():
-    """Initialize registry with built-in pipelines and plugins."""
+    """Initialize registry with built-in pipelines, nodes, and plugins."""
     # Register built-in pipelines first
     _register_pipelines()
 
-    # Load and register plugin pipelines
+    # Register built-in nodes (no-op on the base abstraction branch)
+    from scope.core.nodes import register_builtin_nodes
+
+    register_builtin_nodes()
+
+    # Load and register plugins. The unified register_plugin_nodes fires
+    # both register_pipelines and register_nodes hooks, so old and new
+    # plugins are picked up in one call.
     try:
         from scope.core.plugins import (
             ensure_plugins_installed,
             load_plugins,
-            register_plugin_pipelines,
+            register_plugin_nodes,
         )
 
         ensure_plugins_installed()
         load_plugins()
-        register_plugin_pipelines(PipelineRegistry)
+        register_plugin_nodes()
     except Exception as e:
         logger.error(
             f"Failed to load plugins: {e}. Built-in pipelines are still available."
         )
 
+    from scope.core.nodes.registry import NodeRegistry
+
     pipeline_count = len(PipelineRegistry.list_pipelines())
-    logger.info(f"Registry initialized with {pipeline_count} pipeline(s)")
+    node_count = len(NodeRegistry.list_node_types())
+    logger.info(
+        f"Registry initialized with {pipeline_count} pipeline(s) and "
+        f"{node_count} node(s)"
+    )
 
 
 # Auto-register pipelines on module import

--- a/src/scope/core/plugins/__init__.py
+++ b/src/scope/core/plugins/__init__.py
@@ -14,6 +14,7 @@ from .manager import (
     get_plugin_manager,
     load_plugins,
     pm,
+    register_plugin_nodes,
     register_plugin_pipelines,
 )
 
@@ -22,6 +23,7 @@ __all__ = [
     "ensure_plugins_installed",
     "load_plugins",
     "pm",
+    "register_plugin_nodes",
     "register_plugin_pipelines",
     "get_plugin_manager",
     "FailedPluginInfo",

--- a/src/scope/core/plugins/hookspecs.py
+++ b/src/scope/core/plugins/hookspecs.py
@@ -22,3 +22,17 @@ class ScopeHookSpec:
             def register_pipelines(register):
                 register(MyPipeline)
         """
+
+    @hookspec
+    def register_nodes(self, register):
+        """Register custom node types.
+
+        Args:
+            register: Callback to register node classes.
+                     Usage: register(NodeClass)
+
+        Example:
+            @scope.core.hookimpl
+            def register_nodes(register):
+                register(MyCustomNode)
+        """

--- a/src/scope/core/plugins/manager.py
+++ b/src/scope/core/plugins/manager.py
@@ -550,30 +550,36 @@ class PluginManager:
         with self._lock:
             return list(self._failed_plugins)
 
-    def register_plugin_pipelines(self, registry: "PipelineRegistry") -> None:
-        """Call register_pipelines hook for all plugins.
+    def register_plugin_nodes(self, registry: Any = None) -> None:
+        """Fire ``register_nodes`` and ``register_pipelines`` hooks.
 
-        Args:
-            registry: PipelineRegistry to register pipelines with
+        Both hooks plant into the unified :class:`NodeRegistry` storage,
+        so existing plugins using ``register_pipelines(register)`` keep
+        working unchanged alongside new ones using ``register_nodes``.
+        The ``registry`` argument is accepted for legacy callers but
+        ignored — the unified storage is always used.
         """
+        from scope.core.nodes.registry import NodeRegistry
+        from scope.core.pipelines.registry import PipelineRegistry
+
+        del registry  # legacy parameter, kept for callsite compat
+
         with self._lock:
-            # Clear previous mappings
             self._pipeline_to_plugin.clear()
 
-            def register_callback(pipeline_class: Any) -> None:
-                """Callback function passed to plugins."""
-                config_class = pipeline_class.get_config_class()
-                pipeline_id = config_class.pipeline_id
-                registry.register(pipeline_id, pipeline_class)
+            def register_callback(node_class: Any) -> None:
+                NodeRegistry.register(node_class)
+                node_id = getattr(node_class, "node_type_id", None) or (
+                    node_class.get_config_class().pipeline_id
+                )
+                logger.info(f"Registered plugin node: {node_id}")
 
-                # Track which plugin owns this pipeline
-                # We'll update this mapping after the hook call
-                logger.info(f"Registered plugin pipeline: {pipeline_id}")
-
+            self._pm.hook.register_nodes(register=register_callback)
             self._pm.hook.register_pipelines(register=register_callback)
+            self._update_pipeline_plugin_mapping(PipelineRegistry)
 
-            # Update pipeline-to-plugin mapping by checking which plugins provide which pipelines
-            self._update_pipeline_plugin_mapping(registry)
+    # Backwards-compat alias for internal callers using the legacy name.
+    register_plugin_pipelines = register_plugin_nodes
 
     def _update_pipeline_plugin_mapping(self, registry: "PipelineRegistry") -> None:
         """Update the mapping of pipeline IDs to plugin names."""
@@ -1658,10 +1664,15 @@ def load_plugins() -> None:
     get_plugin_manager().load_plugins()
 
 
-def register_plugin_pipelines(registry: "PipelineRegistry") -> None:
-    """Call register_pipelines hook for all plugins.
+def register_plugin_nodes(registry: Any = None) -> None:
+    """Fire ``register_nodes`` + ``register_pipelines`` hooks.
 
-    Args:
-        registry: PipelineRegistry to register pipelines with
+    Both hookspecs plant into the unified :class:`NodeRegistry` storage,
+    so old and new plugins coexist. The ``registry`` argument is kept
+    for legacy callers and ignored.
     """
-    get_plugin_manager().register_plugin_pipelines(registry)
+    get_plugin_manager().register_plugin_nodes(registry)
+
+
+# Backwards-compat alias for internal callers using the legacy name.
+register_plugin_pipelines = register_plugin_nodes

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -781,15 +781,23 @@ async def get_pipeline_schemas(
         return _pipeline_schemas_cache
 
     from scope.core.nodes.registry import NodeRegistry
+    from scope.core.pipelines.registry import PipelineRegistry
     from scope.core.plugins import get_plugin_manager
 
     plugin_manager = get_plugin_manager()
     pipelines: dict = {}
 
+    # Pipelines always appear — the set is ``PipelineRegistry.list_pipelines()``.
+    # ``pipeline_meta`` is either the full ``get_schema_with_metadata()`` output
+    # or a degraded identity-only stub with a ``schema_error`` field when that
+    # call failed (see ``Pipeline.get_definition``). Either way the pipeline
+    # stays visible in the UI; the legacy behaviour of 500-ing or silently
+    # disappearing on a broken plugin is gone.
+    pipeline_ids = set(PipelineRegistry.list_pipelines())
     for definition in NodeRegistry.get_all_definitions():
-        if definition.pipeline_meta is None:
+        if definition.node_type_id not in pipeline_ids:
             continue
-        schema_data = dict(definition.pipeline_meta)
+        schema_data = dict(definition.pipeline_meta or {})
         schema_data["plugin_name"] = plugin_manager.get_plugin_for_pipeline(
             definition.node_type_id
         )

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -117,14 +117,22 @@ from .scope_cloud_types import ScopeCloudBackend
 from .tempo_router import router as tempo_router
 
 # Cached responses for pipeline schemas, node definitions, and plugin list.
-# Invalidated by _invalidate_plugin_caches() on install/uninstall.
+# Invalidated by _invalidate_plugin_caches() on plugin install/uninstall and
+# on cloud connect/disconnect — the latter matters because cloud mode proxies
+# the schema/definition endpoints to the cloud backend, so the cached payload
+# depends on cloud-mode state and must be rebuilt when it flips.
 _pipeline_schemas_cache: PipelineSchemasResponse | None = None
 _node_definitions_cache: NodeDefinitionsResponse | None = None
 _plugins_list_cache: object | None = None
 
 
 def _invalidate_plugin_caches():
-    """Reset plugin, pipeline schema, and node definition caches after install/uninstall."""
+    """Reset plugin, pipeline schema, and node definition caches.
+
+    Called on plugin install/uninstall and on cloud connect/disconnect so
+    that the next fetch rebuilds the payload from whichever registry is
+    authoritative for the current mode.
+    """
     global _pipeline_schemas_cache, _node_definitions_cache, _plugins_list_cache
     _pipeline_schemas_cache = None
     _node_definitions_cache = None

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -106,6 +106,7 @@ from .schema import (
     IceCandidateRequest,
     IceServerConfig,
     IceServersResponse,
+    NodeDefinitionsResponse,
     PipelineLoadRequest,
     PipelineSchemasResponse,
     PipelineStatusResponse,
@@ -115,16 +116,18 @@ from .schema import (
 from .scope_cloud_types import ScopeCloudBackend
 from .tempo_router import router as tempo_router
 
-# Cached responses for pipeline schemas and plugin list.
+# Cached responses for pipeline schemas, node definitions, and plugin list.
 # Invalidated by _invalidate_plugin_caches() on install/uninstall.
 _pipeline_schemas_cache: PipelineSchemasResponse | None = None
+_node_definitions_cache: NodeDefinitionsResponse | None = None
 _plugins_list_cache: object | None = None
 
 
 def _invalidate_plugin_caches():
-    """Reset plugin and pipeline schema caches after install/uninstall."""
-    global _pipeline_schemas_cache, _plugins_list_cache
+    """Reset plugin, pipeline schema, and node definition caches after install/uninstall."""
+    global _pipeline_schemas_cache, _node_definitions_cache, _plugins_list_cache
     _pipeline_schemas_cache = None
+    _node_definitions_cache = None
     _plugins_list_cache = None
 
     # Also clear the plugin manager's per-plugin update check TTL cache
@@ -761,44 +764,72 @@ async def get_pipeline_schemas(
     http_request: Request,
     cloud_manager: ScopeCloudBackend = Depends(get_scope_cloud),
 ):
-    """Get configuration schemas and defaults for all available pipelines.
+    """Compat alias for the pipeline-rich subset of the unified node catalog.
 
-    Returns the output of each pipeline's get_schema_with_metadata() method,
-    which includes:
-    - Pipeline metadata (id, name, description, version)
-    - supported_modes: List of supported input modes ("text", "video")
-    - default_mode: Default input mode for this pipeline
-    - mode_defaults: Mode-specific default overrides (if any)
-    - config_schema: Full JSON schema with defaults
+    Derives its response from the unified :class:`NodeRegistry` —
+    every entry whose :attr:`NodeDefinition.pipeline_meta` is set is a
+    pipeline, and ``pipeline_meta`` already holds the full output of
+    ``get_schema_with_metadata()`` (config_schema, mode_defaults,
+    supports_lora, supports_vace, etc.). Kept so existing frontend
+    callers in ``usePipelines.ts`` keep working without migration; new
+    code should read from ``GET /api/v1/nodes/definitions`` instead.
 
-    The frontend should use this as the source of truth for parameter defaults.
-
-    In cloud mode (when connected to cloud), this proxies the request to the
-    cloud-hosted scope backend to get the available pipelines there.
+    In cloud mode this proxies to the cloud-hosted scope backend.
     """
     global _pipeline_schemas_cache
     if _pipeline_schemas_cache is not None:
         return _pipeline_schemas_cache
 
-    from scope.core.pipelines.registry import PipelineRegistry
+    from scope.core.nodes.registry import NodeRegistry
     from scope.core.plugins import get_plugin_manager
 
     plugin_manager = get_plugin_manager()
     pipelines: dict = {}
 
-    for pipeline_id in PipelineRegistry.list_pipelines():
-        config_class = PipelineRegistry.get_config_class(pipeline_id)
-        if config_class:
-            # get_schema_with_metadata() includes supported_modes, default_mode,
-            # and mode_defaults directly from the config class
-            schema_data = config_class.get_schema_with_metadata()
-            schema_data["plugin_name"] = plugin_manager.get_plugin_for_pipeline(
-                pipeline_id
-            )
-            pipelines[pipeline_id] = schema_data
+    for definition in NodeRegistry.get_all_definitions():
+        if definition.pipeline_meta is None:
+            continue
+        schema_data = dict(definition.pipeline_meta)
+        schema_data["plugin_name"] = plugin_manager.get_plugin_for_pipeline(
+            definition.node_type_id
+        )
+        pipelines[definition.node_type_id] = schema_data
 
     response = PipelineSchemasResponse(pipelines=pipelines)
     _pipeline_schemas_cache = response
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Node definitions
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/v1/nodes/definitions", response_model=NodeDefinitionsResponse)
+async def get_node_definitions():
+    """Return definitions for every registered node — pipelines included.
+
+    The unified discovery endpoint. Pipelines (Pipeline subclasses)
+    appear with ``pipeline_meta`` populated; plain custom nodes leave
+    ``pipeline_meta`` ``None``. Frontend consumers that only want plain
+    nodes filter on ``pipeline_meta == null`` client-side; consumers
+    that want rich pipeline data read from ``pipeline_meta`` directly.
+
+    Memoized in ``_node_definitions_cache`` and invalidated by
+    ``_invalidate_plugin_caches`` whenever a plugin is installed or
+    uninstalled, so the modal open / graph hydrate hot paths don't
+    rebuild the payload (including full ``pipeline_meta``) every call.
+    """
+    global _node_definitions_cache
+    if _node_definitions_cache is not None:
+        return _node_definitions_cache
+
+    from scope.core.nodes.registry import NodeRegistry
+
+    response = NodeDefinitionsResponse(
+        nodes=[d.model_dump() for d in NodeRegistry.get_all_definitions()]
+    )
+    _node_definitions_cache = response
     return response
 
 

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -814,7 +814,11 @@ async def get_pipeline_schemas(
 
 
 @app.get("/api/v1/nodes/definitions", response_model=NodeDefinitionsResponse)
-async def get_node_definitions():
+@cloud_proxy()
+async def get_node_definitions(
+    http_request: Request,
+    cloud_manager: ScopeCloudBackend = Depends(get_scope_cloud),
+):
     """Return definitions for every registered node — pipelines included.
 
     The unified discovery endpoint. Pipelines (Pipeline subclasses)
@@ -827,6 +831,10 @@ async def get_node_definitions():
     ``_invalidate_plugin_caches`` whenever a plugin is installed or
     uninstalled, so the modal open / graph hydrate hot paths don't
     rebuild the payload (including full ``pipeline_meta``) every call.
+
+    In cloud mode this proxies to the cloud-hosted scope backend so the
+    Add Node modal and graph hydrator see cloud-registered nodes (plain
+    and pipeline) rather than just the local set.
     """
     global _node_definitions_cache
     if _node_definitions_cache is not None:

--- a/src/scope/server/graph_schema.py
+++ b/src/scope/server/graph_schema.py
@@ -29,7 +29,7 @@ Example (YOLO plugin + Longlive with shared input video):
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -41,13 +41,24 @@ class GraphNode(BaseModel):
         ...,
         description="Unique node id (e.g. 'input', 'yolo_plugin', 'longlive', 'output')",
     )
-    type: Literal["source", "pipeline", "sink", "record"] = Field(
+    type: Literal["source", "pipeline", "sink", "record", "node"] = Field(
         ...,
-        description="source = external input, pipeline = pipeline instance, sink = output, record = file recorder",
+        description=(
+            "source = external input, pipeline = pipeline instance, "
+            "sink = output, record = file recorder, node = custom backend node"
+        ),
     )
     pipeline_id: str | None = Field(
         default=None,
         description="Pipeline ID (registry key) when type is 'pipeline'",
+    )
+    node_type_id: str | None = Field(
+        default=None,
+        description="Node type ID (NodeRegistry key) when type is 'node'",
+    )
+    params: dict[str, Any] | None = Field(
+        default=None,
+        description="Per-node parameter values for custom nodes",
     )
     source_mode: str | None = Field(
         default=None,
@@ -114,6 +125,10 @@ class GraphConfig(BaseModel):
         """Return node ids that are record nodes."""
         return [n.id for n in self.nodes if n.type == "record"]
 
+    def get_backend_node_ids(self) -> list[str]:
+        """Return node ids that are backend (custom) nodes."""
+        return [n.id for n in self.nodes if n.type == "node"]
+
     def edges_from(self, node_id: str) -> list[GraphEdge]:
         """Return edges whose source is the given node."""
         return [e for e in self.edges if e.from_node == node_id]
@@ -149,10 +164,12 @@ class GraphConfig(BaseModel):
         if not self.get_sink_node_ids():
             errors.append("Graph must have at least one sink node")
 
-        # Pipeline nodes must have pipeline_id
+        # Pipeline nodes must have pipeline_id; backend nodes need node_type_id
         for node in self.nodes:
             if node.type == "pipeline" and not node.pipeline_id:
                 errors.append(f"Pipeline node '{node.id}' is missing pipeline_id")
+            if node.type == "node" and not node.node_type_id:
+                errors.append(f"Node '{node.id}' is missing node_type_id")
 
         # Edge references must point to existing nodes
         node_id_set = set(node_ids)

--- a/src/scope/server/schema.py
+++ b/src/scope/server/schema.py
@@ -559,6 +559,18 @@ class PipelineSchemasResponse(BaseModel):
     pipelines: dict = Field(..., description="Pipeline schemas keyed by pipeline ID")
 
 
+class NodeDefinitionsResponse(BaseModel):
+    """Response containing definitions for all registered node types.
+
+    Each entry is the ``model_dump()`` of a :class:`NodeDefinition`
+    (pipelines carry rich ``pipeline_meta``; plain nodes leave it null).
+    """
+
+    nodes: list[dict[str, Any]] = Field(
+        ..., description="Flat list of node definitions"
+    )
+
+
 class AssetFileInfo(BaseModel):
     """Metadata for an available asset file on disk."""
 

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -2,8 +2,15 @@
 
 from typing import ClassVar
 
+# Import BasePipelineConfig from ``base_schema`` rather than the ``schema``
+# re-export. ``schema`` triggers ``longlive/__init__.py`` → ``LongLivePipeline``
+# → ``diffusers`` at module load time, which (a) trips the freezegun tests in
+# ``test_logs_config`` when freezegun walks lazy-loaded diffusers attributes
+# and (b) cascades into a pydantic v1 ``ConstrainedDate`` metaclass conflict
+# in every downstream test that imports ``scope.server.app``. Pulling from
+# ``base_schema`` keeps test collection lightweight and side-effect-free.
+from scope.core.pipelines.base_schema import BasePipelineConfig
 from scope.core.pipelines.interface import Pipeline
-from scope.core.pipelines.schema import BasePipelineConfig
 
 
 def _make_pipeline_class(registration_id: str) -> type[Pipeline]:

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -1,6 +1,26 @@
 """Unit tests for PipelineRegistry unregister and is_registered methods."""
 
-from unittest.mock import MagicMock
+from typing import ClassVar
+
+from scope.core.pipelines.interface import Pipeline
+from scope.core.pipelines.schema import BasePipelineConfig
+
+
+def _make_pipeline_class(registration_id: str) -> type[Pipeline]:
+    """Build a minimal Pipeline subclass whose config carries the given id."""
+
+    class _TestConfig(BasePipelineConfig):
+        pipeline_id: ClassVar[str] = registration_id
+
+    class _TestPipeline(Pipeline):
+        @classmethod
+        def get_config_class(cls) -> type[BasePipelineConfig]:
+            return _TestConfig
+
+        def __call__(self, **kwargs) -> dict:
+            return {}
+
+    return _TestPipeline
 
 
 class TestPipelineRegistryUnregister:
@@ -8,23 +28,15 @@ class TestPipelineRegistryUnregister:
 
     def test_unregister_removes_pipeline(self):
         """Should remove a registered pipeline from the registry."""
-        # Import fresh to avoid state from other tests
         from scope.core.pipelines.registry import PipelineRegistry
 
-        # Create a mock pipeline class
-        mock_pipeline = MagicMock()
-        mock_config = MagicMock()
-        mock_config.pipeline_id = "test-pipeline"
-        mock_pipeline.get_config_class.return_value = mock_config
+        pipeline_cls = _make_pipeline_class("test-unregister-1")
 
-        # Register the pipeline
-        PipelineRegistry.register("test-unregister-1", mock_pipeline)
+        PipelineRegistry.register("test-unregister-1", pipeline_cls)
         assert "test-unregister-1" in PipelineRegistry.list_pipelines()
 
-        # Unregister it
         result = PipelineRegistry.unregister("test-unregister-1")
 
-        # Verify it was removed
         assert result is True
         assert "test-unregister-1" not in PipelineRegistry.list_pipelines()
 
@@ -32,10 +44,9 @@ class TestPipelineRegistryUnregister:
         """Should return True when pipeline was found and removed."""
         from scope.core.pipelines.registry import PipelineRegistry
 
-        mock_pipeline = MagicMock()
+        pipeline_cls = _make_pipeline_class("test-unregister-2")
 
-        # Register then unregister
-        PipelineRegistry.register("test-unregister-2", mock_pipeline)
+        PipelineRegistry.register("test-unregister-2", pipeline_cls)
         result = PipelineRegistry.unregister("test-unregister-2")
 
         assert result is True
@@ -56,14 +67,12 @@ class TestPipelineRegistryIsRegistered:
         """Should return True for registered pipeline."""
         from scope.core.pipelines.registry import PipelineRegistry
 
-        mock_pipeline = MagicMock()
+        pipeline_cls = _make_pipeline_class("test-is-registered-1")
 
-        # Register the pipeline
-        PipelineRegistry.register("test-is-registered-1", mock_pipeline)
+        PipelineRegistry.register("test-is-registered-1", pipeline_cls)
 
         assert PipelineRegistry.is_registered("test-is-registered-1") is True
 
-        # Cleanup
         PipelineRegistry.unregister("test-is-registered-1")
 
     def test_is_registered_returns_false(self):


### PR DESCRIPTION
## Summary

Introduces the fine-grained backend node framework and frontend catalog that surface plugin-defined processing nodes in the graph editor. Pipelines are folded into the same `BaseNode` hierarchy so plugin authors and users see one concept. This is the metadata/discovery foundation for the execution-scheduler and ACEStep follow-ups; execution contracts are layered on by those branches.

## Backend

- **`src/scope/core/nodes/`** (new): `BaseNode` ABC, Pydantic schemas (`NodeDefinition` / `NodePort` / `NodeParam`), and a `NodeRegistry` keyed by `node_type_id`. Widget hints (number `min`/`max`/`step`, select `options`, …) live in a free-form `NodeParam.ui: dict | None` so the base schema doesn't grow as new widget kinds appear.
- **Pipeline ↔ Node unification**: `Pipeline` is now `class Pipeline(BaseNode, ABC)` — pure inheritance change. Concrete pipeline subclasses (longlive, krea, LTX-2, VACE, streamdiffusion, …) touch zero lines. `Pipeline.get_definition()` projects the config class into a `NodeDefinition` and stuffs the full `get_schema_with_metadata()` output into `pipeline_meta`.
- **`PipelineRegistry`** becomes a filtering view over `NodeRegistry`. Every pre-existing call site (`list_pipelines`, `get_config_class`, `chain_produces_*`, `register`, `unregister`, `is_registered`, `get`) keeps its old signature so the server, plugin manager, OSC/DMX docs, workflows resolver, and tests work unchanged. Built-in pipelines route through `NodeRegistry.register` so they share the same id-derivation and debug-log path as plugin nodes, and `pipeline_id` is asserted against the config class to catch drift.
- **Plugins**: new `register_nodes` pluggy hookspec + `PluginManager.register_plugin_nodes` hook caller. Existing `register_pipelines` plugins keep working unchanged — both hooks plant into the unified storage.
- **`graph_schema`**: allow `type="node"` `GraphNode` with `node_type_id` and `params`, a `get_backend_node_ids()` helper, and a validation error when `node_type_id` is missing. Existing `"type": "pipeline"` workflows still load.
- **`GET /api/v1/nodes/definitions`**: the canonical discovery endpoint. Pipelines carry the full config schema as `pipeline_meta`; plain custom nodes leave `pipeline_meta` `None`. `/api/v1/pipelines/schemas` becomes a thin compat alias derived from the same registry, so `usePipelines.ts` and cloud-mode proxy callers keep working without migration.

`BaseNode` intentionally only requires `get_definition()`; execution contracts (push vs. pull) are layered by the specialized branches.

## Frontend

- **`api.ts`**: extend `GraphNode` with `node_type_id` / `params` and add `NodeDefinitionDto`, `NodePortDef`, `NodeParamDef`, and `fetchNodeDefinitions({ signal? })`.
- **`graphUtils.ts`**: add `custom_node` to `FlowNodeData.nodeType` (typed via the canonical `NodePortDef` / `NodeParamDef`) and round-trip `custom_node` ↔ backend `type: "node"` in `graphConfigToFlow` / `flowToGraphConfig`.
- **`CustomNode.tsx`** (new): schema-driven React Flow node rendering input/output ports with port-type colors and ComfyUI-style param widgets (select / boolean / number / text). Number widgets read `p.ui?.min` / `max` / `step`; select widgets read `p.ui?.options`.
- **`AddNodeModal`**: fetch node definitions while open and merge them into the catalog under a new "Plugins" category. Pipelines are filtered out and continue to be added via the existing "Pipeline" placeholder + dropdown UX.
- **`useNodeFactories`**: add `custom_node` to `NodeTypeKey` / `NODE_DEFAULTS` and route the add flow through `extraData`.
- **`useGraphPersistence`**: after import/restore, hydrate every `custom_node` with its definition, preserving saved `customNodeParams` over definition defaults. Hydration runs through an `AbortController` so a stale fetch (rapid reload, unmount) cannot overwrite newer node state.
- **`connectionValidation`**: when either endpoint is a `custom_node`, enforce port-type equality; built-in node streams stay untyped.
- **`PipelineNode` / `contextMenuItems` / `GraphEditor`**: rename the user-facing "Pipeline" label to "Node" / "Model" so the word "pipeline" disappears from the UI; register `custom_node: CustomNode` in `nodeTypes`.

## Backwards compatibility

- Existing `Pipeline` subclasses don't change.
- Existing `register_pipelines` plugins don't change.
- Existing `PipelineRegistry.*` call sites don't change.
- Existing `"type": "pipeline"` saved workflows still load.
- `GraphNode.type` keeps both `"pipeline"` and `"node"` literals.

## Test plan

- [ ] Load Scope and confirm `GET /api/v1/nodes/definitions` returns every registered built-in pipeline (with `pipeline_meta` populated) plus any plugin-registered plain nodes.
- [ ] Open the Add Node modal and verify the "Plugins" category lists backend-registered nodes.
- [ ] Drop a custom node into the graph, save, reload, and verify params and port wiring are preserved.
- [ ] Connect a custom node port to another custom node port of a different `port_type` and verify the connection is rejected.
- [ ] Load an existing pre-PR workflow with `"type": "pipeline"` nodes and verify it still loads without warnings.
- [ ] Confirm an existing `register_pipelines` plugin still loads and its pipelines appear in both `/api/v1/pipelines/schemas` and `/api/v1/nodes/definitions`.
