### PR TITLE
fix: Unify cloud connect and surface connection errors (#873)

### DIFF
--- a/frontend/src/components/onboarding/CloudAuthStep.tsx
+++ b/frontend/src/components/onboarding/CloudAuthStep.tsx
@@ -4,10 +4,9 @@ import { Button } from "../ui/button";
 import {
   isAuthenticated,
   getDaydreamUserDisplayName,
-  getDaydreamUserId,
   redirectToSignIn,
 } from "../../lib/auth";
-import { activateCloudRelay } from "../../lib/onboardingStorage";
+import { connectToCloud } from "../../lib/cloudApi";
 
 type AuthState = "idle" | "waiting" | "success" | "error";
 
@@ -32,7 +31,9 @@ export function CloudAuthStep({ onComplete }: CloudAuthStepProps) {
   useEffect(() => {
     if (authState === "success") {
       setDisplayName(getDaydreamUserDisplayName());
-      activateCloudRelay(getDaydreamUserId());
+      connectToCloud().catch(e =>
+        console.error("[Onboarding] Cloud connect failed:", e)
+      );
       advanceRef.current = setTimeout(onComplete, AUTO_ADVANCE_DELAY_MS);
     }
     return () => {
@@ -46,7 +47,9 @@ export function CloudAuthStep({ onComplete }: CloudAuthStepProps) {
     const handleSuccess = () => {
       setAuthState("success");
       setDisplayName(getDaydreamUserDisplayName());
-      activateCloudRelay(getDaydreamUserId());
+      connectToCloud().catch(e =>
+        console.error("[Onboarding] Cloud connect failed:", e)
+      );
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       advanceRef.current = setTimeout(onComplete, AUTO_ADVANCE_DELAY_MS);
     };

--- a/frontend/src/components/onboarding/CloudConnectingStep.tsx
+++ b/frontend/src/components/onboarding/CloudConnectingStep.tsx
@@ -1,27 +1,12 @@
 import { useEffect, useState, useRef, useCallback } from "react";
-import { Loader2, CheckCircle2 } from "lucide-react";
+import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
 import { useCloudStatus } from "../../hooks/useCloudStatus";
-import { getDaydreamUserId } from "../../lib/auth";
+import { connectToCloud } from "../../lib/cloudApi";
 import { persistSurveyAnswers } from "../../lib/onboardingStorage";
 import { useOnboarding } from "../../contexts/OnboardingContext";
 import { useTelemetry } from "../../contexts/TelemetryContext";
 import { CloudSurveyScreens, type SurveyAnswers } from "./CloudSurveyScreens";
 import { TelemetryDisclosure } from "./TelemetryDisclosure";
-
-/** Fire-and-forget: tell the backend to connect to the cloud relay. */
-async function activateCloudRelay() {
-  const userId = getDaydreamUserId();
-  if (!userId) return;
-  try {
-    await fetch("/api/v1/cloud/connect", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: userId }),
-    });
-  } catch (err) {
-    console.error("[Onboarding] Failed to auto-connect to cloud:", err);
-  }
-}
 
 interface CloudConnectingStepProps {
   onConnected: () => void;
@@ -32,7 +17,8 @@ export function CloudConnectingStep({
   onConnected,
   onBack,
 }: CloudConnectingStepProps) {
-  const { isConnected, isConnecting, connectStage, refresh } = useCloudStatus();
+  const { isConnected, isConnecting, connectStage, error, refresh } =
+    useCloudStatus();
   const { setOnboardingStyle, setSurveyAnswers } = useOnboarding();
   const {
     isDisclosed: telemetryDisclosed,
@@ -55,7 +41,9 @@ export function CloudConnectingStep({
   useEffect(() => {
     if (didConnect.current) return;
     didConnect.current = true;
-    activateCloudRelay().then(() => refresh());
+    connectToCloud()
+      .catch(e => console.error("[Onboarding] Cloud connect failed:", e))
+      .then(() => refresh());
   }, [refresh]);
 
   // Keep polling while this step is visible
@@ -212,6 +200,18 @@ export function CloudConnectingStep({
 
   // --- Survey done, waiting for cloud ---
   if (!isConnected) {
+    if (error) {
+      return (
+        <div className="flex flex-col items-center gap-4 w-full max-w-md mx-auto text-center">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+          <h2 className="text-2xl font-semibold text-foreground">
+            Cloud connection failed
+          </h2>
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      );
+    }
+
     return (
       <div className="flex flex-col items-center gap-6 w-full max-w-md mx-auto text-center">
         <h2 className="text-2xl font-semibold text-foreground">

--- a/frontend/src/components/settings/DaydreamAccountSection.tsx
+++ b/frontend/src/components/settings/DaydreamAccountSection.tsx
@@ -15,11 +15,10 @@ import {
   isAuthenticated,
   redirectToSignIn,
   clearDaydreamAuth,
-  getDaydreamAPIKey,
-  getDaydreamUserId,
   getDaydreamUserDisplayName,
   refreshUserProfile,
 } from "../../lib/auth";
+import { connectToCloud } from "../../lib/cloudApi";
 import { useCloudStatus } from "../../hooks/useCloudStatus";
 
 interface DaydreamAccountSectionProps {
@@ -102,17 +101,10 @@ export function DaydreamAccountSection({
     setError(null);
 
     try {
-      const userId = getDaydreamUserId();
-      const apiKey = getDaydreamAPIKey();
+      const response = await connectToCloud();
 
-      const response = await fetch("/api/v1/cloud/connect", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ user_id: userId, api_key: apiKey }),
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
+      if (!response || !response.ok) {
+        const data = response ? await response.json() : {};
         throw new Error(data.detail || "Connection failed");
       }
 

--- a/frontend/src/lib/cloudApi.ts
+++ b/frontend/src/lib/cloudApi.ts
@@ -1,0 +1,20 @@
+import { getDaydreamAPIKey, getDaydreamUserId } from "./auth";
+
+/**
+ * Connect to the cloud relay. Reads credentials from local auth storage
+ * internally so callers don't need to pass them around.
+ *
+ * Returns the fetch Response so callers can inspect status if needed,
+ * or `null` if no user is signed in.
+ */
+export async function connectToCloud(): Promise<Response | null> {
+  const userId = getDaydreamUserId();
+  if (!userId) return null;
+
+  const apiKey = getDaydreamAPIKey();
+  return fetch("/api/v1/cloud/connect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId, api_key: apiKey }),
+  });
+}

--- a/frontend/src/lib/onboardingStorage.ts
+++ b/frontend/src/lib/onboardingStorage.ts
@@ -72,20 +72,6 @@ export async function persistSurveyAnswers(answers: {
   }
 }
 
-/** Fire-and-forget: tell the backend to connect to the cloud relay. */
-export async function activateCloudRelay(userId: string | null): Promise<void> {
-  if (!userId) return;
-  try {
-    await fetch("/api/v1/cloud/connect", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: userId }),
-    });
-  } catch (err) {
-    console.error("[Onboarding] Failed to auto-connect to cloud:", err);
-  }
-}
-
 /**
  * Reset onboarding so it shows on next launch.
  * Used by Settings → Advanced → "Show onboarding again".


### PR DESCRIPTION
Onboarding's /cloud/connect POST only sent {user_id}, missing api_key. In Livepeer mode this caused cloud connections to fail silently, hanging the UI forever on "Almost there…".

- Extract shared connectToCloud() helper into lib/cloudApi.ts so all call sites (onboarding auth, onboarding connecting, settings toggle) use the same payload with both user_id and api_key

- Remove duplicate activateCloudRelay() from CloudConnectingStep and onboardingStorage

- Surface status.error in CloudConnectingStep's final waiting state instead of spinning indefinitely


(cherry picked from commit f82f01c272e466c2b205d569dc78c7a618b52b13)