### PR TITLE
fix(longlive): add logger + warning when KV cache write is skipped (#921)

### DIFF
--- a/src/scope/core/pipelines/longlive/modules/causal_model.py
+++ b/src/scope/core/pipelines/longlive/modules/causal_model.py
@@ -1,5 +1,6 @@
 # Modified from https://github.com/NVlabs/LongLive
 # SPDX-License-Identifier: CC-BY-NC-SA-4.0
+import logging
 import math
 
 import torch
@@ -13,6 +14,7 @@ from torch.nn.attention.flex_attention import (
 )
 
 from scope.core.pipelines.wan2_1.modules.attention import attention
+
 from .model import (
     WAN_CROSSATTENTION_CLASSES,
     MLPProj,
@@ -29,6 +31,8 @@ from .model import (
 flex_attention = torch.compile(
     flex_attention, dynamic=False, mode="max-autotune-no-cudagraphs"
 )
+
+logger = logging.getLogger(__name__)
 
 
 def causal_rope_apply(x, grid_sizes, freqs, start_frame=0):
@@ -331,6 +335,15 @@ class CausalWanSelfAttention(nn.Module):
                     temp_v[:, write_start_index:local_end_index] = v[
                         :, roped_offset : roped_offset + write_len
                     ]
+                else:
+                    logger.warning(
+                        "KV cache write skipped (roll_and_insert): "
+                        "write_start_index (%d) >= local_end_index (%d) — "
+                        "cache indices may be stale after a rapid mode transition. "
+                        "(See daydreamlive/scope#921)",
+                        write_start_index,
+                        local_end_index,
+                    )
 
                 # Save cache update info for later use
                 cache_update_info = {
@@ -377,6 +390,15 @@ class CausalWanSelfAttention(nn.Module):
                     temp_v[:, write_start_index:local_end_index] = v[
                         :, roped_offset : roped_offset + write_len
                     ]
+                else:
+                    logger.warning(
+                        "KV cache write skipped (direct_insert): "
+                        "write_start_index (%d) >= local_end_index (%d) — "
+                        "cache indices may be stale after a rapid mode transition. "
+                        "(See daydreamlive/scope#921)",
+                        write_start_index,
+                        local_end_index,
+                    )
 
                 # Save cache update info for later use
                 cache_update_info = {


### PR DESCRIPTION
## Summary

Addresses #921.

The `if write_len > 0` guards on both KV cache write paths in `CausalWanSelfAttention.forward()` already prevent the RuntimeError that caused 310+ chunk failures per session (empty tensor slice when `write_start_index == local_end_index`). However, silent skips made it impossible to detect cache-state drift from Grafana logs.

## Changes

- Add `import logging` and `logger = logging.getLogger(__name__)` to `causal_model.py`
- Add `else: logger.warning(...)` on both the **roll_and_insert** and **direct_insert** write paths

The WARNING message includes `write_start_index`, `local_end_index`, and a reference to #921.

## Why this matters

When rapid video↔text mode transitions leave the cache index in a stale state, the skip now surfaces in logs as a WARNING instead of silently passing through. This:
1. Confirms the guard is firing in production
2. Provides the index values needed to diagnose root-cause cache drift
3. Allows Grafana alert rules to key on `KV cache write skipped` if this starts happening frequently

## Testing

- Syntax check: `python3 -c 'import ast; ast.parse(...)'` ✅
- Ruff lint: no new violations introduced ✅

cc @mjh1 @emranemran