### PR TITLE
Fix double-drain of output frames in headless mode

### DIFF
--- a/src/scope/server/headless.py
+++ b/src/scope/server/headless.py
@@ -335,6 +335,11 @@ class HeadlessSession:
 
         self.frame_processor: FrameProcessor = frame_processor
         self.expect_audio = expect_audio
+        # In graph mode this tracks the most recently consumed frame across all
+        # sink queues, not a canonical sink. Callers that need stable per-sink
+        # capture should pass sink_node_id to get_last_frame().
+        # TODO: Revisit whether get_last_frame() should instead use explicit
+        # primary-sink semantics for graph sessions.
         self._last_frame = None
         self._last_frames_by_sink: dict[str, object] = {}
         self._frame_lock = threading.Lock()
@@ -354,6 +359,13 @@ class HeadlessSession:
         self._frame_consumer_running = True
         self._frame_consumer_task = asyncio.create_task(self._consume_frames())
 
+    def _dispatch_video_frame(self, video_frame) -> None:
+        for sink in self._get_sinks_snapshot():
+            try:
+                sink.on_video_frame(video_frame)
+            except Exception as e:
+                self._handle_failed_sink(sink, e, stream_type="video")
+
     async def _consume_frames(self):
         """Pull frames from FrameProcessor so pipeline workers don't stall."""
         from av import VideoFrame
@@ -361,30 +373,35 @@ class HeadlessSession:
         while self._frame_consumer_running and self.frame_processor.running:
             got_any = False
 
-            # Consume from per-sink queues (multi-sink graph mode)
-            for sid in self.frame_processor.get_sink_node_ids():
-                sink_tensor = self.frame_processor.get_from_sink(sid)
-                if sink_tensor is not None:
+            sink_node_ids = self.frame_processor.get_sink_node_ids()
+            if sink_node_ids:
+                # Graph mode: drain each sink queue exactly once. The first sink
+                # still drives the single headless media stream (TS/MP4), while
+                # bare get_last_frame() keeps its existing latest-consumed-frame
+                # semantics across all sinks.
+                for idx, sid in enumerate(sink_node_ids):
+                    sink_tensor = self.frame_processor.get_from_sink(sid)
+                    if sink_tensor is None:
+                        continue
                     got_any = True
-                    frame_np = sink_tensor.numpy()
-                    vf = VideoFrame.from_ndarray(frame_np, format="rgb24")
+                    vf = VideoFrame.from_ndarray(sink_tensor.numpy(), format="rgb24")
                     with self._frame_lock:
                         self._last_frames_by_sink[sid] = vf
                         self._last_frame = vf
-
-            # Also consume from the primary output queue
-            frame_tensor = self.frame_processor.get()
-            if frame_tensor is not None:
-                got_any = True
-                frame_np = frame_tensor.numpy()
-                vf = VideoFrame.from_ndarray(frame_np, format="rgb24")
-                with self._frame_lock:
-                    self._last_frame = vf
-                for sink in self._get_sinks_snapshot():
-                    try:
-                        sink.on_video_frame(vf)
-                    except Exception as e:
-                        self._handle_failed_sink(sink, e, stream_type="video")
+                    # Preserve existing single-stream headless behavior:
+                    # only the first sink feeds TS/MP4 fanout.
+                    if idx == 0:
+                        self._dispatch_video_frame(vf)
+            else:
+                frame_tensor = self.frame_processor.get()
+                if frame_tensor is not None:
+                    got_any = True
+                    vf = VideoFrame.from_ndarray(frame_tensor.numpy(), format="rgb24")
+                    # Without explicit sink queues, the latest frame is simply
+                    # the latest primary output frame consumed by headless.
+                    with self._frame_lock:
+                        self._last_frame = vf
+                    self._dispatch_video_frame(vf)
 
             while True:
                 audio_tensor, sample_rate = self.frame_processor.get_audio()
@@ -518,6 +535,8 @@ class HeadlessSession:
         """Return the most recently cached frame, or None.
 
         If sink_node_id is provided, return the frame from that specific sink.
+        Without sink_node_id in graph mode, this returns the latest frame
+        consumed from any sink rather than a stable primary-sink frame.
         """
         with self._frame_lock:
             if sink_node_id and sink_node_id in self._last_frames_by_sink:

--- a/src/scope/server/mcp_router.py
+++ b/src/scope/server/mcp_router.py
@@ -106,7 +106,10 @@ async def capture_frame(
 
     Returns the most recent rendered frame from the active session
     (WebRTC or headless). When sink_node_id is provided, captures from
-    that specific sink node in a multi-sink graph.
+    that specific sink node in a multi-sink graph. In multi-sink headless
+    sessions, omitting sink_node_id returns the most recently consumed frame
+    from any sink, so callers that need stable per-sink capture should pass
+    sink_node_id explicitly.
     """
     frame = webrtc_manager.get_last_frame(sink_node_id=sink_node_id)
     if frame is None:

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -30,6 +30,33 @@ class _SingleFrameProcessor:
         self.running = False
 
 
+class _SinkOnlyFrameProcessor:
+    def __init__(self, frames_by_sink: dict[str, torch.Tensor]):
+        self.running = True
+        self._sink_ids = list(frames_by_sink.keys())
+        self._frames_by_sink = dict(frames_by_sink)
+        self.get_calls = 0
+
+    def get_sink_node_ids(self):
+        return list(self._sink_ids)
+
+    def get_from_sink(self, sink_node_id):
+        frame = self._frames_by_sink.pop(sink_node_id, None)
+        if not self._frames_by_sink:
+            self.running = False
+        return frame
+
+    def get(self):
+        self.get_calls += 1
+        raise AssertionError("headless graph mode should not call get()")
+
+    def get_audio(self):
+        return None, None
+
+    def stop(self):
+        self.running = False
+
+
 class _CountingRecorder(HeadlessMediaSink):
     def __init__(self):
         self.is_recording = True
@@ -53,6 +80,20 @@ class _CountingRecorder(HeadlessMediaSink):
 class _FailingRecorder(_CountingRecorder):
     def on_video_frame(self, video_frame) -> None:
         raise RuntimeError("synthetic sink failure")
+
+
+class _CollectingSink(HeadlessMediaSink):
+    def __init__(self):
+        self.frames = []
+
+    def on_video_frame(self, video_frame) -> None:
+        self.frames.append(torch.from_numpy(video_frame.to_ndarray(format="rgb24")))
+
+    def on_audio_chunk(self, audio_tensor, sample_rate) -> None:
+        return
+
+    def close(self) -> None:
+        return
 
 
 @pytest.mark.anyio
@@ -87,3 +128,56 @@ async def test_headless_clears_recorder_reference_on_sink_failure():
 
     assert session._recorder is None
     assert recorder not in session._get_sinks_snapshot()
+
+
+@pytest.mark.anyio
+async def test_headless_graph_mode_avoids_primary_queue_double_drain():
+    primary = torch.full((16, 16, 3), 7, dtype=torch.uint8)
+    frame_processor = _SinkOnlyFrameProcessor({"output": primary})
+    session = HeadlessSession(frame_processor=frame_processor)
+
+    sink = _CollectingSink()
+    session.add_media_sink(sink)
+    session._frame_consumer_running = True
+
+    await session._consume_frames()
+
+    assert frame_processor.get_calls == 0
+    assert len(sink.frames) == 1
+    assert torch.equal(sink.frames[0], primary)
+    assert torch.equal(
+        torch.from_numpy(session.get_last_frame("output").to_ndarray(format="rgb24")),
+        primary,
+    )
+
+
+@pytest.mark.anyio
+async def test_headless_graph_mode_keeps_latest_consumed_frame_behavior():
+    primary = torch.full((16, 16, 3), 11, dtype=torch.uint8)
+    secondary = torch.full((16, 16, 3), 22, dtype=torch.uint8)
+    frame_processor = _SinkOnlyFrameProcessor(
+        {"output": primary, "output_1": secondary}
+    )
+    session = HeadlessSession(frame_processor=frame_processor)
+
+    sink = _CollectingSink()
+    session.add_media_sink(sink)
+    session._frame_consumer_running = True
+
+    await session._consume_frames()
+
+    assert frame_processor.get_calls == 0
+    assert len(sink.frames) == 1
+    assert torch.equal(sink.frames[0], primary)
+    assert torch.equal(
+        torch.from_numpy(session.get_last_frame("output").to_ndarray(format="rgb24")),
+        primary,
+    )
+    assert torch.equal(
+        torch.from_numpy(session.get_last_frame("output_1").to_ndarray(format="rgb24")),
+        secondary,
+    )
+    assert torch.equal(
+        torch.from_numpy(session.get_last_frame().to_ndarray(format="rgb24")),
+        secondary,
+    )


### PR DESCRIPTION
Headless graph sessions were draining both per-sink queues and the primary (first) queue in the same consumer loop, allowing one read path to consume frames intended for the other. In practice, this caused headless media sinks (TS/MP4 fanout) to miss frames because preview caching consumed them first.

The root cause was commit af49de02, which added per-sink draining in `HeadlessSession` while retaining the separate primary `get()` drain.

`_consume_frames` now uses a single dequeue path per mode:

- **Graph mode**: drain only per-sink queues via `get_from_sink()`; never call `get()`. The first sink still drives TS/MP4 fanout.
- **Non-graph mode**: keep the legacy primary-queue path via `get()`.

`get_last_frame()` without a `sink_node_id` still returns the latest consumed frame from any sink rather than a canonical primary sink. This is documented in the docstrings and left as a future TODO.

Extracted `_dispatch_video_frame()` to deduplicate the sink fanout logic between both paths.

**Unit tests** (`uv run pytest tests/test_headless.py`):

- New `test_headless_graph_mode_avoids_primary_queue_double_drain` — verifies that graph-mode headless never calls `get()` when sink queues are present, and that the single media sink receives exactly the expected frame.
- New `test_headless_graph_mode_keeps_latest_consumed_frame_behavior` — multi-sink scenario verifying:
  - Per-sink cached frames remain distinct.
  - Only the first sink's frames feed TS/MP4 fanout.
  - Bare `get_last_frame()` returns the latest consumed frame across all sinks.
- Existing recorder and sink-failure tests continue to pass.

**End-to-end validation**:

- MP4-only, TS-only, and MP4+TS scenarios all produced outputs with correct frame cadence and content consistency.
- Before the fix, instrumentation confirmed the symptom: sink callback counts diverged from encoded-frame counts due to the primary queue stealing frames from per-sink queues.