### PR TITLE
Drain stale frames from record queues before starting recording

### DIFF
--- a/src/scope/server/recording_coordinator.py
+++ b/src/scope/server/recording_coordinator.py
@@ -73,6 +73,22 @@ class RecordingCoordinator:
         """Return the list of record node IDs."""
         return list(self._record_queues.keys())
 
+    @staticmethod
+    def _drain_queue(q: queue.Queue) -> int:
+        """Drop all currently buffered items and return the count removed.
+
+        Record queues are live as soon as the graph starts, so they may already
+        contain stale frames by the time recording begins. Starting from stale
+        backlog skews content-vs-duration checks and can hide timing bugs.
+        """
+        dropped = 0
+        while True:
+            try:
+                q.get_nowait()
+                dropped += 1
+            except queue.Empty:
+                return dropped
+
     def get(self, record_node_id: str) -> torch.Tensor | None:
         """Read a frame from a record node's output queue."""
         rec_q = self._record_queues.get(record_node_id)
@@ -122,6 +138,14 @@ class RecordingCoordinator:
             if self._entries[node_id].manager.is_recording_started:
                 logger.info(f"Record node {node_id} already recording")
                 return True
+
+        dropped = self._drain_queue(rec_q)
+        if dropped > 0:
+            logger.info(
+                "Dropped %d stale frame(s) from record queue %s before start",
+                dropped,
+                node_id,
+            )
 
         from .recording import RecordingManager
         from .tracks import QueueVideoTrack

--- a/tests/test_recording_coordinator.py
+++ b/tests/test_recording_coordinator.py
@@ -1,0 +1,44 @@
+import queue
+
+import pytest
+
+from scope.server.recording_coordinator import RecordingCoordinator
+
+
+@pytest.mark.anyio
+async def test_start_recording_drops_stale_record_queue_frames(monkeypatch):
+    coordinator = RecordingCoordinator()
+    rec_q: queue.Queue = queue.Queue(maxsize=10)
+    rec_q.put_nowait("stale-1")
+    rec_q.put_nowait("stale-2")
+    rec_q.put_nowait("stale-3")
+    coordinator.setup_queues({"record": rec_q})
+
+    captured = {}
+
+    class FakeQueueVideoTrack:
+        def __init__(self, frame_queue, fps: float = 30.0):
+            captured["queue_size_on_init"] = frame_queue.qsize()
+            captured["fps"] = fps
+
+        def stop(self):
+            return
+
+    class FakeRecordingManager:
+        def __init__(self, video_track=None):
+            self.is_recording_started = False
+            captured["track_instance"] = video_track
+
+        async def start_recording(self):
+            captured["manager_started"] = True
+
+    monkeypatch.setattr("scope.server.tracks.QueueVideoTrack", FakeQueueVideoTrack)
+    monkeypatch.setattr("scope.server.recording.RecordingManager", FakeRecordingManager)
+
+    ok = await coordinator.start_recording("record", fps=29.97)
+
+    assert ok is True
+    assert rec_q.qsize() == 0
+    assert captured["queue_size_on_init"] == 0
+    assert captured["fps"] == 29.97
+    assert captured["manager_started"] is True


### PR DESCRIPTION
Record queues are wired in at graph build time and accumulate frames from session start. When recording begins later, the queue may already contain a backlog of stale frames from earlier in the session, causing the recorded content to span more source time than the actual recording wall-clock duration.

Flush the queue in RecordingCoordinator.start_recording() before constructing the QueueVideoTrack so recordings begin from "now."

Added test_recording_coordinator.py with a regression test verifying stale frames are drained before the recording track is initialized.


Made-with: Cursor