### PR TITLE
Propagate audio timestamps end-to-end through Livepeer output

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -540,13 +540,16 @@ async def _media_audio_output_loop(
 
     next_audio_pts = 0
     pts_sample_rate: int | None = None
+    last_audio_media_ts: float | None = None
 
     try:
         while not stop_event.is_set():
-            audio_tensor, sample_rate = frame_processor.get_audio()
-            if audio_tensor is None:
+            audio_packet = frame_processor.get_audio_packet()
+            if audio_packet is None:
                 await asyncio.sleep(0.01)
                 continue
+            audio_tensor = audio_packet.audio
+            sample_rate = audio_packet.sample_rate
             if sample_rate is None or sample_rate <= 0:
                 continue
 
@@ -564,8 +567,36 @@ async def _media_audio_output_loop(
             frame_samples = int(getattr(frame, "samples", 0) or 0)
             if frame_samples <= 0:
                 continue
-            # Stamp explicit monotonic PTS in sample-time so mux timing does
-            # not fall back to wall-clock heuristics.
+
+            should_use_preserved_ts = False
+            if audio_packet.timestamp.is_valid:
+                media_ts = audio_packet.timestamp.pts * float(
+                    audio_packet.timestamp.time_base
+                )
+                if last_audio_media_ts is None or media_ts > last_audio_media_ts:
+                    should_use_preserved_ts = True
+                    frame.pts = int(audio_packet.timestamp.pts)
+                    frame.time_base = audio_packet.timestamp.time_base
+                    last_audio_media_ts = media_ts
+                    # Keep synthetic fallback aligned with the preserved timeline.
+                    pts_sample_rate = sample_rate_int
+                    next_audio_pts = (
+                        int(round(media_ts * sample_rate_int)) + frame_samples
+                    )
+                else:
+                    logger.warning(
+                        "Ignoring non-monotonic preserved audio timestamp "
+                        "(pts=%s, time_base=%s)",
+                        audio_packet.timestamp.pts,
+                        audio_packet.timestamp.time_base,
+                    )
+
+            if should_use_preserved_ts:
+                await publisher.write_frame(frame)
+                continue
+
+            # Fallback: stamp explicit monotonic PTS in sample-time so mux timing
+            # does not fall back to wall-clock heuristics.
             if pts_sample_rate is None:
                 pts_sample_rate = sample_rate_int
             elif sample_rate_int != pts_sample_rate:
@@ -580,6 +611,7 @@ async def _media_audio_output_loop(
             frame.pts = next_audio_pts
             frame.time_base = fractions.Fraction(1, sample_rate_int)
             next_audio_pts += frame_samples
+            last_audio_media_ts = frame.pts * float(frame.time_base)
             await publisher.write_frame(frame)
     except asyncio.CancelledError:
         raise

--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -573,11 +573,15 @@ async def _media_audio_output_loop(
                 media_ts = audio_packet.timestamp.pts * float(
                     audio_packet.timestamp.time_base
                 )
-                if last_audio_media_ts is None or media_ts > last_audio_media_ts:
+                frame_duration_s = frame_samples / sample_rate_int
+                if (
+                    last_audio_media_ts is None
+                    or media_ts >= last_audio_media_ts
+                ):
                     should_use_preserved_ts = True
                     frame.pts = int(audio_packet.timestamp.pts)
                     frame.time_base = audio_packet.timestamp.time_base
-                    last_audio_media_ts = media_ts
+                    last_audio_media_ts = media_ts + frame_duration_s
                     # Keep synthetic fallback aligned with the preserved timeline.
                     pts_sample_rate = sample_rate_int
                     next_audio_pts = (
@@ -586,9 +590,11 @@ async def _media_audio_output_loop(
                 else:
                     logger.warning(
                         "Ignoring non-monotonic preserved audio timestamp "
-                        "(pts=%s, time_base=%s)",
+                        "(pts=%s, time_base=%s, start=%.6f, previous_end=%.6f)",
                         audio_packet.timestamp.pts,
                         audio_packet.timestamp.time_base,
+                        media_ts,
+                        last_audio_media_ts,
                     )
 
             if should_use_preserved_ts:
@@ -611,7 +617,9 @@ async def _media_audio_output_loop(
             frame.pts = next_audio_pts
             frame.time_base = fractions.Fraction(1, sample_rate_int)
             next_audio_pts += frame_samples
-            last_audio_media_ts = frame.pts * float(frame.time_base)
+            last_audio_media_ts = (frame.pts * float(frame.time_base)) + (
+                frame_samples / sample_rate_int
+            )
             await publisher.write_frame(frame)
     except asyncio.CancelledError:
         raise

--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -574,10 +574,7 @@ async def _media_audio_output_loop(
                     audio_packet.timestamp.time_base
                 )
                 frame_duration_s = frame_samples / sample_rate_int
-                if (
-                    last_audio_media_ts is None
-                    or media_ts >= last_audio_media_ts
-                ):
+                if last_audio_media_ts is None or media_ts >= last_audio_media_ts:
                     should_use_preserved_ts = True
                     frame.pts = int(audio_packet.timestamp.pts)
                     frame.time_base = audio_packet.timestamp.time_base

--- a/src/scope/server/audio_track.py
+++ b/src/scope/server/audio_track.py
@@ -48,11 +48,14 @@ class AudioProcessingTrack(MediaStreamTrack):
         self.channels = channels
 
         self._samples_per_frame = int(AUDIO_CLOCK_RATE * AUDIO_PTIME)  # 960
-        self._chunks: collections.deque[np.ndarray] = collections.deque()
+        self._chunks: collections.deque[tuple[np.ndarray, int | None]] = (
+            collections.deque()
+        )
         self._buffered_samples: int = 0  # total interleaved sample count
         self._first_audio_logged = False
         self._start: float | None = None
         self._timestamp: int = 0
+        self._last_preserved_pts: int | None = None
 
     @staticmethod
     def _resample_audio(
@@ -100,15 +103,18 @@ class AudioProcessingTrack(MediaStreamTrack):
         # Drain all available audio from the queue to minimise latency
         # for bursty or small-chunk pipelines.
         while True:
-            audio_tensor, sample_rate = self.frame_processor.get_audio()
-            if audio_tensor is None and sample_rate is None:
+            audio_packet = self.frame_processor.get_audio_packet()
+            if audio_packet is None:
                 break
+            audio_tensor = audio_packet.audio
+            sample_rate = audio_packet.sample_rate
 
             # Flush sentinel: discard buffered audio so a new prompt
             # is heard immediately instead of after the old speech finishes.
             if audio_tensor is None and sample_rate == AUDIO_FLUSH_SENTINEL:
                 self._chunks.clear()
                 self._buffered_samples = 0
+                self._last_preserved_pts = None
                 logger.info("Audio buffer flushed (prompt change)")
                 continue
 
@@ -139,7 +145,16 @@ class AudioProcessingTrack(MediaStreamTrack):
             # columns first, producing [L0, R0, L1, R1, ...] which is exactly
             # what packed interleaved s16 expects in a single plane.
             interleaved = np.ravel(audio_np, order="F").astype(np.float32)
-            self._chunks.append(interleaved)
+            chunk_pts: int | None = None
+            if audio_packet.timestamp.is_valid:
+                # Convert the preserved timestamp onto the outgoing 48kHz sample
+                # timeline so the buffered chunk stores the PTS of its first
+                # output sample, regardless of the packet's original time_base.
+                media_ts = audio_packet.timestamp.pts * float(
+                    audio_packet.timestamp.time_base
+                )
+                chunk_pts = int(round(media_ts * AUDIO_CLOCK_RATE))
+            self._chunks.append((interleaved, chunk_pts))
             self._buffered_samples += len(interleaved)
 
         # Cap buffer to prevent unbounded growth.
@@ -147,29 +162,75 @@ class AudioProcessingTrack(MediaStreamTrack):
         # single large chunk (e.g. LTX2 delivering >1s at once) is never
         # discarded entirely.
         max_interleaved = AUDIO_MAX_BUFFER_SAMPLES * self.channels
+        overflow = self._buffered_samples - max_interleaved
+        while overflow > 0 and self._chunks:
+            chunk, pts = self._chunks[0]
+            if len(chunk) <= overflow:
+                self._chunks.popleft()
+                self._buffered_samples -= len(chunk)
+                overflow -= len(chunk)
+                continue
+
+            # Dropping samples from the front of a buffered chunk means its
+            # start PTS must move forward by the same number of output samples.
+            shifted_pts = None if pts is None else pts + (overflow // self.channels)
+            self._chunks[0] = (chunk[overflow:], shifted_pts)
+            self._buffered_samples -= overflow
+            overflow = 0
+
         if self._buffered_samples > max_interleaved:
-            flat = np.concatenate(list(self._chunks))
-            self._chunks.clear()
-            trimmed = flat[-max_interleaved:]
-            self._chunks.append(trimmed)
-            self._buffered_samples = len(trimmed)
             logger.warning("Audio buffer overflow, dropped oldest chunks")
 
         # Serve a 20ms frame from the buffer
         samples_needed = self._samples_per_frame * self.channels
         if self._buffered_samples >= samples_needed:
-            flat = np.concatenate(list(self._chunks))
-            self._chunks.clear()
-            frame_samples = flat[:samples_needed]
-            remainder = flat[samples_needed:]
-            if len(remainder) > 0:
-                self._chunks.append(remainder)
-            self._buffered_samples = len(remainder)
-            return self._create_audio_frame(frame_samples)
+            frame_parts: list[np.ndarray] = []
+            remaining = samples_needed
+            preserved_pts: int | None = None
+            first_chunk = True
+
+            while remaining > 0 and self._chunks:
+                chunk, pts = self._chunks[0]
+                take = min(len(chunk), remaining)
+                if first_chunk:
+                    # The emitted frame inherits the timestamp of its first
+                    # output sample.
+                    preserved_pts = pts
+                    first_chunk = False
+
+                frame_parts.append(chunk[:take])
+                if take == len(chunk):
+                    self._chunks.popleft()
+                else:
+                    # The leftover tail becomes a new buffered chunk whose
+                    # first-sample PTS advances by the number of consumed
+                    # output samples.
+                    shifted_pts = None if pts is None else pts + (take // self.channels)
+                    self._chunks[0] = (chunk[take:], shifted_pts)
+
+                self._buffered_samples -= take
+                remaining -= take
+
+            frame_samples = np.concatenate(frame_parts)
+            frame_pts = preserved_pts
+            if frame_pts is not None:
+                if (
+                    self._last_preserved_pts is None
+                    or frame_pts > self._last_preserved_pts
+                ):
+                    self._last_preserved_pts = frame_pts
+                else:
+                    logger.warning(
+                        "Ignoring non-monotonic preserved audio timestamp in AudioProcessingTrack"
+                    )
+                    frame_pts = None
+            return self._create_audio_frame(frame_samples, pts_override=frame_pts)
 
         return self._create_silence_frame()
 
-    def _create_audio_frame(self, samples: np.ndarray) -> AudioFrame:
+    def _create_audio_frame(
+        self, samples: np.ndarray, pts_override: int | None = None
+    ) -> AudioFrame:
         """Build a packed s16 AudioFrame from interleaved float32 samples.
 
         ``samples`` must already be interleaved: [L0, R0, L1, R1, …] for
@@ -185,7 +246,7 @@ class AudioProcessingTrack(MediaStreamTrack):
         layout = "stereo" if self.channels == 2 else "mono"
         frame = AudioFrame(format="s16", layout=layout, samples=self._samples_per_frame)
         frame.sample_rate = AUDIO_CLOCK_RATE
-        frame.pts = self._timestamp
+        frame.pts = self._timestamp if pts_override is None else pts_override
         frame.time_base = AUDIO_TIME_BASE
         frame.planes[0].update(samples_int16.tobytes())
         return frame
@@ -203,4 +264,5 @@ class AudioProcessingTrack(MediaStreamTrack):
     def stop(self):
         self._chunks.clear()
         self._buffered_samples = 0
+        self._last_preserved_pts = None
         super().stop()

--- a/src/scope/server/cloud_relay.py
+++ b/src/scope/server/cloud_relay.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
-from .media_packets import MediaTimestamp, VideoPacket
+from .media_packets import AudioPacket, MediaTimestamp, VideoPacket
 
 if TYPE_CHECKING:
     from aiortc.mediastreams import VideoFrame
@@ -63,7 +63,7 @@ class CloudRelay:
 
         # Output queues populated by cloud callbacks
         self._frame_queue: queue.Queue = queue.Queue(maxsize=2)
-        self._audio_queue: queue.Queue = queue.Queue(maxsize=50)
+        self._audio_queue: queue.Queue[AudioPacket] = queue.Queue(maxsize=50)
 
         # Counters
         self.frames_to_cloud = 0
@@ -197,12 +197,22 @@ class CloudRelay:
             if frame.format.name in ("s16", "s16p"):
                 audio_tensor = audio_tensor / 32768.0
 
+            packet = AudioPacket(
+                audio=audio_tensor,
+                sample_rate=frame.sample_rate,
+                timestamp=MediaTimestamp(
+                    pts=frame.pts,
+                    time_base=Fraction(frame.time_base)
+                    if frame.time_base is not None
+                    else None,
+                ),
+            )
             try:
-                self._audio_queue.put_nowait((audio_tensor, frame.sample_rate))
+                self._audio_queue.put_nowait(packet)
             except queue.Full:
                 try:
                     self._audio_queue.get_nowait()
-                    self._audio_queue.put_nowait((audio_tensor, frame.sample_rate))
+                    self._audio_queue.put_nowait(packet)
                 except queue.Empty:
                     pass
         except Exception as e:
@@ -219,12 +229,12 @@ class CloudRelay:
         except queue.Empty:
             return None
 
-    def get_audio(self) -> tuple[torch.Tensor | None, int | None]:
-        """Get the next audio chunk and sample rate, or (None, None)."""
+    def get_audio(self) -> AudioPacket | None:
+        """Get the next audio packet received from cloud, or None."""
         try:
             return self._audio_queue.get_nowait()
         except queue.Empty:
-            return None, None
+            return None
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -12,7 +12,13 @@ from aiortc.mediastreams import VideoFrame
 
 from .cloud_relay import CloudRelay, compute_relay_video_mode
 from .kafka_publisher import publish_event
-from .media_packets import MediaTimestamp, VideoPacket, ensure_video_packet
+from .media_packets import (
+    AudioPacket,
+    MediaTimestamp,
+    VideoPacket,
+    ensure_audio_packet,
+    ensure_video_packet,
+)
 from .modulation import ModulationEngine
 from .parameter_scheduler import ParameterScheduler
 from .pipeline_manager import PipelineManager
@@ -561,31 +567,39 @@ class FrameProcessor:
             return None
         return packet.tensor
 
-    def get_audio(self) -> tuple[torch.Tensor | None, int | None]:
+    def get_audio_packet(self) -> AudioPacket | None:
         """Get the next audio chunk and its sample rate.
 
         In local mode, reads from the sink processor's audio output queue.
         In cloud mode, reads from the CloudRelay audio queue.
 
         Returns:
-            Tuple of (audio_tensor, sample_rate) or (None, None) if no audio available.
-            audio_tensor shape: (channels, samples) - typically (2, N) for stereo
+            AudioPacket or None if no audio is available.
         """
         if not self.running:
-            return None, None
+            return None
 
         if self._cloud_relay is not None:
-            return self._cloud_relay.get_audio()
+            item = self._cloud_relay.get_audio()
+            if item is None:
+                return None
+            return ensure_audio_packet(item)
 
         if self._sink_processor is None:
-            return None, None
+            return None
 
         try:
-            audio, sample_rate = self._sink_processor.audio_output_queue.get_nowait()
-            # Pass through flush sentinels (audio=None, sample_rate=-1)
-            return audio, sample_rate
+            item = self._sink_processor.audio_output_queue.get_nowait()
+            return ensure_audio_packet(item)
         except queue.Empty:
+            return None
+
+    def get_audio(self) -> tuple[torch.Tensor | None, int | None]:
+        """Backwards-compatible audio getter returning (audio, sample_rate)."""
+        packet = self.get_audio_packet()
+        if packet is None:
             return None, None
+        return packet.audio, packet.sample_rate
 
     def get_fps(self) -> float:
         """Get the playback FPS for the video track.

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -707,6 +707,21 @@ class LivepeerClient:
 
                 decoded_kind = getattr(decoded, "kind", None)
                 if decoded_kind == "audio":
+                    time_base = getattr(frame, "time_base", None)
+                    audio_ts = (
+                        frame.pts * float(time_base)
+                        if time_base is not None and frame.pts is not None
+                        else None
+                    )
+                    decision = compute_pacing_decision(
+                        pacing,
+                        media_ts=audio_ts,
+                        now_monotonic=time.monotonic(),
+                    )
+                    self._record_pacing_observation(decision)
+                    if decision.sleep_s > 0:
+                        await asyncio.sleep(decision.sleep_s)
+                    pacing.prev_wall_monotonic = time.monotonic()
                     self.audio_output_handler.handle_frame(frame)
                     continue
                 if decoded_kind != "video":

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -14,7 +14,12 @@ import torch
 from scope.core.pipelines.controller import parse_ctrl_input
 
 from .kafka_publisher import publish_event
-from .media_packets import MediaTimestamp, VideoPacket, ensure_video_packet
+from .media_packets import (
+    AudioPacket,
+    MediaTimestamp,
+    VideoPacket,
+    ensure_video_packet,
+)
 from .pipeline_manager import PipelineNotAvailableException
 from .tempo_sync import get_beat_boundary
 
@@ -89,8 +94,8 @@ class PipelineProcessor:
         # Consumed by FrameProcessor.get_audio() on the sink processor.
         # Flushed on prompt change, so only needs enough headroom for
         # bursty production (pipeline thread outpacing real-time playback).
-        self.audio_output_queue: queue.Queue[tuple[torch.Tensor, int]] = queue.Queue(
-            maxsize=10
+        self.audio_output_queue: queue.Queue[AudioPacket | tuple[torch.Tensor, int]] = (
+            queue.Queue(maxsize=10)
         )
 
         # Current parameters used by processing thread
@@ -525,7 +530,21 @@ class PipelineProcessor:
             if audio_output is not None and audio_sample_rate is not None:
                 try:
                     audio_cpu = audio_output.detach().cpu()
-                    self.audio_output_queue.put_nowait((audio_cpu, audio_sample_rate))
+                    audio_ts = output_dict.get("audio_timestamps")
+                    timestamp = MediaTimestamp()
+                    if isinstance(audio_ts, list) and audio_ts:
+                        first = audio_ts[0]
+                        if isinstance(first, MediaTimestamp):
+                            timestamp = first
+                    elif isinstance(audio_ts, MediaTimestamp):
+                        timestamp = audio_ts
+                    self.audio_output_queue.put_nowait(
+                        AudioPacket(
+                            audio=audio_cpu,
+                            sample_rate=audio_sample_rate,
+                            timestamp=timestamp,
+                        )
+                    )
                 except queue.Full:
                     logger.warning(
                         "Audio output queue full for %s, dropping audio chunk",

--- a/tests/test_audio_packets.py
+++ b/tests/test_audio_packets.py
@@ -1,0 +1,84 @@
+import queue
+from fractions import Fraction
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+from av import AudioFrame
+
+from scope.server.cloud_relay import CloudRelay
+from scope.server.frame_processor import FrameProcessor
+from scope.server.media_packets import AudioPacket, MediaTimestamp
+
+
+def _make_frame_processor_with_audio_queue(items):
+    processor = object.__new__(FrameProcessor)
+    processor.running = True
+    processor._cloud_relay = None
+    audio_queue = queue.Queue()
+    for item in items:
+        audio_queue.put_nowait(item)
+    processor._sink_processor = SimpleNamespace(audio_output_queue=audio_queue)
+    return processor
+
+
+def test_get_audio_packet_accepts_legacy_audio_tuple():
+    audio = torch.ones((2, 8))
+    processor = _make_frame_processor_with_audio_queue([(audio, 48_000)])
+
+    packet = processor.get_audio_packet()
+
+    assert packet == AudioPacket(audio=audio, sample_rate=48_000)
+
+
+def test_get_audio_remains_backward_compatible_for_audio_packets():
+    audio = torch.zeros((1, 16))
+    packet = AudioPacket(
+        audio=audio,
+        sample_rate=24_000,
+        timestamp=MediaTimestamp(pts=7),
+    )
+    processor = _make_frame_processor_with_audio_queue([packet])
+
+    assert processor.get_audio() == (audio, 24_000)
+
+
+def test_get_audio_packet_accepts_legacy_cloud_tuple():
+    audio = torch.randn((2, 16))
+    processor = object.__new__(FrameProcessor)
+    processor.running = True
+    processor._sink_processor = None
+    processor._cloud_relay = SimpleNamespace(get_audio=lambda: (audio, 48_000))
+
+    packet = processor.get_audio_packet()
+
+    assert packet == AudioPacket(audio=audio, sample_rate=48_000)
+
+
+def test_cloud_relay_audio_packet_preserves_timestamp():
+    class _FakeCloudManager:
+        def add_frame_callback(self, callback):  # pragma: no cover - unused in test
+            return None
+
+        def add_audio_callback(self, callback):  # pragma: no cover - unused in test
+            return None
+
+        def remove_frame_callback(self, callback):  # pragma: no cover - unused in test
+            return None
+
+        def remove_audio_callback(self, callback):  # pragma: no cover - unused in test
+            return None
+
+    relay = CloudRelay(_FakeCloudManager())
+    audio_np = np.zeros((2, 160), dtype=np.float32)
+    frame = AudioFrame.from_ndarray(audio_np, format="fltp", layout="stereo")
+    frame.sample_rate = 48_000
+    frame.pts = 321
+    frame.time_base = Fraction(1, 48_000)
+
+    relay.on_audio_from_cloud(frame)
+    packet = relay.get_audio()
+
+    assert packet is not None
+    assert packet.sample_rate == 48_000
+    assert packet.timestamp == MediaTimestamp(pts=321, time_base=Fraction(1, 48_000))

--- a/tests/test_audio_processing_track.py
+++ b/tests/test_audio_processing_track.py
@@ -3,6 +3,7 @@ and the full recv() integration path.
 """
 
 import asyncio
+import fractions
 import time
 from unittest.mock import MagicMock
 
@@ -17,6 +18,7 @@ from scope.server.audio_track import (
     AUDIO_PTIME,
     AudioProcessingTrack,
 )
+from scope.server.media_packets import AudioPacket, MediaTimestamp
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,7 +38,7 @@ def _make_track(channels: int = 2, started: bool = True) -> AudioProcessingTrack
     """
     fp = MagicMock()
     fp.paused = False
-    fp.get_audio = MagicMock(return_value=(None, None))
+    fp.get_audio_packet = MagicMock(return_value=None)
     track = AudioProcessingTrack(frame_processor=fp, channels=channels)
     if started:
         track._start = time.time()
@@ -53,16 +55,20 @@ def _run(coro):
         loop.close()
 
 
-def _once(audio_tensor, sample_rate: int):
-    """Return a side_effect callable that yields (tensor, rate) once, then (None, None)."""
+def _once(audio_tensor, sample_rate: int, timestamp: MediaTimestamp | None = None):
+    """Yield one AudioPacket, then None."""
     returned = False
 
     def _side_effect():
         nonlocal returned
         if not returned:
             returned = True
-            return (audio_tensor, sample_rate)
-        return (None, None)
+            return AudioPacket(
+                audio=audio_tensor,
+                sample_rate=sample_rate,
+                timestamp=timestamp or MediaTimestamp(),
+            )
+        return None
 
     return _side_effect
 
@@ -202,7 +208,9 @@ class TestRecv:
     def test_with_audio_tensor(self):
         track = _make_track(started=False)
         audio = torch.randn(2, SAMPLES_PER_FRAME + 100)
-        track.frame_processor.get_audio = MagicMock(side_effect=_once(audio, 48000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 48000)
+        )
 
         frame = _run(track.recv())
         assert isinstance(frame, AudioFrame)
@@ -211,7 +219,9 @@ class TestRecv:
     def test_resamples_to_48khz(self):
         track = _make_track(started=False)
         audio = torch.randn(2, SAMPLES_PER_FRAME)  # enough after 2x upsample
-        track.frame_processor.get_audio = MagicMock(side_effect=_once(audio, 24000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 24000)
+        )
 
         frame = _run(track.recv())
         assert frame.sample_rate == AUDIO_CLOCK_RATE
@@ -219,7 +229,9 @@ class TestRecv:
     def test_mono_upmixed_to_stereo(self):
         track = _make_track(started=False)
         audio = torch.randn(1, SAMPLES_PER_FRAME + 100)
-        track.frame_processor.get_audio = MagicMock(side_effect=_once(audio, 48000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 48000)
+        )
 
         frame = _run(track.recv())
         assert frame.layout.name == "stereo"
@@ -227,7 +239,9 @@ class TestRecv:
     def test_1d_tensor_treated_as_mono(self):
         track = _make_track(started=False)
         audio = torch.randn(SAMPLES_PER_FRAME + 100)  # 1D
-        track.frame_processor.get_audio = MagicMock(side_effect=_once(audio, 48000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 48000)
+        )
 
         frame = _run(track.recv())
         assert isinstance(frame, AudioFrame)
@@ -236,7 +250,9 @@ class TestRecv:
         track = _make_track(started=False)
         track.frame_processor.paused = True
         audio = torch.randn(2, SAMPLES_PER_FRAME + 100)
-        track.frame_processor.get_audio = MagicMock(side_effect=_once(audio, 48000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 48000)
+        )
 
         frame = _run(track.recv())
         raw = np.frombuffer(bytes(frame.planes[0]), dtype=np.int16)
@@ -245,7 +261,9 @@ class TestRecv:
     def test_undersized_chunk_returns_silence(self):
         track = _make_track(started=False)
         audio = torch.randn(2, 100)  # too small for a 960-sample frame
-        track.frame_processor.get_audio = MagicMock(side_effect=_once(audio, 48000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 48000)
+        )
 
         frame = _run(track.recv())
         raw = np.frombuffer(bytes(frame.planes[0]), dtype=np.int16)
@@ -258,15 +276,15 @@ class TestRecv:
 
         call_count = 0
 
-        def get_audio():
+        def get_audio_packet():
             nonlocal call_count
             call_count += 1
             # Return one chunk per drain cycle (odd calls), None to end drain (even)
             if call_count % 2 == 1:
-                return (torch.randn(2, chunk_size), 48000)
-            return (None, None)
+                return AudioPacket(audio=torch.randn(2, chunk_size), sample_rate=48000)
+            return None
 
-        track.frame_processor.get_audio = MagicMock(side_effect=get_audio)
+        track.frame_processor.get_audio_packet = MagicMock(side_effect=get_audio_packet)
 
         # Call recv() repeatedly until we get a non-silence frame
         got_real_frame = False
@@ -289,14 +307,14 @@ class TestRecv:
         chunk_size = 200
         chunks_returned = 0
 
-        def get_audio():
+        def get_audio_packet():
             nonlocal chunks_returned
             if chunks_returned < 5:
                 chunks_returned += 1
-                return (torch.randn(2, chunk_size), 48000)
-            return (None, None)
+                return AudioPacket(audio=torch.randn(2, chunk_size), sample_rate=48000)
+            return None
 
-        track.frame_processor.get_audio = MagicMock(side_effect=get_audio)
+        track.frame_processor.get_audio_packet = MagicMock(side_effect=get_audio_packet)
 
         _run(track.recv())
         assert chunks_returned == 5
@@ -304,12 +322,40 @@ class TestRecv:
         # minus 960 × 2 = 1920 consumed for one frame = 80 remaining
         assert track._buffered_samples == 80
 
+    def test_preserves_valid_packet_timestamp_at_48khz(self):
+        track = _make_track(started=False)
+        audio = torch.randn(2, SAMPLES_PER_FRAME + 100)
+        timestamp = MediaTimestamp(pts=1234, time_base=fractions.Fraction(1, 48000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 48000, timestamp=timestamp)
+        )
+
+        frame = _run(track.recv())
+
+        assert frame.pts == 1234
+        assert frame.time_base == fractions.Fraction(1, 48000)
+
+    def test_translates_preserved_timestamp_when_resampling(self):
+        track = _make_track(started=False)
+        input_samples = 600
+        audio = torch.randn(2, input_samples)
+        timestamp = MediaTimestamp(pts=2400, time_base=fractions.Fraction(1, 24000))
+        track.frame_processor.get_audio_packet = MagicMock(
+            side_effect=_once(audio, 24000, timestamp=timestamp)
+        )
+
+        frame = _run(track.recv())
+
+        # 2400 @ 24kHz -> 4800 @ 48kHz
+        assert frame.pts == 4800
+        assert frame.time_base == fractions.Fraction(1, 48000)
+
     def test_caps_buffer_at_max(self):
         """Oversized buffer is trimmed to the cap after recv()."""
         track = _make_track(started=False)
         max_interleaved = AUDIO_MAX_BUFFER_SAMPLES * track.channels
         oversized = np.ones(max_interleaved + 5000, dtype=np.float32)
-        track._chunks.append(oversized)
+        track._chunks.append((oversized, None))
         track._buffered_samples = len(oversized)
 
         _run(track.recv())

--- a/uv.lock
+++ b/uv.lock
@@ -1332,7 +1332,7 @@ wheels = [
 [[package]]
 name = "livepeer-gateway"
 version = "0.1.0"
-source = { git = "https://github.com/livepeer/livepeer-python-gateway#aedd6db17429827b681395a22e7f4aaf3dc7e877" }
+source = { git = "https://github.com/livepeer/livepeer-python-gateway#601a253437976b7eb889dbd5e823cad6655b761a" }
 dependencies = [
     { name = "aiohttp" },
     { name = "av" },


### PR DESCRIPTION
Preserve `AudioPacket.timestamp` from pipeline output through Livepeer publish/receive and into the local WebRTC audio track instead of restamping audio at each boundary. This keeps audio on a single authoritative timeline while preserving synthetic fallbacks for invalid or missing timestamps.

Audio counterpart to https://github.com/daydreamlive/scope/pull/901