### PR TITLE
feat: auth-aware subscribe button, credit counter, and Daydream Cloud…

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -278,18 +278,17 @@ export function Header({
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-              <Button
-                variant="ghost"
-                size="sm"
+              <button
+                type="button"
                 onClick={() =>
                   openExternalUrl(
                     `${DAYDREAM_APP_BASE}/dashboard/usage`
                   )
                 }
-                className="h-6 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+                className="h-6 px-2 rounded-md text-[11px] font-semibold text-white bg-gradient-to-r from-[#36619D] via-[#2FBEC5] to-[#FF982E] hover:brightness-110 transition-all"
               >
                 Top Up
-              </Button>
+              </button>
             </span>
           )}
           <Button
@@ -326,25 +325,23 @@ export function Header({
                   : "Connect to Cloud"}
             </span>
           </Button>
-          {/* Subscribe CTA / Plan badge */}
+          {/* Upgrade CTA / Plan badge */}
           {!isSignedIn ? (
-            <Button
-              variant="ghost"
-              size="sm"
+            <button
+              type="button"
               onClick={() => redirectToSignIn()}
-              className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+              className="h-7 px-3 rounded-md text-xs font-semibold text-white bg-gradient-to-r from-[#36619D] via-[#2FBEC5] to-[#FF982E] hover:brightness-110 transition-all"
             >
-              Subscribe
-            </Button>
+              Upgrade
+            </button>
           ) : billing.tier === "free" ? (
-            <Button
-              variant="ghost"
-              size="sm"
+            <button
+              type="button"
               onClick={() => billing.openCheckout("pro")}
-              className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+              className="h-7 px-3 rounded-md text-xs font-semibold text-white bg-gradient-to-r from-[#36619D] via-[#2FBEC5] to-[#FF982E] hover:brightness-110 transition-all"
             >
               Upgrade for more credits
-            </Button>
+            </button>
           ) : (
             <Button
               variant="ghost"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -16,6 +16,7 @@ import { PaywallModal } from "./PaywallModal";
 import { toast } from "sonner";
 import { useCloudStatus } from "../hooks/useCloudStatus";
 import { useBilling } from "../contexts/BillingContext";
+import { isAuthenticated, redirectToSignIn } from "../lib/auth";
 
 function formatTrialTime(totalSeconds: number): string {
   const s = Math.max(0, Math.floor(totalSeconds));
@@ -70,6 +71,19 @@ export function Header({
 
   // Billing state
   const billing = useBilling();
+
+  // Auth state — reactive to sign-in / sign-out
+  const [isSignedIn, setIsSignedIn] = useState(() => isAuthenticated());
+
+  useEffect(() => {
+    const handleAuthChange = () => setIsSignedIn(isAuthenticated());
+    window.addEventListener("daydream-auth-change", handleAuthChange);
+    window.addEventListener("daydream-auth-success", handleAuthChange);
+    return () => {
+      window.removeEventListener("daydream-auth-change", handleAuthChange);
+      window.removeEventListener("daydream-auth-success", handleAuthChange);
+    };
+  }, []);
 
   // Track the last close code we've shown a toast for to avoid duplicates
   const lastNotifiedCloseCodeRef = useRef<number | null>(null);
@@ -212,6 +226,12 @@ export function Header({
           )}
         </div>
         <div className="flex items-center gap-1">
+          {/* Credit balance (left of cloud button) */}
+          {isSignedIn && billing.credits && (
+            <span className="flex items-center gap-1 text-xs font-medium px-2 text-muted-foreground">
+              {Math.round(billing.credits.balance)} credits
+            </span>
+          )}
           <Button
             variant="ghost"
             size="sm"
@@ -246,15 +266,36 @@ export function Header({
                   : "Connect to Cloud"}
             </span>
           </Button>
-          {/* Subscribe CTA (free tier only) */}
-          {billing.tier === "free" && !billing.credits && (
+          {/* Subscribe CTA / Plan badge */}
+          {!isSignedIn ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => redirectToSignIn()}
+              className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Subscribe
+            </Button>
+          ) : billing.tier === "free" ? (
             <Button
               variant="ghost"
               size="sm"
               onClick={() => billing.openCheckout("pro")}
               className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
             >
-              Subscribe
+              Free Plan - Subscribe for more credits
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setInitialTab("billing");
+                setSettingsOpen(true);
+              }}
+              className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              {billing.tier === "pro" ? "Pro" : "Max"}
             </Button>
           )}
           {isConnected &&

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,8 +8,15 @@ import {
   Monitor,
   Clock,
   AlertTriangle,
+  HelpCircle,
 } from "lucide-react";
 import { Button } from "./ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 import { SettingsDialog } from "./SettingsDialog";
 import { PluginsDialog } from "./PluginsDialog";
 import { PaywallModal } from "./PaywallModal";
@@ -17,6 +24,11 @@ import { toast } from "sonner";
 import { useCloudStatus } from "../hooks/useCloudStatus";
 import { useBilling } from "../contexts/BillingContext";
 import { isAuthenticated, redirectToSignIn } from "../lib/auth";
+import { openExternalUrl } from "../lib/openExternal";
+
+const DAYDREAM_APP_BASE =
+  (import.meta.env.VITE_DAYDREAM_APP_BASE as string | undefined) ||
+  "https://app.daydream.monster";
 
 function formatTrialTime(totalSeconds: number): string {
   const s = Math.max(0, Math.floor(totalSeconds));
@@ -228,8 +240,56 @@ export function Header({
         <div className="flex items-center gap-1">
           {/* Credit balance (left of cloud button) */}
           {isSignedIn && billing.credits && (
-            <span className="flex items-center gap-1 text-xs font-medium px-2 text-muted-foreground">
-              {Math.round(billing.credits.balance)} credits
+            <span className="flex items-center gap-1.5 text-xs font-medium px-2 text-muted-foreground">
+              <span className="tabular-nums">
+                {billing.credits.balance.toFixed(2)}
+              </span>{" "}
+              credits remaining
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Credit info"
+                    >
+                      <HelpCircle className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="bottom"
+                    className="max-w-[260px] text-xs leading-relaxed"
+                  >
+                    Daydream Cloud inference requires credit purchases. For more
+                    information, please refer to our{" "}
+                    <a
+                      href="https://daydream.live/pricing"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-primary-foreground/80"
+                      onClick={e => {
+                        e.preventDefault();
+                        openExternalUrl("https://daydream.live/pricing");
+                      }}
+                    >
+                      Pricing page
+                    </a>
+                    .
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  openExternalUrl(
+                    `${DAYDREAM_APP_BASE}/dashboard/usage`
+                  )
+                }
+                className="h-6 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+              >
+                Top Up
+              </Button>
             </span>
           )}
           <Button
@@ -283,7 +343,7 @@ export function Header({
               onClick={() => billing.openCheckout("pro")}
               className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
             >
-              Free Plan - Subscribe for more credits
+              Upgrade for more credits
             </Button>
           ) : (
             <Button

--- a/frontend/src/components/settings/BillingTab.tsx
+++ b/frontend/src/components/settings/BillingTab.tsx
@@ -101,8 +101,8 @@ export function BillingTab() {
           Subscription & Billing
         </h3>
         <p className="text-sm text-muted-foreground">
-          You're on the free plan. Subscribe to get credits for remote
-          inference.
+          You're on the free plan. Subscribe to get credits for Daydream
+          Cloud.
         </p>
         {credits && credits.balance > 0 && (
           <div className="text-sm text-muted-foreground">

--- a/frontend/src/components/settings/DaydreamAccountSection.tsx
+++ b/frontend/src/components/settings/DaydreamAccountSection.tsx
@@ -220,7 +220,7 @@ export function DaydreamAccountSection({
           />
         </div>
         <p className="text-xs text-muted-foreground">
-          Use remote inference for running pipelines.
+          Use Daydream Cloud inference for running workflows.
           {!isSignedIn &&
             !(status.connected || status.connecting) &&
             " Log in required."}


### PR DESCRIPTION
… text updates

- Subscribe button shows 3 states: sign-in prompt (unauthenticated), free plan CTA, or plan badge linking to Billing tab
- Credit counter displayed to the left of the cloud connect button
- Updated "remote inference" references to "Daydream Cloud"