### PR TITLE
Handle expired auth sessions gracefully

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import {
   handleOAuthCallback,
   initElectronAuthListener,
   initEnvKeyAuth,
+  redirectToSignIn,
 } from "./lib/auth";
 import { toast } from "sonner";
 import { TelemetryProvider } from "./contexts/TelemetryContext";
@@ -32,6 +33,25 @@ type AuthResult =
 function App() {
   const [isHandlingAuth, setIsHandlingAuth] = useState(true);
   const [authResult, setAuthResult] = useState<AuthResult>(null);
+
+  // Show a persistent toast when the Daydream session expires so the user can
+  // log in again without seeing a raw error. Handled globally here so it
+  // fires regardless of which component triggered the 401.
+  useEffect(() => {
+    const onSessionExpired = () => {
+      toast.error("Your session has expired — please log in again", {
+        duration: Infinity,
+        action: {
+          label: "Log in",
+          onClick: redirectToSignIn,
+        },
+      });
+    };
+    window.addEventListener("daydream-session-expired", onSessionExpired);
+    return () => {
+      window.removeEventListener("daydream-session-expired", onSessionExpired);
+    };
+  }, []);
 
   useEffect(() => {
     // Initialize Electron auth callback listener (if running in Electron)

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -99,6 +99,22 @@ interface UserProfile {
   isAdmin: boolean;
 }
 
+// Dedup guard: prevent firing the event more than once per 30-second window
+let _sessionExpiredFiredAt = 0;
+
+/**
+ * Handle an expired auth session: clear stored credentials and notify the app
+ * so it can surface a "session expired — please log in again" prompt.
+ * Safe to call multiple times concurrently; fires at most once per 30 seconds.
+ */
+export function handleSessionExpired(): void {
+  const now = Date.now();
+  if (now - _sessionExpiredFiredAt < 30_000) return;
+  _sessionExpiredFiredAt = now;
+  clearDaydreamAuth();
+  window.dispatchEvent(new CustomEvent("daydream-session-expired"));
+}
+
 /**
  * Fetch user profile from API
  */
@@ -106,6 +122,10 @@ async function fetchUserProfile(apiKey: string): Promise<UserProfile> {
   const response = await fetch(`${DAYDREAM_API_BASE}/users/profile`, {
     headers: { Authorization: `Bearer ${apiKey}` },
   });
+  if (response.status === 401) {
+    handleSessionExpired();
+    throw new Error("Session expired");
+  }
   if (!response.ok) {
     throw new Error(`Failed to fetch profile: ${response.status}`);
   }
@@ -199,7 +219,9 @@ export async function refreshUserProfile(): Promise<void> {
 }
 
 /**
- * Clear the stored Daydream auth credentials
+ * Clear the stored Daydream auth credentials.
+ * Prefer handleSessionExpired() when clearing due to an expired token so the
+ * app can surface a user-facing message.
  */
 export function clearDaydreamAuth(): void {
   localStorage.removeItem(AUTH_STORAGE_KEY);
@@ -231,6 +253,10 @@ export async function initEnvKeyAuth(): Promise<boolean> {
   const response = await fetch(`${DAYDREAM_API_BASE}/users/profile`, {
     headers: { Authorization: `Bearer ${envKey}` },
   });
+  if (response.status === 401) {
+    handleSessionExpired();
+    throw new Error("Session expired");
+  }
   if (!response.ok) {
     throw new Error(
       `Failed to fetch profile with env API key: ${response.status}`
@@ -294,6 +320,10 @@ export async function fetchFalCdnToken(): Promise<FalCdnToken> {
   const response = await fetch(`${DAYDREAM_API_BASE}/auth/fal/cdn-token`, {
     headers: { Authorization: `Bearer ${apiKey}` },
   });
+  if (response.status === 401) {
+    handleSessionExpired();
+    throw new Error("Session expired");
+  }
   if (!response.ok) {
     throw new Error(`Failed to fetch fal CDN token: ${response.status}`);
   }

--- a/frontend/src/lib/cloudAdapter.ts
+++ b/frontend/src/lib/cloudAdapter.ts
@@ -36,6 +36,7 @@ import type {
   AssetsResponse,
   AssetFileInfo,
 } from "./api";
+import { handleSessionExpired } from "./auth";
 
 type MessageHandler = (response: ApiResponse) => void;
 
@@ -220,7 +221,7 @@ export class CloudAdapter {
         (message.status && message.status >= 400)
       ) {
         if (message.status === 401) {
-          window.dispatchEvent(new CustomEvent("daydream-session-expired"));
+          handleSessionExpired();
         }
         pending.reject(
           new Error(

--- a/frontend/src/lib/cloudAdapter.ts
+++ b/frontend/src/lib/cloudAdapter.ts
@@ -219,6 +219,9 @@ export class CloudAdapter {
         message.type === "error" ||
         (message.status && message.status >= 400)
       ) {
+        if (message.status === 401) {
+          window.dispatchEvent(new CustomEvent("daydream-session-expired"));
+        }
         pending.reject(
           new Error(
             message.error || `Request failed with status ${message.status}`

--- a/frontend/src/lib/daydreamExport.ts
+++ b/frontend/src/lib/daydreamExport.ts
@@ -1,3 +1,5 @@
+import { handleSessionExpired } from "./auth";
+
 const DAYDREAM_API_BASE =
   (import.meta.env.VITE_DAYDREAM_API_BASE as string | undefined) ||
   "https://api.daydream.live";
@@ -29,6 +31,10 @@ export async function createDaydreamImportSession(
     }
   );
 
+  if (response.status === 401) {
+    handleSessionExpired();
+    throw new Error("Session expired");
+  }
   if (!response.ok) {
     const text = await response.text();
     throw new Error(


### PR DESCRIPTION
## Summary

- Add global 401 response interception across all Daydream cloud API calls (`auth.ts`, `cloudAdapter.ts`, `daydreamExport.ts`)
- Show a persistent toast ("Your session has expired — please log in again") with a login action button instead of raw error messages
- Central `handleSessionExpired()` function with 30s dedup guard to prevent toast spam from rapid WebSocket 401s

## Changes

- `frontend/src/lib/auth.ts` — `handleSessionExpired()` with credential clearing, event dispatch, and dedup guard; 401 checks on `fetchUserProfile`, `fetchFalCdnToken`, `initEnvKeyAuth`
- `frontend/src/lib/cloudAdapter.ts` — 401 detection in WebSocket message handler, calls `handleSessionExpired()`
- `frontend/src/lib/daydreamExport.ts` — 401 check on `createDaydreamImportSession`
- `frontend/src/App.tsx` — Global `daydream-session-expired` event listener with `toast.error` (duration: Infinity) + login redirect action

4 files changed, 61 insertions(+), 1 deletion(-)

## Test plan

- [ ] Log in to Scope, then invalidate/expire the auth token server-side
- [ ] Verify toast appears with "Your session has expired — please log in again" message
- [ ] Verify "Log in" button redirects to login flow
- [ ] Verify no raw 401 error messages shown to user
- [ ] Test across different pages/tabs in the app
- [ ] Trigger rapid 401s (e.g. WebSocket reconnect loop) and verify dedup prevents toast spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>