### PR TITLE
fix: downgrade bundled plugin uninstall from ERROR to WARNING

### DIFF
--- a/src/scope/core/plugins/__init__.py
+++ b/src/scope/core/plugins/__init__.py
@@ -3,6 +3,7 @@
 from .hookspecs import hookimpl
 from .manager import (
     FailedPluginInfo,
+    PluginBundledError,
     PluginDependencyError,
     PluginInstallError,
     PluginInUseError,
@@ -32,4 +33,5 @@ __all__ = [
     "PluginNameCollisionError",
     "PluginDependencyError",
     "PluginInstallError",
+    "PluginBundledError",
 ]

--- a/src/scope/core/plugins/manager.py
+++ b/src/scope/core/plugins/manager.py
@@ -80,6 +80,12 @@ class PluginInstallError(Exception):
     pass
 
 
+class PluginBundledError(PluginInstallError):
+    """Attempted to uninstall a bundled (built-in) plugin."""
+
+    pass
+
+
 @dataclass(frozen=True)
 class FailedPluginInfo:
     """Information about a plugin entry point that failed to load."""
@@ -1360,7 +1366,7 @@ class PluginManager:
 
         # Prevent uninstalling bundled plugins
         if plugin_info.get("bundled"):
-            raise PluginInstallError(
+            raise PluginBundledError(
                 f"Plugin '{name}' is bundled and cannot be uninstalled"
             )
 

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -2957,6 +2957,7 @@ async def uninstall_plugin(
     cloud-hosted scope backend.
     """
     from scope.core.plugins import (
+        PluginBundledError,
         PluginInstallError,
         PluginNotFoundError,
         get_plugin_manager,
@@ -2990,6 +2991,12 @@ async def uninstall_plugin(
         raise HTTPException(
             status_code=404,
             detail=f"Plugin '{name}' not found",
+        ) from e
+    except PluginBundledError as e:
+        logger.warning(f"Plugin uninstall rejected (bundled plugin): {name} - {e}")
+        raise HTTPException(
+            status_code=400,
+            detail=str(e),
         ) from e
     except PluginInstallError as e:
         logger.error(f"Plugin uninstall failed: {name} - {e}")


### PR DESCRIPTION
## Summary

Fixes #837 — ERROR-level log noise on every prod fal.ai job from `scope-ltx-2` bundled plugin cleanup attempts.

## Root Cause

The `uninstall_plugin` endpoint was catching all `PluginInstallError` exceptions (including bundled-plugin rejection) and logging them as `ERROR`. Attempting to uninstall a bundled plugin is an **expected, handled condition** — the fal.ai cleanup loop always tries to uninstall all plugins at job end, including bundled ones. It's not a server error.

## Changes

- **`manager.py`**: Add `PluginBundledError(PluginInstallError)` subclass so callers can distinguish bundled-rejection from genuine install failures. Raise it instead of `PluginInstallError` in `_uninstall_plugin_sync` when a bundled plugin is targeted.
- **`__init__.py`**: Export `PluginBundledError`.
- **`app.py`**: Catch `PluginBundledError` before the generic handler in the uninstall endpoint: log at `WARNING`, return HTTP **400** (client error) instead of 500 (server error).

## Before / After

| | Before | After |
|---|---|---|
| Log level | `ERROR` | `WARNING` |
| HTTP status | 500 | 400 |
| Noise in prod | 5+ per 12h window | 0 (warning-level, not ERROR-forwarded) |

## Testing

- All 99 existing plugin manager tests pass (`test_plugin_manager.py`)
- `PluginBundledError` is a subclass of `PluginInstallError` so existing `except PluginInstallError` catch sites in other paths still work correctly