### PR TITLE
Add app selector to fal deploy workflow

### DIFF
--- a/.github/workflows/fal-deploy.yml
+++ b/.github/workflows/fal-deploy.yml
@@ -11,6 +11,15 @@ on:
           - main
           - prod
         default: 'main'
+      app:
+        description: 'Which app to deploy'
+        required: true
+        type: choice
+        options:
+          - both
+          - scope-app
+          - scope-livepeer
+        default: 'both'
   workflow_run:
     workflows: ["Build and Push Docker Image"]
     types:
@@ -42,6 +51,10 @@ jobs:
         run: pip install fal
 
       - name: Deploy Scope app to fal
+        if: >
+          github.event_name == 'workflow_run' ||
+          github.event.inputs.app == 'both' ||
+          github.event.inputs.app == 'scope-app'
         env:
           FAL_KEY: ${{ secrets.FAL_KEY }}
         run: |
@@ -52,10 +65,14 @@ jobs:
             ENV="main"
           fi
 
-          echo "Deploying to $ENV"
+          echo "Deploying Scope app to $ENV"
           fal deploy --env $ENV --auth public src/scope/cloud/fal_app.py
 
       - name: Deploy Livepeer runner to fal
+        if: >
+          github.event_name == 'workflow_run' ||
+          github.event.inputs.app == 'both' ||
+          github.event.inputs.app == 'scope-livepeer'
         env:
           FAL_KEY: ${{ secrets.FAL_KEY }}
         run: |


### PR DESCRIPTION
## Summary
- Adds an "app" dropdown to the "Deploy to fal" workflow with three options: `both`, `scope-app`, `scope-livepeer`
- Allows deploying just the livepeer runner or just the cloud relay app independently
- Auto-triggered deploys (from Docker build on main) still deploy both apps
- No changes to deployment commands or fal configuration

## Why
Currently the workflow always deploys both apps. When iterating on the livepeer runner, there's no need to redeploy the cloud relay app (and vice versa).

## Test plan
- [ ] Trigger workflow manually with `scope-livepeer` selected — only livepeer step should run
- [ ] Trigger workflow manually with `scope-app` selected — only scope app step should run
- [ ] Trigger workflow manually with `both` selected — both steps run (existing behavior)
- [ ] Verify auto-trigger from Docker build still deploys both

🤖 Generated with [Claude Code](https://claude.com/claude-code)