### PR TITLE
Add YouTube input source

### DIFF
--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -189,6 +189,7 @@ interface GraphEditorProps {
   spoutAvailable?: boolean;
   ndiAvailable?: boolean;
   syphonAvailable?: boolean;
+  youtubeAvailable?: boolean;
   onSpoutSourceChange?: (name: string) => void;
   onNdiSourceChange?: (identifier: string) => void;
   onSyphonSourceChange?: (identifier: string) => void;
@@ -241,6 +242,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
       spoutAvailable = false,
       ndiAvailable = false,
       syphonAvailable = false,
+      youtubeAvailable = false,
       onSpoutSourceChange,
       onNdiSourceChange,
       onSyphonSourceChange,
@@ -342,6 +344,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         spoutAvailable,
         ndiAvailable,
         syphonAvailable,
+        youtubeAvailable,
         spoutOutputAvailable,
         ndiOutputAvailable,
         syphonOutputAvailable,

--- a/frontend/src/components/graph/hooks/graph/useGraphState.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphState.ts
@@ -119,6 +119,7 @@ export interface GraphEditorAvailability {
   spoutAvailable: boolean;
   ndiAvailable: boolean;
   syphonAvailable: boolean;
+  youtubeAvailable: boolean;
   spoutOutputAvailable: boolean;
   ndiOutputAvailable: boolean;
   syphonOutputAvailable: boolean;
@@ -296,6 +297,7 @@ export function useGraphState(
     spoutAvailable: availability.spoutAvailable,
     ndiAvailable: availability.ndiAvailable,
     syphonAvailable: availability.syphonAvailable,
+    youtubeAvailable: availability.youtubeAvailable,
     spoutOutputAvailable: availability.spoutOutputAvailable,
     ndiOutputAvailable: availability.ndiOutputAvailable,
     syphonOutputAvailable: availability.syphonOutputAvailable,
@@ -345,6 +347,7 @@ export function useGraphState(
     availability.spoutAvailable,
     availability.ndiAvailable,
     availability.syphonAvailable,
+    availability.youtubeAvailable,
     availability.spoutOutputAvailable,
     availability.ndiOutputAvailable,
     availability.syphonOutputAvailable,

--- a/frontend/src/components/graph/nodes/SourceNode.tsx
+++ b/frontend/src/components/graph/nodes/SourceNode.tsx
@@ -2,7 +2,11 @@ import { useEffect, useRef, useCallback, useState } from "react";
 import { Handle, Position } from "@xyflow/react";
 import type { NodeProps, Node } from "@xyflow/react";
 import type { FlowNodeData } from "../../../lib/graphUtils";
-import { getInputSourceSources, type DiscoveredSource } from "../../../lib/api";
+import {
+  getInputSourceResolution,
+  getInputSourceSources,
+  type DiscoveredSource,
+} from "../../../lib/api";
 import { useNodeData } from "../hooks/node/useNodeData";
 import { useNodeCollapse } from "../hooks/node/useNodeCollapse";
 import {
@@ -27,7 +31,17 @@ const SOURCE_MODE_OPTIONS = [
   { value: "spout", label: "Spout" },
   { value: "ndi", label: "NDI" },
   { value: "syphon", label: "Syphon" },
+  { value: "youtube", label: "YouTube" },
 ];
+
+const YOUTUBE_URL_REGEX =
+  /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtube\.com\/(?:watch\?[^#\s]*\bv=|shorts\/|embed\/)|youtu\.be\/)[A-Za-z0-9_-]{11}(?:[?&#/][^\s]*)?$/;
+
+type YoutubeStatus =
+  | { kind: "idle" }
+  | { kind: "probing" }
+  | { kind: "ready"; width: number; height: number }
+  | { kind: "error"; message: string };
 
 export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const { updateData } = useNodeData(id);
@@ -44,6 +58,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const spoutAvailable = data.spoutAvailable ?? false;
   const ndiAvailable = data.ndiAvailable ?? false;
   const syphonAvailable = data.syphonAvailable ?? false;
+  const youtubeAvailable = data.youtubeAvailable ?? false;
   const onSpoutSourceChange = data.onSpoutSourceChange as
     | ((name: string) => void)
     | undefined;
@@ -63,6 +78,9 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const [isDiscoveringNdi, setIsDiscoveringNdi] = useState(false);
   const [syphonSources, setSyphonSources] = useState<DiscoveredSource[]>([]);
   const [isDiscoveringSyphon, setIsDiscoveringSyphon] = useState(false);
+  const [youtubeStatus, setYoutubeStatus] = useState<YoutubeStatus>({
+    kind: "idle",
+  });
 
   useEffect(() => {
     if (videoRef.current && localStream instanceof MediaStream) {
@@ -113,6 +131,55 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     }
   }, [sourceMode, syphonAvailable]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Probe YouTube URL (debounced) when in youtube mode.
+  useEffect(() => {
+    if (sourceMode !== "youtube") return;
+    if (!youtubeAvailable) {
+      setYoutubeStatus({
+        kind: "error",
+        message: "yt-dlp not installed on server",
+      });
+      return;
+    }
+    const url = sourceName.trim();
+    if (!url) {
+      setYoutubeStatus({ kind: "idle" });
+      return;
+    }
+    if (!YOUTUBE_URL_REGEX.test(url)) {
+      setYoutubeStatus({ kind: "error", message: "Invalid YouTube URL" });
+      return;
+    }
+    let cancelled = false;
+    setYoutubeStatus({ kind: "probing" });
+    const handle = window.setTimeout(async () => {
+      try {
+        const res = await getInputSourceResolution("youtube", url, 10000);
+        if (cancelled) return;
+        setYoutubeStatus({
+          kind: "ready",
+          width: res.width,
+          height: res.height,
+        });
+      } catch (e) {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        // Map common HTTP statuses to friendlier messages.
+        let friendly = msg;
+        if (/\b400\b/.test(msg)) friendly = "Invalid YouTube URL";
+        else if (/\b404\b/.test(msg)) friendly = "Video unavailable or private";
+        else if (/\b408\b/.test(msg))
+          friendly = "Timed out — check your network";
+        else if (/\b500\b/.test(msg)) friendly = "Server error — see logs";
+        setYoutubeStatus({ kind: "error", message: friendly });
+      }
+    }, 500);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [sourceMode, sourceName, youtubeAvailable]);
+
   const discoverSyphonSources = useCallback(async () => {
     if (!syphonAvailable) return;
     setIsDiscoveringSyphon(true);
@@ -129,12 +196,27 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
 
   const handleSourceModeChange = (newMode: string) => {
     updateData({
-      sourceMode: newMode as "video" | "camera" | "spout" | "ndi" | "syphon",
-      ...(newMode !== "spout" && newMode !== "ndi" && newMode !== "syphon"
+      sourceMode: newMode as
+        | "video"
+        | "camera"
+        | "spout"
+        | "ndi"
+        | "syphon"
+        | "youtube",
+      ...(newMode !== "spout" &&
+      newMode !== "ndi" &&
+      newMode !== "syphon" &&
+      newMode !== "youtube"
         ? { sourceName: undefined }
         : {}),
     });
+    setYoutubeStatus({ kind: "idle" });
     onSourceModeChange?.(newMode);
+  };
+
+  const handleYoutubeUrlChange = (value: string | number) => {
+    const url = String(value);
+    updateData({ sourceName: url });
   };
 
   const handleSpoutNameChange = (value: string | number) => {
@@ -176,6 +258,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     if (opt.value === "spout") return spoutAvailable;
     if (opt.value === "ndi") return ndiAvailable;
     if (opt.value === "syphon") return syphonAvailable;
+    if (opt.value === "youtube") return youtubeAvailable;
     return true;
   });
 
@@ -219,6 +302,35 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
                   disabled={!spoutAvailable}
                 />
               </NodeParamRow>
+            </div>
+          )}
+
+          {sourceMode === "youtube" && (
+            <div className="px-2 flex flex-col gap-1">
+              <NodeParamRow label="URL">
+                <NodePillInput
+                  type="text"
+                  value={sourceName}
+                  onChange={handleYoutubeUrlChange}
+                  placeholder="https://youtube.com/watch?v=..."
+                  disabled={!youtubeAvailable}
+                />
+              </NodeParamRow>
+              <div
+                className={`text-[10px] px-1 ${
+                  youtubeStatus.kind === "error"
+                    ? "text-red-400"
+                    : youtubeStatus.kind === "ready"
+                      ? "text-green-400"
+                      : "text-[#8c8c8d]"
+                }`}
+              >
+                {youtubeStatus.kind === "idle" && "Paste a YouTube URL"}
+                {youtubeStatus.kind === "probing" && "Checking…"}
+                {youtubeStatus.kind === "ready" &&
+                  `Ready (${youtubeStatus.width}×${youtubeStatus.height})`}
+                {youtubeStatus.kind === "error" && youtubeStatus.message}
+              </div>
             </div>
           )}
 
@@ -381,7 +493,8 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
           {!showPreview &&
             sourceMode !== "spout" &&
             sourceMode !== "ndi" &&
-            sourceMode !== "syphon" && (
+            sourceMode !== "syphon" &&
+            sourceMode !== "youtube" && (
               <div className="flex items-center justify-center rounded-md bg-black/30 text-[10px] text-[#8c8c8d] flex-1 min-h-[40px]">
                 Waiting for input...
               </div>

--- a/frontend/src/components/graph/utils/nodeEnrichment.ts
+++ b/frontend/src/components/graph/utils/nodeEnrichment.ts
@@ -47,6 +47,7 @@ export interface EnrichNodesDeps {
   spoutAvailable: boolean;
   ndiAvailable: boolean;
   syphonAvailable: boolean;
+  youtubeAvailable: boolean;
   spoutOutputAvailable: boolean;
   ndiOutputAvailable: boolean;
   syphonOutputAvailable: boolean;
@@ -171,6 +172,7 @@ export function enrichNodes(
           spoutAvailable: deps.spoutAvailable,
           ndiAvailable: deps.ndiAvailable,
           syphonAvailable: deps.syphonAvailable,
+          youtubeAvailable: deps.youtubeAvailable,
           onSpoutSourceChange: (name: string) =>
             deps.onSpoutSourceChangeRef.current?.(name),
           onNdiSourceChange: (identifier: string) =>

--- a/frontend/src/hooks/useVideoSource.ts
+++ b/frontend/src/hooks/useVideoSource.ts
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 
-export type VideoSourceMode = "video" | "camera" | "spout" | "ndi" | "syphon";
+export type VideoSourceMode =
+  | "video"
+  | "camera"
+  | "spout"
+  | "ndi"
+  | "syphon"
+  | "youtube";
 
 export const SAMPLE_VIDEOS = [
   "/assets/test.mp4",
@@ -200,8 +206,13 @@ export function useVideoSource(props?: UseVideoSourceProps) {
       setMode(newMode);
       setError(null);
 
-      // Spout/NDI/Syphon mode - no local stream needed, input comes from server-side receiver
-      if (newMode === "spout" || newMode === "ndi" || newMode === "syphon") {
+      // Spout/NDI/Syphon/YouTube mode - no local stream needed, input comes from server-side receiver
+      if (
+        newMode === "spout" ||
+        newMode === "ndi" ||
+        newMode === "syphon" ||
+        newMode === "youtube"
+      ) {
         if (localStream) {
           localStream.getTracks().forEach(track => track.stop());
         }

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -174,9 +174,9 @@ export interface FlowNodeData {
   outputSinkEnabled?: boolean;
   /** For output nodes: the sender name */
   outputSinkName?: string;
-  /** For source nodes: video source mode (video, camera, spout, ndi, syphon) */
-  sourceMode?: "video" | "camera" | "spout" | "ndi" | "syphon";
-  /** For source nodes: source name/identifier for Spout/NDI (sender name for Spout, identifier for NDI) */
+  /** For source nodes: video source mode (video, camera, spout, ndi, syphon, youtube) */
+  sourceMode?: "video" | "camera" | "spout" | "ndi" | "syphon" | "youtube";
+  /** For source nodes: source name/identifier (sender name for Spout, identifier for NDI/Syphon, video URL for YouTube) */
   sourceName?: string;
   /** For source nodes: local video preview stream (camera or file) */
   localStream?: MediaStream | null;
@@ -190,6 +190,8 @@ export interface FlowNodeData {
   ndiAvailable?: boolean;
   /** For source nodes: whether Syphon is available (macOS) */
   syphonAvailable?: boolean;
+  /** For source nodes: whether YouTube (yt-dlp) is available on the server */
+  youtubeAvailable?: boolean;
   /** For source nodes: callback when Spout receiver name changes */
   onSpoutSourceChange?: (name: string) => void;
   /** For source nodes: callback when NDI source changes */

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -144,7 +144,9 @@ function graphHasOnlyServerSideSources(graph: GraphConfig | null): boolean {
   if (sources.length === 0) return false;
   return sources.every(n => {
     const sm = n.source_mode || "video";
-    return sm === "spout" || sm === "ndi" || sm === "syphon";
+    return (
+      sm === "spout" || sm === "ndi" || sm === "syphon" || sm === "youtube"
+    );
   });
 }
 
@@ -233,12 +235,15 @@ export function StreamPage() {
     skipNextModeReset,
   } = useStreamState();
 
-  // Derive NDI and Syphon input availability from dynamic input sources list
+  // Derive NDI, Syphon, and YouTube input availability from dynamic input sources list
   const ndiAvailable = availableInputSources.some(
     s => s.source_id === "ndi" && s.available
   );
   const syphonAvailable = availableInputSources.some(
     s => s.source_id === "syphon" && s.available
+  );
+  const youtubeAvailable = availableInputSources.some(
+    s => s.source_id === "youtube" && s.available
   );
   // Output availability flags are passed to GraphEditor for output nodes
   const hasAvailableOutputs =
@@ -2302,7 +2307,12 @@ export function StreamPage() {
               // Use first server-side source for backward compat input_source param
               for (const sourceNode of sourceNodes) {
                 const sm = sourceNode.source_mode || "video";
-                if (sm === "spout" || sm === "ndi" || sm === "syphon") {
+                if (
+                  sm === "spout" ||
+                  sm === "ndi" ||
+                  sm === "syphon" ||
+                  sm === "youtube"
+                ) {
                   graphInputSource = {
                     enabled: true,
                     source_type: sm,
@@ -2989,7 +2999,8 @@ export function StreamPage() {
             n.type === "source" &&
             (n.source_mode || "video") !== "spout" &&
             (n.source_mode || "video") !== "ndi" &&
-            (n.source_mode || "video") !== "syphon"
+            (n.source_mode || "video") !== "syphon" &&
+            (n.source_mode || "video") !== "youtube"
         );
         if (webrtcSourceNodes.length > 0) {
           const streams: Record<string, MediaStream> = {};
@@ -3214,7 +3225,8 @@ export function StreamPage() {
                     | "camera"
                     | "spout"
                     | "ndi"
-                    | "syphon";
+                    | "syphon"
+                    | "youtube";
 
                   // Sync inputMode setting so perform mode reflects the graph's choice
                   const inputMode: InputMode =
@@ -3239,7 +3251,8 @@ export function StreamPage() {
                   if (
                     sourceMode === "spout" ||
                     sourceMode === "ndi" ||
-                    sourceMode === "syphon"
+                    sourceMode === "syphon" ||
+                    sourceMode === "youtube"
                   ) {
                     // For server-side sources, update settings.inputSource with graph's source_name
                     updateSettings({
@@ -3309,6 +3322,7 @@ export function StreamPage() {
             spoutAvailable={spoutAvailable}
             ndiAvailable={ndiAvailable}
             syphonAvailable={syphonAvailable}
+            youtubeAvailable={youtubeAvailable}
             onSpoutSourceChange={handleSpoutSourceChange}
             onNdiSourceChange={handleNdiSourceChange}
             onSyphonSourceChange={handleSyphonSourceChange}

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -817,8 +817,13 @@ export function StreamPage() {
       // Import/restore calls this with (mode, nodeId). Clear the global
       // useVideoSource stream (e.g. test.mp4) when switching to server-side
       // capture — otherwise WebRTC still sends that track alongside Syphon/NDI/Spout.
-      if (newMode === "spout" || newMode === "ndi" || newMode === "syphon") {
-        void switchMode(newMode as "spout" | "ndi" | "syphon");
+      if (
+        newMode === "spout" ||
+        newMode === "ndi" ||
+        newMode === "syphon" ||
+        newMode === "youtube"
+      ) {
+        void switchMode(newMode as "spout" | "ndi" | "syphon" | "youtube");
       }
       // When switching to file mode during streaming, auto-load a sample
       // video so the WebRTC track is replaced immediately.
@@ -2731,7 +2736,15 @@ export function StreamPage() {
         mode === "ndi" && settings.inputSource?.source_type === "ndi";
       const isSyphonMode =
         mode === "syphon" && settings.inputSource?.source_type === "syphon";
-      const isServerSideInput = isSpoutMode || isNdiMode || isSyphonMode;
+      // Graph-mode: if every Source node uses a server-side input (spout,
+      // ndi, syphon, youtube), suppress the WebRTC local track so the old
+      // sample video doesn't leak into the YouTube source node's queue
+      // while yt-dlp is still downloading.
+      const isGraphAllServerSide =
+        !!graphConfigForStream &&
+        graphHasOnlyServerSideSources(graphConfigForStream);
+      const isServerSideInput =
+        isSpoutMode || isNdiMode || isSyphonMode || isGraphAllServerSide;
 
       // Only send video stream for pipelines that need video input (not in Spout/NDI mode)
       const streamToSend =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "mcp>=1.0.0",
     "livepeer-gateway",
     "protobuf>=5.27.0",
+    "yt-dlp>=2024.10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/scope/core/inputs/__init__.py
+++ b/src/scope/core/inputs/__init__.py
@@ -48,6 +48,13 @@ def get_input_source_classes() -> dict[str, type[InputSource]]:
     except Exception:
         pass
 
+    try:
+        from .youtube import YouTubeInputSource
+
+        sources[YouTubeInputSource.source_id] = YouTubeInputSource
+    except Exception:
+        pass
+
     return sources
 
 

--- a/src/scope/core/inputs/interface.py
+++ b/src/scope/core/inputs/interface.py
@@ -7,6 +7,18 @@ from typing import ClassVar
 import numpy as np
 
 
+class InputSourceError(Exception):
+    """Base class for input source errors raised during probe/connect."""
+
+
+class InvalidSourceURLError(InputSourceError):
+    """Raised when a source identifier/URL is malformed or disallowed."""
+
+
+class SourceUnavailableError(InputSourceError):
+    """Raised when a source exists but cannot be accessed (private, deleted, geo-blocked, etc.)."""
+
+
 @dataclass
 class InputSourceInfo:
     """Information about a discovered input source."""

--- a/src/scope/core/inputs/youtube.py
+++ b/src/scope/core/inputs/youtube.py
@@ -1,0 +1,380 @@
+"""YouTube input source.
+
+Downloads a YouTube video to a local cache via yt-dlp, then reuses
+VideoFileInputSource to decode and loop frames with PyAV pacing.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+from pathlib import Path
+from typing import ClassVar
+
+import numpy as np
+
+from .interface import (
+    InputSource,
+    InputSourceInfo,
+    InvalidSourceURLError,
+    SourceUnavailableError,
+)
+from .video_file import VideoFileInputSource
+
+logger = logging.getLogger(__name__)
+
+# yt-dlp format selector: prefer mp4 video+audio ≤1080p, fallback to any ≤1080p.
+_YTDLP_FORMAT = (
+    "bv*[ext=mp4][height<=1080]+ba[ext=m4a]/b[ext=mp4][height<=1080]/best[height<=1080]"
+)
+
+# Only accept URLs on these hosts. Guards against yt-dlp's generic
+# extractor being used as an SSRF oracle.
+_ALLOWED_HOSTS = re.compile(
+    r"^(?:https?://)?(?:www\.|m\.)?(?:youtube\.com|youtu\.be)(?:/|$)",
+    re.IGNORECASE,
+)
+
+# Patterns to extract the 11-char YouTube video ID.
+_VIDEO_ID_PATTERNS = [
+    re.compile(r"(?:v=|/shorts/|/embed/|youtu\.be/)([A-Za-z0-9_-]{11})(?:[?&/]|$)"),
+]
+
+_VIDEO_ID_LEN = 11
+
+# Per-video-id lock to prevent concurrent downloads of the same URL.
+_download_locks_guard = threading.Lock()
+_download_locks: dict[str, threading.Lock] = {}
+
+
+def _extract_video_id(url: str) -> str | None:
+    """Return the 11-char video id, or None if the URL isn't a valid YouTube URL."""
+    if not isinstance(url, str) or not url.strip():
+        return None
+    url = url.strip()
+    if not _ALLOWED_HOSTS.search(url):
+        return None
+    for pat in _VIDEO_ID_PATTERNS:
+        m = pat.search(url)
+        if m:
+            vid = m.group(1)
+            if len(vid) == _VIDEO_ID_LEN:
+                return vid
+    return None
+
+
+def _get_cache_path(video_id: str) -> Path:
+    """Return cache file path for a given video id, creating parent dir."""
+    from scope.server.models_config import get_assets_dir
+
+    # Put cache next to assets so users don't need a new env var.
+    cache_dir = get_assets_dir().parent / "cache" / "youtube"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"{video_id}.mp4"
+
+
+def _classify_download_error(msg: str) -> tuple[str, str]:
+    """Classify a yt-dlp error message into (category, human message).
+
+    Categories: private, unavailable, age, geo, rate, live, other.
+    """
+    low = msg.lower()
+    if "private" in low:
+        return "private", "Video is private"
+    if "members-only" in low or "members only" in low:
+        return "private", "Video is members-only"
+    if "removed" in low or "not available" in low or "unavailable" in low:
+        return "unavailable", "Video is unavailable or has been removed"
+    if "age" in low and "restrict" in low:
+        return "age", "Video is age-restricted"
+    if "country" in low or "geo" in low or "not available in your" in low:
+        return "geo", "Video is geo-blocked in this region"
+    if "429" in low or "too many requests" in low:
+        return "rate", "YouTube rate-limited the request (HTTP 429)"
+    if "live" in low and "stream" in low:
+        return "live", "Live streams are not supported"
+    return "other", msg
+
+
+class YouTubeInputSource(InputSource):
+    """Input source that downloads a YouTube video and plays it on loop."""
+
+    source_id: ClassVar[str] = "youtube"
+    source_name: ClassVar[str] = "YouTube"
+    source_description: ClassVar[str] = (
+        "Download a YouTube video by URL and play it on loop."
+    )
+
+    def __init__(self):
+        self._inner: VideoFileInputSource | None = None
+        self._url: str | None = None
+        self._video_id: str | None = None
+
+    @classmethod
+    def is_available(cls) -> bool:
+        try:
+            import av  # noqa: F401
+            import yt_dlp  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    def list_sources(self, timeout_ms: int = 5000) -> list[InputSourceInfo]:
+        # YouTube can't be enumerated; source_name is the URL itself.
+        return []
+
+    def connect(self, identifier: str) -> bool:
+        """Resolve + download the URL to cache, then open it with PyAV.
+
+        Args:
+            identifier: A YouTube URL.
+
+        Returns:
+            True if the video is downloaded and opened.
+        """
+        self.disconnect()
+
+        video_id = _extract_video_id(identifier)
+        if video_id is None:
+            logger.error(f"Invalid YouTube URL: {identifier!r}")
+            return False
+
+        # Reject live streams before downloading.
+        is_live = self._probe_is_live(identifier)
+        if is_live is True:
+            logger.error(f"Refusing to connect to live stream: {identifier}")
+            return False
+
+        cache_path = _get_cache_path(video_id)
+
+        # Serialize concurrent downloads of the same video id.
+        lock = self._get_download_lock(video_id)
+        with lock:
+            if not cache_path.exists() or cache_path.stat().st_size == 0:
+                if not self._download(identifier, cache_path):
+                    return False
+
+            # Open via VideoFileInputSource; on failure retry once after
+            # deleting a possibly-corrupted cache.
+            inner = VideoFileInputSource()
+            if inner.connect(str(cache_path)):
+                self._inner = inner
+                self._url = identifier
+                self._video_id = video_id
+                logger.info(
+                    f"YouTubeInputSource connected: {identifier} "
+                    f"(cache={cache_path.name})"
+                )
+                return True
+
+            logger.warning(
+                f"Cached file failed to open ({cache_path.name}), redownloading once"
+            )
+            try:
+                cache_path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.error(f"Could not delete corrupted cache {cache_path}: {e}")
+                return False
+
+            if not self._download(identifier, cache_path):
+                return False
+
+            inner = VideoFileInputSource()
+            if inner.connect(str(cache_path)):
+                self._inner = inner
+                self._url = identifier
+                self._video_id = video_id
+                return True
+
+            logger.error(f"Failed to open YouTube video after redownload: {identifier}")
+            return False
+
+    def receive_frame(self, timeout_ms: int = 100) -> np.ndarray | None:
+        if self._inner is None:
+            return None
+        return self._inner.receive_frame(timeout_ms=timeout_ms)
+
+    def disconnect(self):
+        if self._inner is not None:
+            try:
+                self._inner.close()
+            except Exception as e:
+                logger.error(f"Error closing inner video source: {e}")
+            finally:
+                self._inner = None
+        self._url = None
+        self._video_id = None
+
+    def get_source_resolution(
+        self, identifier: str, timeout_ms: int = 5000
+    ) -> tuple[int, int] | None:
+        """Probe the video's resolution without downloading the full file.
+
+        Uses yt-dlp's metadata-only extract. Returns None if the URL is
+        invalid, the video is unavailable, or the metadata lacks dimensions.
+        """
+        if _extract_video_id(identifier) is None:
+            logger.error(f"Invalid YouTube URL for resolution probe: {identifier!r}")
+            raise InvalidSourceURLError("URL is not a recognized YouTube video link")
+
+        try:
+            import yt_dlp
+        except ImportError:
+            logger.error("yt-dlp is not installed; cannot probe YouTube source")
+            return None
+
+        ydl_opts = {
+            "format": _YTDLP_FORMAT,
+            "quiet": True,
+            "no_warnings": True,
+            "noplaylist": True,
+            "socket_timeout": max(1, timeout_ms // 1000),
+            "skip_download": True,
+        }
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(identifier, download=False)
+        except yt_dlp.utils.DownloadError as e:
+            cat, msg = _classify_download_error(str(e))
+            logger.error(f"YouTube probe failed ({cat}): {msg}")
+            if cat in ("private", "unavailable", "age", "geo", "live"):
+                raise SourceUnavailableError(msg) from e
+            # Rate limit / other → return None (endpoint falls through to 408).
+            return None
+        except Exception as e:
+            logger.error(f"YouTube probe error: {e}")
+            return None
+
+        if info is None:
+            return None
+        if info.get("is_live") or info.get("live_status") in ("is_live", "is_upcoming"):
+            logger.error("Refusing live stream for resolution probe")
+            raise SourceUnavailableError("Live streams are not supported")
+
+        width = info.get("width")
+        height = info.get("height")
+        if (
+            isinstance(width, int)
+            and isinstance(height, int)
+            and width > 0
+            and height > 0
+        ):
+            return (width, height)
+
+        # Fallback: scan the merged format's requested_formats.
+        req = info.get("requested_formats") or []
+        for fmt in req:
+            w = fmt.get("width")
+            h = fmt.get("height")
+            if isinstance(w, int) and isinstance(h, int) and w > 0 and h > 0:
+                return (w, h)
+        return None
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_download_lock(video_id: str) -> threading.Lock:
+        with _download_locks_guard:
+            lock = _download_locks.get(video_id)
+            if lock is None:
+                lock = threading.Lock()
+                _download_locks[video_id] = lock
+            return lock
+
+    @staticmethod
+    def _probe_is_live(url: str) -> bool | None:
+        """Return True if the URL refers to a live stream, False if not, None on error."""
+        try:
+            import yt_dlp
+        except ImportError:
+            return None
+        try:
+            with yt_dlp.YoutubeDL(
+                {"quiet": True, "no_warnings": True, "skip_download": True}
+            ) as ydl:
+                info = ydl.extract_info(url, download=False)
+        except Exception:
+            return None
+        if info is None:
+            return None
+        if info.get("is_live"):
+            return True
+        if info.get("live_status") in ("is_live", "is_upcoming"):
+            return True
+        return False
+
+    @staticmethod
+    def _download(url: str, cache_path: Path) -> bool:
+        """Download the video to ``cache_path``. Returns True on success.
+
+        Retries once on HTTP 429 after a 5s backoff.
+        """
+        try:
+            import yt_dlp
+        except ImportError:
+            logger.error("yt-dlp is not installed; install it to use YouTube sources")
+            return False
+
+        tmp_path = cache_path.with_suffix(cache_path.suffix + ".part")
+        ydl_opts = {
+            "format": _YTDLP_FORMAT,
+            "outtmpl": str(cache_path),
+            "noplaylist": True,
+            "quiet": True,
+            "no_warnings": True,
+            "merge_output_format": "mp4",
+            "overwrites": True,
+            # Prevent creation of .live_chat.json etc.
+            "writesubtitles": False,
+            "writeautomaticsub": False,
+        }
+
+        def _run() -> tuple[bool, str]:
+            try:
+                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                    ydl.download([url])
+                return True, ""
+            except yt_dlp.utils.DownloadError as e:
+                return False, str(e)
+            except OSError as e:
+                return False, f"disk error: {e}"
+            except Exception as e:
+                return False, f"{type(e).__name__}: {e}"
+
+        ok, err = _run()
+        if not ok:
+            cat, msg = _classify_download_error(err)
+            if cat == "rate":
+                logger.warning(f"YouTube rate-limited; retrying after 5s: {msg}")
+                time.sleep(5.0)
+                ok, err = _run()
+                if not ok:
+                    cat, msg = _classify_download_error(err)
+
+        if not ok:
+            logger.error(f"YouTube download failed ({cat}): {msg}")
+            # Best-effort cleanup of partials.
+            for p in (tmp_path, cache_path):
+                try:
+                    if p.exists() and p.stat().st_size == 0:
+                        p.unlink()
+                except OSError:
+                    pass
+            return False
+
+        if not cache_path.exists() or cache_path.stat().st_size == 0:
+            logger.error(
+                f"YouTube download reported success but file missing: {cache_path}"
+            )
+            return False
+
+        logger.info(
+            f"YouTube download complete: {cache_path.name} "
+            f"({cache_path.stat().st_size // 1024} KB)"
+        )
+        return True

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -2464,6 +2464,11 @@ def get_input_source_resolution(
     """Probe the native resolution of a specific input source."""
     source_class = _resolve_input_source_class(source_type)
 
+    from scope.core.inputs.interface import (
+        InvalidSourceURLError,
+        SourceUnavailableError,
+    )
+
     try:
         instance = source_class()
         try:
@@ -2482,6 +2487,10 @@ def get_input_source_resolution(
             instance.close()
     except HTTPException:
         raise
+    except InvalidSourceURLError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except SourceUnavailableError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Error probing resolution for '{source_type}/{identifier}': {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/scope/server/graph_schema.py
+++ b/src/scope/server/graph_schema.py
@@ -51,11 +51,11 @@ class GraphNode(BaseModel):
     )
     source_mode: str | None = Field(
         default=None,
-        description="Video source mode for source nodes: 'video', 'camera', 'spout', 'ndi', 'syphon'",
+        description="Video source mode for source nodes: 'video', 'camera', 'spout', 'ndi', 'syphon', 'youtube'",
     )
     source_name: str | None = Field(
         default=None,
-        description="Source name/identifier for Spout/NDI/Syphon sources (sender name for Spout, source identifier for NDI/Syphon)",
+        description="Source name/identifier for Spout/NDI/Syphon/YouTube sources (sender name for Spout, source identifier for NDI/Syphon, video URL for YouTube)",
     )
     tempo_sync: bool = Field(
         default=False,

--- a/src/scope/server/source_manager.py
+++ b/src/scope/server/source_manager.py
@@ -347,7 +347,13 @@ class SourceManager:
         for node in graph.nodes:
             if node.type != "source":
                 continue
-            if node.source_mode not in ("spout", "ndi", "syphon", "video_file"):
+            if node.source_mode not in (
+                "spout",
+                "ndi",
+                "syphon",
+                "video_file",
+                "youtube",
+            ):
                 continue
             source_name = node.source_name or ""
             node_id = node.id

--- a/uv.lock
+++ b/uv.lock
@@ -602,6 +602,7 @@ dependencies = [
     { name = "triton-windows", marker = "sys_platform == 'win32'" },
     { name = "twilio" },
     { name = "uvicorn" },
+    { name = "yt-dlp" },
 ]
 
 [package.optional-dependencies]
@@ -675,6 +676,7 @@ requires-dist = [
     { name = "twilio", specifier = ">=9.8.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'livepeer'", specifier = ">=0.35.0" },
+    { name = "yt-dlp", specifier = ">=2024.10.0" },
 ]
 provides-extras = ["kafka", "livepeer", "link", "midi"]
 
@@ -3507,6 +3509,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/34/7c6b4e3f89cb6416d2cd7ab6dab141a1df97ab0fb22d15816db2c92148c9/yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9", size = 3119221, upload-time = "2026-03-17T23:43:00.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8", size = 3315134, upload-time = "2026-03-17T23:42:57.863Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a new "youtube" option to the Source node that downloads a YouTube video via yt-dlp into a per-video-id cache and plays it on loop by delegating frame decoding to VideoFileInputSource. The probe endpoint differentiates 400 (invalid URL) / 404 (unavailable / private / live) / 408 (timeout) so the UI can render accurate status.