### PR TITLE
Add flip option to Syphon inputs.

### DIFF
--- a/frontend/src/components/InputAndControlsPanel.tsx
+++ b/frontend/src/components/InputAndControlsPanel.tsx
@@ -88,6 +88,8 @@ interface InputAndControlsPanelProps {
   // Currently selected Syphon source identifier
   selectedSyphonSource?: string;
   onSyphonSourceChange?: (identifier: string) => void;
+  syphonFlipVertical?: boolean;
+  onSyphonFlipVerticalChange?: (enabled: boolean) => void;
   // VACE reference images (only shown when VACE is enabled)
   vaceEnabled?: boolean;
   refImages?: string[];
@@ -160,6 +162,8 @@ export function InputAndControlsPanel({
   onNdiSourceChange,
   selectedSyphonSource = "",
   onSyphonSourceChange,
+  syphonFlipVertical = false,
+  onSyphonFlipVerticalChange,
   vaceEnabled = true,
   refImages = [],
   onRefImagesChange,
@@ -228,7 +232,9 @@ export function InputAndControlsPanel({
   // Use higher FPS for Syphon since it's local GPU sharing with minimal overhead
   const syphonStreamUrl =
     mode === "syphon" && selectedSyphonSource
-      ? getInputSourceStreamUrl("syphon", selectedSyphonSource, 15)
+      ? getInputSourceStreamUrl("syphon", selectedSyphonSource, 15, {
+          flipVertical: syphonFlipVertical,
+        })
       : null;
   const [isSyphonStreamLoaded, setIsSyphonStreamLoaded] = useState(false);
 
@@ -574,6 +580,21 @@ export function InputAndControlsPanel({
                     )}
                   </div>
                 )}
+                <div className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+                  <div className="min-w-0">
+                    <div className="text-sm">Flip Vertical</div>
+                    <div className="text-xs text-muted-foreground">
+                      Compensate for Syphon senders that arrive upside down.
+                    </div>
+                  </div>
+                  <Switch
+                    checked={syphonFlipVertical}
+                    onCheckedChange={checked =>
+                      onSyphonFlipVerticalChange?.(checked)
+                    }
+                    disabled={mode !== "syphon" || isStreaming}
+                  />
+                </div>
               </div>
             ) : (
               /* Video/Camera Input Preview */

--- a/frontend/src/components/graph/nodes/SourceNode.tsx
+++ b/frontend/src/components/graph/nodes/SourceNode.tsx
@@ -34,6 +34,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const { collapsed, toggleCollapse } = useNodeCollapse();
   const sourceMode = data.sourceMode || "video";
   const sourceName = data.sourceName || "";
+  const sourceFlipVertical = data.sourceFlipVertical === true;
   const localStream = data.localStream as MediaStream | null | undefined;
   const onVideoFileUpload = data.onVideoFileUpload as
     | ((file: File) => Promise<boolean>)
@@ -153,6 +154,12 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     onSyphonSourceChange?.(identifier);
   };
 
+  const handleSyphonFlipVerticalChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    updateData({ sourceFlipVertical: e.target.checked });
+  };
+
   const handleFileClick = useCallback(() => {
     fileInputRef.current?.click();
   }, []);
@@ -199,7 +206,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
       {!collapsed && (
         <div className="px-2 py-1.5 flex flex-col gap-1.5 flex-1 min-h-0">
           <div className="px-2">
-            <NodeParamRow label="Source">
+            <NodeParamRow label="Source" className="justify-start gap-2">
               <NodePillSelect
                 value={sourceMode}
                 onChange={handleSourceModeChange}
@@ -266,7 +273,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
 
           {sourceMode === "syphon" && (
             <div className="px-2 flex flex-col gap-1.5">
-              <NodeParamRow label="Source">
+              <NodeParamRow label="Source" className="justify-start gap-2">
                 <div className="flex items-center gap-1">
                   <NodePillSearchableSelect
                     value={sourceName}
@@ -302,6 +309,20 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
                     </svg>
                   </button>
                 </div>
+              </NodeParamRow>
+              <NodeParamRow label="Flip Y" className="justify-start gap-2">
+                <label className="flex items-center gap-2 text-[10px] text-[#fafafa]">
+                  <input
+                    type="checkbox"
+                    checked={sourceFlipVertical}
+                    onChange={handleSyphonFlipVerticalChange}
+                    className="h-3 w-3 accent-white"
+                    disabled={data.isStreaming === true}
+                  />
+                  <span className="text-left text-[#8c8c8d]">
+                    Fix flipped inputs
+                  </span>
+                </label>
               </NodeParamRow>
             </div>
           )}

--- a/frontend/src/hooks/useUnifiedWebRTC.ts
+++ b/frontend/src/hooks/useUnifiedWebRTC.ts
@@ -35,6 +35,7 @@ interface InitialParameters {
     enabled: boolean;
     source_type: string;
     source_name: string;
+    flip_vertical?: boolean;
   };
   produces_video?: boolean;
   produces_audio?: boolean;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -341,9 +341,15 @@ export const getInputSourceResolution = async (
 export const getInputSourceStreamUrl = (
   sourceType: string,
   identifier: string,
-  fps = 2
-): string =>
-  `/api/v1/input-sources/${sourceType}/sources/${encodeURIComponent(identifier)}/stream?fps=${fps}`;
+  fps = 2,
+  options?: { flipVertical?: boolean }
+): string => {
+  const params = new URLSearchParams({ fps: String(fps) });
+  if (options?.flipVertical) {
+    params.set("flip_vertical", "true");
+  }
+  return `/api/v1/input-sources/${sourceType}/sources/${encodeURIComponent(identifier)}/stream?${params.toString()}`;
+};
 
 export const fetchCurrentLogs = async (): Promise<string> => {
   const response = await fetch("/api/v1/logs/current", {
@@ -915,6 +921,7 @@ export interface GraphNode {
   h?: number | null;
   source_mode?: string | null;
   source_name?: string | null;
+  source_flip_vertical?: boolean;
   tempo_sync?: boolean;
   sink_mode?: string | null;
   sink_name?: string | null;

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -178,6 +178,8 @@ export interface FlowNodeData {
   sourceMode?: "video" | "camera" | "spout" | "ndi" | "syphon";
   /** For source nodes: source name/identifier for Spout/NDI (sender name for Spout, identifier for NDI) */
   sourceName?: string;
+  /** For source nodes: whether incoming Syphon frames should be flipped vertically */
+  sourceFlipVertical?: boolean;
   /** For source nodes: local video preview stream (camera or file) */
   localStream?: MediaStream | null;
   /** For source nodes: callback to upload a video file */
@@ -699,6 +701,7 @@ export function graphConfigToFlow(
             | "syphon"
             | undefined) ?? "video",
         sourceName: n.source_name ?? undefined,
+        sourceFlipVertical: n.source_flip_vertical ?? false,
       },
     });
   });
@@ -1221,6 +1224,10 @@ export function flowToGraphConfig(
         n.data.nodeType === "source" ? (n.data.sourceMode ?? null) : undefined,
       source_name:
         n.data.nodeType === "source" ? (n.data.sourceName ?? null) : undefined,
+      source_flip_vertical:
+        n.data.nodeType === "source"
+          ? Boolean(n.data.sourceFlipVertical)
+          : undefined,
       tempo_sync: tempoConnectedPipelineIds.has(n.id) || undefined,
     };
   });
@@ -1426,6 +1433,7 @@ export function applyHardwareInputSourceToLinearGraph(
     enabled: boolean;
     source_type: string;
     source_name: string;
+    flip_vertical?: boolean;
   }
 ): GraphConfig {
   const t = inputSource?.source_type;
@@ -1443,6 +1451,8 @@ export function applyHardwareInputSourceToLinearGraph(
             ...n,
             source_mode: t,
             source_name: inputSource.source_name ?? "",
+            source_flip_vertical:
+              t === "syphon" ? Boolean(inputSource.flip_vertical) : false,
           }
         : n
     ),

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -1632,11 +1632,16 @@ export function StreamPage() {
           enabled: true,
           source_type: "syphon",
           source_name: settings.inputSource?.source_name ?? "",
+          flip_vertical: settings.inputSource?.flip_vertical ?? false,
         },
       });
     } else {
       updateSettings({
-        inputSource: { enabled: false, source_type: "", source_name: "" },
+        inputSource: {
+          enabled: false,
+          source_type: "",
+          source_name: "",
+        },
       });
     }
     switchMode(newMode);
@@ -1677,6 +1682,7 @@ export function StreamPage() {
         enabled: true,
         source_type: "syphon",
         source_name: identifier,
+        flip_vertical: settings.inputSource?.flip_vertical ?? false,
       },
     });
 
@@ -1695,6 +1701,17 @@ export function StreamPage() {
     } catch (e) {
       console.warn("Could not probe Syphon source resolution:", e);
     }
+  };
+
+  const handleSyphonFlipVerticalChange = (enabled: boolean) => {
+    updateSettings({
+      inputSource: {
+        enabled: true,
+        source_type: "syphon",
+        source_name: settings.inputSource?.source_name ?? "",
+        flip_vertical: enabled,
+      },
+    });
   };
 
   const handleLivePromptSubmit = useCallback(
@@ -2243,6 +2260,7 @@ export function StreamPage() {
         enabled: boolean;
         source_type: string;
         source_name: string;
+        flip_vertical?: boolean;
       } | null = null;
       // Sink node IDs for multi-track WebRTC
       const graphSinkNodeIds: string[] = [];
@@ -2307,6 +2325,12 @@ export function StreamPage() {
                     enabled: true,
                     source_type: sm,
                     source_name: sourceNode.source_name ?? "",
+                    ...(sm === "syphon"
+                      ? {
+                          flip_vertical:
+                            sourceNode.source_flip_vertical ?? false,
+                        }
+                      : {}),
                   };
                   break;
                 }
@@ -2767,6 +2791,7 @@ export function StreamPage() {
           enabled: boolean;
           source_type: string;
           source_name: string;
+          flip_vertical?: boolean;
         };
         graph?: GraphConfig;
       } = {
@@ -3250,6 +3275,10 @@ export function StreamPage() {
                           sourceNode?.source_name ??
                           settings.inputSource?.source_name ??
                           "",
+                        flip_vertical:
+                          sourceNode?.source_flip_vertical ??
+                          settings.inputSource?.flip_vertical ??
+                          false,
                       },
                     });
                     switchMode(sourceMode);
@@ -3401,6 +3430,12 @@ export function StreamPage() {
                     : ""
                 }
                 onSyphonSourceChange={handleSyphonSourceChange}
+                syphonFlipVertical={
+                  settings.inputSource?.source_type === "syphon"
+                    ? (settings.inputSource?.flip_vertical ?? false)
+                    : false
+                }
+                onSyphonFlipVerticalChange={handleSyphonFlipVerticalChange}
                 vaceEnabled={
                   settings.vaceEnabled ??
                   (pipelines?.[settings.pipelineId]?.supportsVACE &&

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -102,6 +102,7 @@ export interface SettingsState {
     enabled: boolean;
     source_type: string;
     source_name: string;
+    flip_vertical?: boolean;
   };
   // Beat-quantize mode for discrete parameter changes
   quantizeMode?: "none" | "beat" | "bar" | "2_bar" | "4_bar";

--- a/src/scope/core/inputs/syphon.py
+++ b/src/scope/core/inputs/syphon.py
@@ -32,6 +32,13 @@ class SyphonInputSource(InputSource):
     def __init__(self):
         self._receiver = None
         self._connected = False
+        self._flip_vertical = False
+
+    def set_flip_vertical(self, enabled: bool) -> None:
+        """Flip received frames vertically to compensate for sender orientation."""
+        self._flip_vertical = enabled
+        if self._receiver is not None:
+            self._receiver.set_flip_vertical(enabled)
 
     @classmethod
     def is_available(cls) -> bool:
@@ -84,7 +91,7 @@ class SyphonInputSource(InputSource):
 
             self.disconnect()
 
-            self._receiver = SyphonReceiver()
+            self._receiver = SyphonReceiver(flip_vertical=self._flip_vertical)
             if self._receiver.connect(identifier):
                 self._connected = True
                 logger.info(

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -2489,7 +2489,10 @@ def get_input_source_resolution(
 
 @app.get("/api/v1/input-sources/{source_type}/sources/{identifier:path}/stream")
 async def stream_input_source_preview(
-    source_type: str, identifier: str, fps: int = Query(2, ge=1, le=30)
+    source_type: str,
+    identifier: str,
+    fps: int = Query(2, ge=1, le=30),
+    flip_vertical: bool = Query(False),
 ):
     """MJPEG stream of an input source for live preview."""
     source_class = _resolve_input_source_class(source_type)
@@ -2505,6 +2508,8 @@ async def stream_input_source_preview(
         try:
             # Create persistent receiver
             receiver = source_class()
+            if source_type == "syphon" and hasattr(receiver, "set_flip_vertical"):
+                receiver.set_flip_vertical(flip_vertical)
             connected = await loop.run_in_executor(None, receiver.connect, identifier)
             if not connected:
                 logger.warning(f"Preview stream: could not connect to '{identifier}'")

--- a/src/scope/server/graph_schema.py
+++ b/src/scope/server/graph_schema.py
@@ -57,6 +57,10 @@ class GraphNode(BaseModel):
         default=None,
         description="Source name/identifier for Spout/NDI/Syphon sources (sender name for Spout, source identifier for NDI/Syphon)",
     )
+    source_flip_vertical: bool = Field(
+        default=False,
+        description="When true for Syphon sources, flip frames vertically before routing them into the graph.",
+    )
     tempo_sync: bool = Field(
         default=False,
         description="When true, this pipeline receives beat state injection, modulation, and beat cache resets.",

--- a/src/scope/server/source_manager.py
+++ b/src/scope/server/source_manager.py
@@ -169,7 +169,7 @@ class SourceManager:
         )
 
         if enabled and not self._source_enabled:
-            self._create_and_connect(source_type, source_name)
+            self._create_and_connect(source_type, source_name, config)
 
         elif not enabled and self._source_enabled:
             self._stop_primary_source()
@@ -179,9 +179,11 @@ class SourceManager:
             source_type != self._source_type or config.get("reconnect", False)
         ):
             self._stop_primary_source()
-            self._create_and_connect(source_type, source_name)
+            self._create_and_connect(source_type, source_name, config)
 
-    def _create_and_connect(self, source_type: str, source_name: str) -> None:
+    def _create_and_connect(
+        self, source_type: str, source_name: str, config: dict | None = None
+    ) -> None:
         """Create an input source instance and connect to the given source."""
         from scope.core.inputs import get_input_source_classes
 
@@ -203,6 +205,10 @@ class SourceManager:
 
         try:
             self._source = source_class()
+            if source_type == "syphon" and hasattr(self._source, "set_flip_vertical"):
+                self._source.set_flip_vertical(
+                    bool((config or {}).get("flip_vertical", False))
+                )
             if self._source.connect(source_name):
                 self._source_enabled = True
                 self._source_type = source_type
@@ -364,6 +370,10 @@ class SourceManager:
 
             try:
                 source = source_class()
+                if node.source_mode == "syphon" and hasattr(
+                    source, "set_flip_vertical"
+                ):
+                    source.set_flip_vertical(node.source_flip_vertical)
                 if source.connect(source_name):
                     thread = threading.Thread(
                         target=self._receiver_loop,

--- a/src/scope/server/syphon/receiver.py
+++ b/src/scope/server/syphon/receiver.py
@@ -122,10 +122,15 @@ class SyphonReceiver:
             receiver.release()
     """
 
-    def __init__(self):
+    def __init__(self, flip_vertical: bool = False):
         self._client: Any | None = None
         self._connected_server: SyphonServerInfo | None = None
         self._frame_count = 0
+        self._flip_vertical = flip_vertical
+
+    def set_flip_vertical(self, enabled: bool) -> None:
+        """Configure whether received frames should be vertically flipped."""
+        self._flip_vertical = enabled
 
     def discover(self) -> list[SyphonServerInfo]:
         """Discover all available Syphon servers on the system."""
@@ -224,15 +229,16 @@ class SyphonReceiver:
             image = copy_mtl_texture_to_image(texture)
             self._frame_count += 1
 
+            if self._flip_vertical:
+                image = np.flipud(image)
+
             # Handle BGRA pixel format (common macOS default)
-            pixel_format = texture.pixelFormat()
-            if pixel_format == Metal.MTLPixelFormatBGRA8Unorm:
+            if texture.pixelFormat() == Metal.MTLPixelFormatBGRA8Unorm:
                 image = image[:, :, [2, 1, 0, 3]]
 
             if as_rgb:
                 return np.ascontiguousarray(image[:, :, :3])
-            else:
-                return image.copy()
+            return np.ascontiguousarray(image)
 
         except Exception as e:
             logger.error(f"Error receiving Syphon frame: {e}")


### PR DESCRIPTION
Sometimes Syphon inputs appear upside-down. This is most likely because of coordinate-system mismatch between GPU textures and normal image buffers.

What’s going on:

- Syphon shares GPU textures.
- GPU texture coordinates are often treated as bottom-left / Y-up.
- Our pipeline code and numpy image arrays expect top-left / Y-down.
- syphon-python’s copy_mtl_texture_to_image() appears to just copy raw texture bytes into an array without normalizing orientation.
- So if the sender publishes a texture in the “GPU-native” orientation, we read it back as a normal image and it appears vertically flipped.

Also left-align the input elements of the Syphon box.

Note this can only be toggled when a stream is inactive. Making the input flippable while active seemed to reach pretty deeply into the code and I couldn't really understand that, so avoided it.

Before / after:

<img width="1386" height="848" alt="image" src="https://github.com/user-attachments/assets/5760ebbe-d4b9-4b6b-b1fb-b4f27d5120f2" />
<img width="1470" height="1001" alt="image" src="https://github.com/user-attachments/assets/723233cf-eaf1-4639-abde-a7eb83363d53" />
