### PR TITLE
Fix Syphon reloads in workflow mode

### DIFF
--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -2713,8 +2713,17 @@ export function StreamPage() {
         return false;
       }
 
-      // Check video requirements based on input mode
+      // Check video requirements based on input mode.
       const needsVideoInput = currentMode === "video";
+      const graphHasBrowserBackedSources = Boolean(
+        graphConfigForStream?.nodes?.some(
+          n =>
+            n.type === "source" &&
+            (n.source_mode || "video") !== "spout" &&
+            (n.source_mode || "video") !== "ndi" &&
+            (n.source_mode || "video") !== "syphon"
+        )
+      );
       const isSpoutMode =
         mode === "spout" && settings.inputSource?.source_type === "spout";
       const isNdiMode =
@@ -2722,21 +2731,19 @@ export function StreamPage() {
       const isSyphonMode =
         mode === "syphon" && settings.inputSource?.source_type === "syphon";
       const isServerSideInput = isSpoutMode || isNdiMode || isSyphonMode;
+      const needsBrowserVideoTrack =
+        needsVideoInput &&
+        (graphMode || nonLinearGraph
+          ? graphHasBrowserBackedSources
+          : !isServerSideInput);
 
-      // Only send video stream for pipelines that need video input (not in Spout/NDI mode)
-      const streamToSend =
-        needsVideoInput && !isServerSideInput
-          ? localStream || undefined
-          : undefined;
+      const streamToSend = needsBrowserVideoTrack
+        ? localStream || undefined
+        : undefined;
 
       const hasPerNodeStreams =
         graphMode && Object.keys(nodeLocalStreams).length > 0;
-      if (
-        needsVideoInput &&
-        !isServerSideInput &&
-        !localStream &&
-        !hasPerNodeStreams
-      ) {
+      if (needsBrowserVideoTrack && !localStream && !hasPerNodeStreams) {
         console.error("Video input required but no local stream available");
         return false;
       }

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -2715,15 +2715,6 @@ export function StreamPage() {
 
       // Check video requirements based on input mode.
       const needsVideoInput = currentMode === "video";
-      const graphHasBrowserBackedSources = Boolean(
-        graphConfigForStream?.nodes?.some(
-          n =>
-            n.type === "source" &&
-            (n.source_mode || "video") !== "spout" &&
-            (n.source_mode || "video") !== "ndi" &&
-            (n.source_mode || "video") !== "syphon"
-        )
-      );
       const isSpoutMode =
         mode === "spout" && settings.inputSource?.source_type === "spout";
       const isNdiMode =
@@ -2734,7 +2725,7 @@ export function StreamPage() {
       const needsBrowserVideoTrack =
         needsVideoInput &&
         (graphMode || nonLinearGraph
-          ? graphHasBrowserBackedSources
+          ? !graphHasOnlyServerSideSources(graphConfigForStream)
           : !isServerSideInput);
 
       const streamToSend = needsBrowserVideoTrack


### PR DESCRIPTION
After reloading a workflow with a Syphon source, starting the stream would fail with "Video input required but no local stream available".

This happened because handleStartStream() decided whether a browser video stream was required from the global perform-mode input state (settings.inputSource) instead of the restored workflow graph. In workflow mode that global state isn't the source of truth, so graphs containing only server-side sources were incorrectly treated as needing a local stream.

Fix: In graphMode/nonLinearGraph, derive the local-stream requirement from graph topology. Only require a browser stream when the graph contains browser-backed source nodes (video/camera). Graphs with entirely server-side sources (syphon, ndi, spout) now start normally after reload.

Perform mode behavior is unchanged.