### PR TITLE
Pin bundled LTX-2 plugin to latest commit in cloud image

### DIFF
--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -47,8 +47,8 @@ COPY src/ /app/src/
 
 # Pre-install bundled plugins (cannot be removed by users)
 ENV DAYDREAM_SCOPE_BUNDLED_PLUGINS_FILE="/app/bundled-plugins.txt"
-RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git" > /app/bundled-plugins.txt
-RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git
+RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git@129e7b3ea813a92bdca28dac84c55f86002afbe3" > /app/bundled-plugins.txt
+RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git@129e7b3ea813a92bdca28dac84c55f86002afbe3
 
 # Expose port 8000 for RunPod HTTP proxy
 EXPOSE 8000

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -3432,7 +3432,7 @@ def run_server(reload: bool, host: str, port: int, no_browser: bool):
     "--cloud-app-id",
     default="Daydream/scope-app--prod/ws",
     envvar="SCOPE_CLOUD_APP_ID",
-    help="Cloud app ID for cloud mode (e.g., 'usename/scope-app')",
+    help="Cloud app ID for cloud mode (e.g., 'username/scope-app')",
 )
 @click.option(
     "--cloud-api-key",

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -3432,7 +3432,7 @@ def run_server(reload: bool, host: str, port: int, no_browser: bool):
     "--cloud-app-id",
     default="Daydream/scope-app--prod/ws",
     envvar="SCOPE_CLOUD_APP_ID",
-    help="Cloud app ID for cloud mode (e.g., 'username/scope-app')",
+    help="Cloud app ID for cloud mode (e.g., 'usename/scope-app')",
 )
 @click.option(
     "--cloud-api-key",


### PR DESCRIPTION
## Summary

- Pin the bundled `scope-ltx-2` plugin install in `Dockerfile.cloud` to commit [`129e7b3e`](https://github.com/daydreamlive/scope-ltx-2/commit/129e7b3ea813a92bdca28dac84c55f86002afbe3) ("Updating ID-LoRA and distilled 1.1 model.", 2026-04-15).
- The previous unpinned Git URL meant the Docker layer stayed cached across builds, so the cloud image kept shipping an old scope-ltx-2 revision even as upstream moved forward. Pinning to an explicit SHA busts the cache and makes bundled-plugin updates deterministic and reviewable going forward.

## Test plan

- [ ] `docker-build` workflow rebuilds the `-cloud` image successfully on this PR
- [ ] PR preview fal deploy picks up the new LTX-2 version — load the LTX-2 pipeline in the preview app and confirm it runs with the updated ID-LoRA / distilled 1.1 model

🤖 Generated with [Claude Code](https://claude.com/claude-code)