### PR TITLE
feat: accept pipeline parameters in /api/v1/session/start

### DIFF
--- a/src/scope/server/mcp_router.py
+++ b/src/scope/server/mcp_router.py
@@ -6,7 +6,7 @@ endpoints used by the MCP server and other programmatic clients.
 
 import io
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response, StreamingResponse
@@ -225,6 +225,8 @@ class StartStreamRequest(BaseModel):
     prompts: list[dict] | None = None
     input_source: dict | None = None
     graph: dict | None = None
+    parameters: dict[str, Any] | None = None
+    node_parameters: dict[str, dict[str, Any]] | None = None
 
     @model_validator(mode="after")
     def _require_pipeline_or_graph(self) -> "StartStreamRequest":
@@ -419,6 +421,13 @@ async def start_stream(
         initial_params["prompts"] = request.prompts
     if request.input_source is not None:
         initial_params["input_source"] = request.input_source
+    # Flat pipeline parameters (e.g. width/height, __prompt, noise_scale) merged
+    # into initial_parameters so they reach the pipeline on the first call,
+    # matching how the WebRTC frontend delivers them.
+    if request.parameters:
+        for key, value in request.parameters.items():
+            if key not in initial_params:
+                initial_params[key] = value
 
     try:
         if use_cloud:
@@ -436,6 +445,26 @@ async def start_stream(
                 initial_parameters=initial_params,
             )
         frame_processor.start()
+
+        # Per-node parameters target a specific graph node (e.g. longlive vs
+        # rife), distinct from the broadcast `parameters` above.
+        # - Local mode: FrameProcessor.update_parameters routes by node_id (and
+        #   buffers in _pending_node_params if the graph isn't wired yet).
+        # - Cloud mode: the pipelines live on the cloud instance, so forward
+        #   each batch over the WebRTC data channel.
+        if request.node_parameters:
+            for node_id, node_params in request.node_parameters.items():
+                payload = {"node_id": node_id, **node_params}
+                if use_cloud:
+                    try:
+                        cloud_manager.send_parameters(payload)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to forward node_parameters for "
+                            f"'{node_id}' to cloud: {e}"
+                        )
+                else:
+                    frame_processor.update_parameters(payload)
 
         # In cloud graph mode, wire cloud extra output handlers to
         # FrameProcessor's sink/record queues so that HeadlessSession


### PR DESCRIPTION
The headless session-start schema only exposed prompts/input_source, so callers (MCP tests, programmatic clients loading a .scope-workflow) had no way to pass the pipeline params that normally arrive through the WebRTC initial_parameters path. Concretely: width/height, vace_*, noise_scale, denoising_step_list, per-node __prompt, etc. — resulting in outputs at default 576x320 instead of the workflow's 512x512.

Add two optional fields to StartStreamRequest:

- parameters: dict merged into initial_parameters (broadcast to all pipelines / forwarded to cloud in the WebRTC offer).
- node_parameters: per-node-id dict routed via FrameProcessor's node_id-aware update path in local mode, and forwarded to the cloud instance via cloud_manager.send_parameters in cloud mode — which is where the pipelines actually live in relay mode.

Verified locally: loading longlive+rife and starting a session with parameters={width:512,height:512,vace_enabled:true,...} now produces 512x512 output (was 576x320 before).

LoRAs remain in /api/v1/pipeline/load's load_params, matching the pipeline_manager code path — no change needed there.