### PR TITLE
feat: plugin-registerable input sources with dynamic UI

### DIFF
--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -191,6 +191,8 @@ interface GraphEditorProps {
   spoutAvailable?: boolean;
   ndiAvailable?: boolean;
   syphonAvailable?: boolean;
+  /** Full input-source catalog — drives the dynamic Source node dropdown. */
+  availableInputSources?: import("../../lib/api").InputSourceType[];
   onSpoutSourceChange?: (name: string) => void;
   onNdiSourceChange?: (identifier: string) => void;
   onSyphonSourceChange?: (identifier: string) => void;
@@ -241,6 +243,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
       spoutAvailable = false,
       ndiAvailable = false,
       syphonAvailable = false,
+      availableInputSources = [],
       onSpoutSourceChange,
       onNdiSourceChange,
       onSyphonSourceChange,
@@ -343,6 +346,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         spoutOutputAvailable,
         ndiOutputAvailable,
         syphonOutputAvailable,
+        availableInputSources,
       },
       {
         tempoState,

--- a/frontend/src/components/graph/hooks/graph/useGraphState.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphState.ts
@@ -122,6 +122,8 @@ export interface GraphEditorAvailability {
   spoutOutputAvailable: boolean;
   ndiOutputAvailable: boolean;
   syphonOutputAvailable: boolean;
+  /** Full input-source catalog including plugin-declared UI metadata. */
+  availableInputSources: import("../../../../lib/api").InputSourceType[];
 }
 
 export function useGraphState(
@@ -299,6 +301,7 @@ export function useGraphState(
     spoutOutputAvailable: availability.spoutOutputAvailable,
     ndiOutputAvailable: availability.ndiOutputAvailable,
     syphonOutputAvailable: availability.syphonOutputAvailable,
+    availableInputSources: availability.availableInputSources,
     handleEdgeDelete,
     isStreaming: streams.isStreaming,
     isLoading: streams.isLoading ?? false,
@@ -348,6 +351,7 @@ export function useGraphState(
     availability.spoutOutputAvailable,
     availability.ndiOutputAvailable,
     availability.syphonOutputAvailable,
+    availability.availableInputSources,
     tempo.tempoState,
     tempo.tempoSources,
   ]);

--- a/frontend/src/components/graph/nodes/SourceNode.tsx
+++ b/frontend/src/components/graph/nodes/SourceNode.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useRef, useCallback, useState } from "react";
+import { useEffect, useRef, useCallback, useState, useMemo } from "react";
 import { Handle, Position } from "@xyflow/react";
 import type { NodeProps, Node } from "@xyflow/react";
 import type { FlowNodeData } from "../../../lib/graphUtils";
-import { getInputSourceSources, type DiscoveredSource } from "../../../lib/api";
+import {
+  getInputSourceSources,
+  getInputSourceResolution,
+  type DiscoveredSource,
+  type InputSourceType,
+} from "../../../lib/api";
 import { useNodeData } from "../hooks/node/useNodeData";
 import { useNodeCollapse } from "../hooks/node/useNodeCollapse";
 import {
@@ -21,13 +26,36 @@ const HEADER_H = 28;
 const BODY_PAD = 6;
 const SELECT_ROW_H = 20;
 
-const SOURCE_MODE_OPTIONS = [
+// Frontend-only modes that produce a local MediaStream (not backed by an
+// InputSource). Every other value in the dropdown is a server-side
+// source_id from /api/v1/input-sources.
+const LOCAL_MODES = [
   { value: "video", label: "File" },
   { value: "camera", label: "Camera" },
-  { value: "spout", label: "Spout" },
-  { value: "ndi", label: "NDI" },
-  { value: "syphon", label: "Syphon" },
 ];
+
+// Server-side modes that already have dedicated UI blocks below. Anything
+// else (youtube and future plugin sources) falls through to the generic
+// renderer driven by the source's declared ``params``.
+const KNOWN_SERVER_MODES = new Set(["spout", "ndi", "syphon"]);
+
+// "video_file" is represented in the dropdown as the frontend-only "video"
+// mode, so we hide it to avoid a duplicate entry.
+const HIDDEN_SERVER_MODES = new Set(["video_file"]);
+
+type InputKind = "url" | "discovered" | "asset";
+
+function getSourceNameParam(src: InputSourceType | undefined) {
+  return src?.params.find(p => p.name === "source_name");
+}
+
+function getInputKind(src: InputSourceType | undefined): InputKind | null {
+  const p = getSourceNameParam(src);
+  const ui = p?.ui as Record<string, unknown> | undefined;
+  const kind = ui?.input_kind;
+  if (kind === "url" || kind === "discovered" || kind === "asset") return kind;
+  return null;
+}
 
 export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const { updateData } = useNodeData(id);
@@ -45,6 +73,13 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const spoutAvailable = data.spoutAvailable ?? false;
   const ndiAvailable = data.ndiAvailable ?? false;
   const syphonAvailable = data.syphonAvailable ?? false;
+  const availableInputSourcesRaw = data.availableInputSources as
+    | InputSourceType[]
+    | undefined;
+  const availableInputSources = useMemo<InputSourceType[]>(
+    () => availableInputSourcesRaw ?? [],
+    [availableInputSourcesRaw]
+  );
   const onSpoutSourceChange = data.onSpoutSourceChange as
     | ((name: string) => void)
     | undefined;
@@ -64,6 +99,21 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const [isDiscoveringNdi, setIsDiscoveringNdi] = useState(false);
   const [syphonSources, setSyphonSources] = useState<DiscoveredSource[]>([]);
   const [isDiscoveringSyphon, setIsDiscoveringSyphon] = useState(false);
+
+  // Generic discovery + probe state for plugin-declared sources
+  const [pluginSources, setPluginSources] = useState<DiscoveredSource[]>([]);
+  const [isDiscoveringPlugin, setIsDiscoveringPlugin] = useState(false);
+  const [probeStatus, setProbeStatus] = useState<{
+    state: "idle" | "probing" | "ok" | "error";
+    message: string;
+  }>({ state: "idle", message: "" });
+
+  const currentSourceDef = useMemo(
+    () => availableInputSources.find(s => s.source_id === sourceMode),
+    [availableInputSources, sourceMode]
+  );
+  const currentSourceNameParam = getSourceNameParam(currentSourceDef);
+  const currentInputKind = getInputKind(currentSourceDef);
 
   useEffect(() => {
     if (videoRef.current && localStream instanceof MediaStream) {
@@ -128,13 +178,90 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     }
   }, [syphonAvailable]);
 
+  // Generic discovery for plugin-declared "discovered" sources.
+  const discoverPluginSources = useCallback(async () => {
+    if (!currentSourceDef) return;
+    setIsDiscoveringPlugin(true);
+    try {
+      const result = await getInputSourceSources(currentSourceDef.source_id);
+      setPluginSources(result.sources);
+    } catch (e) {
+      console.error(
+        `Failed to discover ${currentSourceDef.source_id} sources:`,
+        e
+      );
+      setPluginSources([]);
+    } finally {
+      setIsDiscoveringPlugin(false);
+    }
+  }, [currentSourceDef]);
+
+  // Auto-discover when switching to a plugin "discovered" source.
+  useEffect(() => {
+    if (
+      currentSourceDef &&
+      !KNOWN_SERVER_MODES.has(sourceMode) &&
+      currentInputKind === "discovered"
+    ) {
+      discoverPluginSources();
+    }
+  }, [sourceMode, currentSourceDef, currentInputKind, discoverPluginSources]);
+
+  // Probe URL-based plugin sources (debounced).
+  useEffect(() => {
+    if (KNOWN_SERVER_MODES.has(sourceMode)) return;
+    if (!currentSourceDef) return;
+    const ui = currentSourceNameParam?.ui as
+      | Record<string, unknown>
+      | undefined;
+    if (!ui?.probe || currentInputKind !== "url") return;
+
+    if (!sourceName.trim()) {
+      setProbeStatus({ state: "idle", message: "" });
+      return;
+    }
+
+    setProbeStatus({ state: "probing", message: "Checking…" });
+    const handle = setTimeout(async () => {
+      try {
+        const { width, height } = await getInputSourceResolution(
+          currentSourceDef.source_id,
+          sourceName,
+          15000
+        );
+        setProbeStatus({
+          state: "ok",
+          message: `Ready (${width}×${height})`,
+        });
+      } catch (e) {
+        const msg =
+          e instanceof Error ? e.message : "Could not read this source";
+        // Map HTTP errors to friendly messages
+        let friendly = msg;
+        if (/\b400\b/.test(msg)) friendly = "Invalid URL";
+        else if (/\b404\b/.test(msg)) friendly = "Video is unavailable";
+        else if (/\b408\b/.test(msg)) friendly = "Could not read this source";
+        setProbeStatus({ state: "error", message: friendly });
+      }
+    }, 600);
+    return () => clearTimeout(handle);
+  }, [
+    sourceName,
+    sourceMode,
+    currentSourceDef,
+    currentSourceNameParam,
+    currentInputKind,
+  ]);
+
   const handleSourceModeChange = (newMode: string) => {
     updateData({
-      sourceMode: newMode as "video" | "camera" | "spout" | "ndi" | "syphon",
-      ...(newMode !== "spout" && newMode !== "ndi" && newMode !== "syphon"
+      sourceMode: newMode,
+      // Reset source_name when leaving any server-side mode that used it
+      ...(newMode === "video" || newMode === "camera"
         ? { sourceName: undefined }
         : {}),
     });
+    setProbeStatus({ state: "idle", message: "" });
     onSourceModeChange?.(newMode);
   };
 
@@ -144,12 +271,12 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     onSpoutSourceChange?.(name);
   };
 
-  const handleNdiSourceChange = (identifier: string) => {
+  const handleNdiSourceChange_ = (identifier: string) => {
     updateData({ sourceName: identifier });
     onNdiSourceChange?.(identifier);
   };
 
-  const handleSyphonSourceChange = (identifier: string) => {
+  const handleSyphonSourceChange_ = (identifier: string) => {
     updateData({ sourceName: identifier });
     onSyphonSourceChange?.(identifier);
   };
@@ -158,6 +285,10 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     updateData({ sourceFlipVertical: e.target.checked });
+  };
+
+  const handlePluginSourceNameChange = (value: string | number) => {
+    updateData({ sourceName: String(value) });
   };
 
   const handleFileClick = useCallback(() => {
@@ -178,13 +309,29 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const showFilePicker = sourceMode === "video";
   const handleY = HEADER_H + BODY_PAD + SELECT_ROW_H / 2;
 
-  // Filter source mode options based on availability
-  const filteredSourceModeOptions = SOURCE_MODE_OPTIONS.filter(opt => {
-    if (opt.value === "spout") return spoutAvailable;
-    if (opt.value === "ndi") return ndiAvailable;
-    if (opt.value === "syphon") return syphonAvailable;
-    return true;
-  });
+  // Dropdown options: frontend-only modes + all available server-side
+  // sources (excluding hidden ones like video_file). Availability is
+  // honored for the three known server-side modes; plugin sources are
+  // included if their backend reports ``available``.
+  const sourceModeOptions = useMemo(() => {
+    const opts: { value: string; label: string }[] = [...LOCAL_MODES];
+    for (const s of availableInputSources) {
+      if (HIDDEN_SERVER_MODES.has(s.source_id)) continue;
+      if (!s.available) {
+        if (s.source_id === "spout" && !spoutAvailable) continue;
+        if (s.source_id === "ndi" && !ndiAvailable) continue;
+        if (s.source_id === "syphon" && !syphonAvailable) continue;
+        continue;
+      }
+      // Preserve the legacy capitalized labels for the three known modes
+      let label = s.source_name;
+      if (s.source_id === "spout") label = "Spout";
+      if (s.source_id === "ndi") label = "NDI";
+      if (s.source_id === "syphon") label = "Syphon";
+      opts.push({ value: s.source_id, label });
+    }
+    return opts;
+  }, [availableInputSources, spoutAvailable, ndiAvailable, syphonAvailable]);
 
   const ndiOptions = ndiSources.map(s => ({
     value: s.identifier,
@@ -194,6 +341,15 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     value: s.identifier,
     label: s.name,
   }));
+  const pluginOptions = pluginSources.map(s => ({
+    value: s.identifier,
+    label: s.name,
+  }));
+
+  const isPluginMode =
+    !showPreview &&
+    !KNOWN_SERVER_MODES.has(sourceMode) &&
+    currentSourceDef !== undefined;
 
   return (
     <NodeCard selected={selected} collapsed={collapsed} autoMinHeight={false}>
@@ -210,7 +366,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
               <NodePillSelect
                 value={sourceMode}
                 onChange={handleSourceModeChange}
-                options={filteredSourceModeOptions}
+                options={sourceModeOptions}
               />
             </NodeParamRow>
           </div>
@@ -235,7 +391,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
                 <div className="flex items-center gap-1">
                   <NodePillSearchableSelect
                     value={sourceName}
-                    onChange={handleNdiSourceChange}
+                    onChange={handleNdiSourceChange_}
                     options={ndiOptions}
                     placeholder={
                       isDiscoveringNdi
@@ -277,7 +433,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
                 <div className="flex items-center gap-1">
                   <NodePillSearchableSelect
                     value={sourceName}
-                    onChange={handleSyphonSourceChange}
+                    onChange={handleSyphonSourceChange_}
                     options={syphonOptions}
                     placeholder={
                       isDiscoveringSyphon
@@ -324,6 +480,84 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
                   </span>
                 </label>
               </NodeParamRow>
+            </div>
+          )}
+
+          {isPluginMode && (
+            <div className="px-2 flex flex-col gap-1.5">
+              {currentInputKind === "url" && (
+                <>
+                  <NodeParamRow label="URL">
+                    <NodePillInput
+                      type="text"
+                      value={sourceName}
+                      onChange={handlePluginSourceNameChange}
+                      placeholder={
+                        (currentSourceNameParam?.ui?.[
+                          "placeholder"
+                        ] as string) || ""
+                      }
+                    />
+                  </NodeParamRow>
+                  {probeStatus.state !== "idle" && (
+                    <div
+                      className={`text-[10px] px-2 ${
+                        probeStatus.state === "error"
+                          ? "text-red-400"
+                          : probeStatus.state === "ok"
+                            ? "text-green-400"
+                            : "text-[#8c8c8d]"
+                      }`}
+                    >
+                      {probeStatus.message}
+                    </div>
+                  )}
+                </>
+              )}
+              {currentInputKind === "discovered" && (
+                <NodeParamRow label="Source">
+                  <div className="flex items-center gap-1">
+                    <NodePillSearchableSelect
+                      value={sourceName}
+                      onChange={handlePluginSourceNameChange}
+                      options={pluginOptions}
+                      placeholder={
+                        isDiscoveringPlugin
+                          ? "Discovering..."
+                          : pluginOptions.length === 0
+                            ? "No sources"
+                            : "Select source"
+                      }
+                      disabled={isDiscoveringPlugin}
+                      className="flex-1"
+                    />
+                    <button
+                      type="button"
+                      onClick={discoverPluginSources}
+                      disabled={isDiscoveringPlugin}
+                      className="w-5 h-5 flex items-center justify-center text-[#fafafa] hover:text-blue-400 transition-colors disabled:opacity-50"
+                      title={`Refresh ${currentSourceDef?.source_name ?? ""} sources`}
+                    >
+                      <svg
+                        className={`h-3 w-3 ${isDiscoveringPlugin ? "animate-spin" : ""}`}
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
+                      </svg>
+                    </button>
+                  </div>
+                </NodeParamRow>
+              )}
+              {currentSourceNameParam?.ui?.["help"] ? (
+                <div className="px-2 text-[10px] text-[#8c8c8d]">
+                  {String(currentSourceNameParam.ui["help"])}
+                </div>
+              ) : null}
             </div>
           )}
 
@@ -402,7 +636,8 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
           {!showPreview &&
             sourceMode !== "spout" &&
             sourceMode !== "ndi" &&
-            sourceMode !== "syphon" && (
+            sourceMode !== "syphon" &&
+            !isPluginMode && (
               <div className="flex items-center justify-center rounded-md bg-black/30 text-[10px] text-[#8c8c8d] flex-1 min-h-[40px]">
                 Waiting for input...
               </div>

--- a/frontend/src/components/graph/utils/nodeEnrichment.ts
+++ b/frontend/src/components/graph/utils/nodeEnrichment.ts
@@ -1,7 +1,11 @@
 import type { Edge, Node } from "@xyflow/react";
 import { extractParameterPorts } from "../../../lib/graphUtils";
 import type { FlowNodeData } from "../../../lib/graphUtils";
-import type { GraphConfig, PipelineSchemaInfo } from "../../../lib/api";
+import type {
+  GraphConfig,
+  InputSourceType,
+  PipelineSchemaInfo,
+} from "../../../lib/api";
 import { buildEdgeStyle } from "../constants";
 
 export interface EnrichNodesDeps {
@@ -47,6 +51,8 @@ export interface EnrichNodesDeps {
   spoutAvailable: boolean;
   ndiAvailable: boolean;
   syphonAvailable: boolean;
+  /** Full input-source catalog including plugin-declared UI metadata. */
+  availableInputSources: InputSourceType[];
   spoutOutputAvailable: boolean;
   ndiOutputAvailable: boolean;
   syphonOutputAvailable: boolean;
@@ -171,6 +177,7 @@ export function enrichNodes(
           spoutAvailable: deps.spoutAvailable,
           ndiAvailable: deps.ndiAvailable,
           syphonAvailable: deps.syphonAvailable,
+          availableInputSources: deps.availableInputSources,
           onSpoutSourceChange: (name: string) =>
             deps.onSpoutSourceChangeRef.current?.(name),
           onNdiSourceChange: (identifier: string) =>

--- a/frontend/src/hooks/useVideoSource.ts
+++ b/frontend/src/hooks/useVideoSource.ts
@@ -1,6 +1,19 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 
-export type VideoSourceMode = "video" | "camera" | "spout" | "ndi" | "syphon";
+// "video" and "camera" are browser-only modes that produce a local
+// MediaStream. Every other value is a server-side source_id (ndi,
+// syphon, spout, youtube, any plugin source) and is handled as a
+// server-side source with no local stream.
+export type VideoSourceMode = string;
+
+export const LOCAL_STREAM_MODES: readonly VideoSourceMode[] = [
+  "video",
+  "camera",
+];
+
+export function isServerSideSourceMode(mode: VideoSourceMode): boolean {
+  return !LOCAL_STREAM_MODES.includes(mode);
+}
 
 export const SAMPLE_VIDEOS = [
   "/assets/test.mp4",
@@ -200,8 +213,9 @@ export function useVideoSource(props?: UseVideoSourceProps) {
       setMode(newMode);
       setError(null);
 
-      // Spout/NDI/Syphon mode - no local stream needed, input comes from server-side receiver
-      if (newMode === "spout" || newMode === "ndi" || newMode === "syphon") {
+      // Server-side sources (spout/ndi/syphon/youtube/any plugin) don't
+      // need a local stream — frames come from the server-side receiver.
+      if (isServerSideSourceMode(newMode)) {
         if (localStream) {
           localStream.getTracks().forEach(track => track.stop());
         }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -250,11 +250,21 @@ export const getHardwareInfo = async (): Promise<HardwareInfoResponse> => {
 
 // Input sources API
 
+export interface InputSourceParam {
+  name: string;
+  param_type: "number" | "string" | "boolean" | "select";
+  default: unknown;
+  description: string;
+  ui: Record<string, unknown> | null;
+  convertible_to_input?: boolean;
+}
+
 export interface InputSourceType {
   source_id: string;
   source_name: string;
   source_description: string;
   available: boolean;
+  params: InputSourceParam[];
 }
 
 export interface InputSourceTypesResponse {

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -177,8 +177,10 @@ export interface FlowNodeData {
   outputSinkEnabled?: boolean;
   /** For output nodes: the sender name */
   outputSinkName?: string;
-  /** For source nodes: video source mode (video, camera, spout, ndi, syphon) */
-  sourceMode?: "video" | "camera" | "spout" | "ndi" | "syphon";
+  /** For source nodes: video source mode. "video" and "camera" are
+   * frontend-only local-stream modes; anything else is a backend
+   * ``InputSource.source_id`` (spout, ndi, syphon, youtube, plugins). */
+  sourceMode?: string;
   /** For source nodes: source name/identifier for Spout/NDI (sender name for Spout, identifier for NDI) */
   sourceName?: string;
   /** For source nodes: whether incoming Syphon frames should be flipped vertically */

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -137,6 +137,11 @@ function getVaceParams(
 }
 
 /** When every source node is Spout/NDI/Syphon, the browser must not send a WebRTC video track. */
+// Frontend-only modes produce a local MediaStream from the browser.
+// Everything else is a backend-side InputSource — matches the logic in
+// useVideoSource.ts/isServerSideSourceMode.
+const LOCAL_ONLY_SOURCE_MODES = new Set(["video", "camera"]);
+
 function graphHasOnlyServerSideSources(graph: GraphConfig | null): boolean {
   const nodes = graph?.nodes;
   if (!nodes?.length) return false;
@@ -144,7 +149,7 @@ function graphHasOnlyServerSideSources(graph: GraphConfig | null): boolean {
   if (sources.length === 0) return false;
   return sources.every(n => {
     const sm = n.source_mode || "video";
-    return sm === "spout" || sm === "ndi" || sm === "syphon";
+    return !LOCAL_ONLY_SOURCE_MODES.has(sm);
   });
 }
 
@@ -793,7 +798,7 @@ export function StreamPage() {
     (newMode: string, nodeId?: string) => {
       if (!nodeId) {
         // Fallback: global mode switch (perform mode)
-        switchMode(newMode as "video" | "camera" | "spout" | "ndi" | "syphon");
+        switchMode(newMode);
         return;
       }
       // Stop any existing stream for this node
@@ -810,10 +815,11 @@ export function StreamPage() {
         createCameraStreamForNode(nodeId);
       }
       // Import/restore calls this with (mode, nodeId). Clear the global
-      // useVideoSource stream (e.g. test.mp4) when switching to server-side
-      // capture — otherwise WebRTC still sends that track alongside Syphon/NDI/Spout.
-      if (newMode === "spout" || newMode === "ndi" || newMode === "syphon") {
-        void switchMode(newMode as "spout" | "ndi" | "syphon");
+      // useVideoSource stream (e.g. test.mp4) when switching to any
+      // server-side source — otherwise WebRTC still sends that track
+      // alongside the server-side receiver.
+      if (!LOCAL_ONLY_SOURCE_MODES.has(newMode)) {
+        void switchMode(newMode);
       }
       // When switching to file mode during streaming, auto-load a sample
       // video so the WebRTC track is replaced immediately.
@@ -2320,7 +2326,7 @@ export function StreamPage() {
               // Use first server-side source for backward compat input_source param
               for (const sourceNode of sourceNodes) {
                 const sm = sourceNode.source_mode || "video";
-                if (sm === "spout" || sm === "ndi" || sm === "syphon") {
+                if (!LOCAL_ONLY_SOURCE_MODES.has(sm)) {
                   graphInputSource = {
                     enabled: true,
                     source_type: sm,
@@ -3013,9 +3019,7 @@ export function StreamPage() {
         const webrtcSourceNodes = (graphConfigForStream.nodes ?? []).filter(
           n =>
             n.type === "source" &&
-            (n.source_mode || "video") !== "spout" &&
-            (n.source_mode || "video") !== "ndi" &&
-            (n.source_mode || "video") !== "syphon"
+            LOCAL_ONLY_SOURCE_MODES.has(n.source_mode || "video")
         );
         if (webrtcSourceNodes.length > 0) {
           const streams: Record<string, MediaStream> = {};
@@ -3339,6 +3343,7 @@ export function StreamPage() {
             spoutAvailable={spoutAvailable}
             ndiAvailable={ndiAvailable}
             syphonAvailable={syphonAvailable}
+            availableInputSources={availableInputSources}
             onSpoutSourceChange={handleSpoutSourceChange}
             onNdiSourceChange={handleNdiSourceChange}
             onSyphonSourceChange={handleSyphonSourceChange}

--- a/src/scope/core/inputs/__init__.py
+++ b/src/scope/core/inputs/__init__.py
@@ -3,20 +3,34 @@
 Input sources provide video frames from external sources like NDI, Spout, etc.
 """
 
-from .interface import InputSource, InputSourceInfo
+from .interface import (
+    InputSource,
+    InputSourceError,
+    InputSourceInfo,
+    InvalidSourceURLError,
+    SourceUnavailableError,
+)
 
 __all__ = [
     "InputSource",
     "InputSourceInfo",
+    "InputSourceError",
+    "InvalidSourceURLError",
+    "SourceUnavailableError",
     "get_input_source_classes",
     "get_available_input_sources",
 ]
 
 
 def get_input_source_classes() -> dict[str, type[InputSource]]:
-    """Get a mapping of source_id -> InputSource subclass for all built-in input sources.
+    """Get a mapping of source_id -> InputSource subclass.
 
-    Returns all known classes regardless of whether they are available on this platform.
+    Merges built-in sources (discovered via try-imports below) with any
+    ``InputSource`` subclass registered through :class:`NodeRegistry`
+    (e.g. by a plugin's ``register_nodes`` hook).
+
+    Returns all known classes regardless of whether they are available on
+    this platform.
     """
     sources: dict[str, type[InputSource]] = {}
 
@@ -45,6 +59,23 @@ def get_input_source_classes() -> dict[str, type[InputSource]]:
         from .video_file import VideoFileInputSource
 
         sources[VideoFileInputSource.source_id] = VideoFileInputSource
+    except Exception:
+        pass
+
+    # Merge plugin-registered sources from the unified NodeRegistry.
+    # Plugin sources override built-ins with the same source_id so a
+    # plugin can replace a broken built-in.
+    try:
+        from scope.core.nodes.registry import NodeRegistry
+
+        for node_type_id in NodeRegistry.list_node_types():
+            cls = NodeRegistry.get(node_type_id)
+            if (
+                cls is not None
+                and isinstance(cls, type)
+                and issubclass(cls, InputSource)
+            ):
+                sources[cls.source_id] = cls
     except Exception:
         pass
 

--- a/src/scope/core/inputs/interface.py
+++ b/src/scope/core/inputs/interface.py
@@ -7,6 +7,18 @@ from typing import ClassVar
 import numpy as np
 
 
+class InputSourceError(Exception):
+    """Base class for input source errors raised during probe/connect."""
+
+
+class InvalidSourceURLError(InputSourceError):
+    """Raised when a source identifier/URL is malformed or disallowed."""
+
+
+class SourceUnavailableError(InputSourceError):
+    """Raised when a source exists but cannot be accessed (private, deleted, geo-blocked, etc.)."""
+
+
 @dataclass
 class InputSourceInfo:
     """Information about a discovered input source."""
@@ -36,6 +48,57 @@ class InputSource(ABC):
     def is_available(cls) -> bool:
         """Check if this input source is available on this platform."""
         return True
+
+    @classmethod
+    def get_definition(cls):
+        """Return a :class:`NodeDefinition` describing this source as a node type.
+
+        Input sources live in the unified :class:`NodeRegistry` alongside
+        plain nodes and pipelines, so every iteration over the registry
+        (definitions endpoint, pipeline schemas, etc.) must succeed on
+        them. The default derives the definition from the class's
+        ``source_id`` / ``source_name`` / ``source_description``, and
+        includes any UI params returned by :meth:`get_source_ui_params`
+        so the frontend can render the right controls without hardcoding
+        each source type.
+        """
+        from scope.core.nodes.base import NodeDefinition, NodePort
+
+        return NodeDefinition(
+            node_type_id=cls.source_id,
+            display_name=cls.source_name,
+            category="source",
+            description=cls.source_description,
+            inputs=[],
+            outputs=[
+                NodePort(name="video", port_type="video", description="Video output"),
+            ],
+            params=cls.get_source_ui_params(),
+            continuous=True,
+        )
+
+    @classmethod
+    def get_source_ui_params(cls):
+        """Return the UI controls the frontend should render for this source.
+
+        The first param named ``source_name`` describes how to collect the
+        identifier stored on ``GraphNode.source_name`` (URL, discovered-
+        sender dropdown, asset picker, etc.). Additional params map to
+        other ``GraphNode`` fields (e.g. ``source_flip_vertical``).
+
+        The default returns no params. Subclasses override to declare
+        their UI. Supported ``ui`` hints for a ``source_name`` param:
+
+        - ``"input_kind"``: ``"url" | "discovered" | "asset"`` — which
+          widget to render.
+        - ``"placeholder"``: placeholder text for ``url`` inputs.
+        - ``"help"``: short help text displayed under the control.
+        - ``"probe"``: bool — call ``/input-sources/{id}/sources/{name}
+          /resolution`` on change to validate and show the resolution.
+        - ``"discovery_endpoint"``: override for ``discovered`` lists
+          (defaults to ``/api/v1/input-sources/{source_id}/sources``).
+        """
+        return []
 
     @abstractmethod
     def list_sources(self, timeout_ms: int = 5000) -> list[InputSourceInfo]:

--- a/src/scope/core/inputs/ndi.py
+++ b/src/scope/core/inputs/ndi.py
@@ -68,6 +68,23 @@ class NDIInputSource(InputSource):
         """Check if the NDI SDK is installed on this system."""
         return ndi_is_available()
 
+    @classmethod
+    def get_source_ui_params(cls):
+        from scope.core.nodes.base import NodeParam
+
+        return [
+            NodeParam(
+                name="source_name",
+                param_type="string",
+                default="",
+                description="NDI sender",
+                ui={
+                    "input_kind": "discovered",
+                    "help": "Pick a discovered NDI sender on your network.",
+                },
+            ),
+        ]
+
     def list_sources(self, timeout_ms: int = 5000) -> list[InputSourceInfo]:
         """List available NDI sources on the network."""
         if self._find_instance is None:

--- a/src/scope/core/inputs/spout.py
+++ b/src/scope/core/inputs/spout.py
@@ -38,6 +38,23 @@ class SpoutInputSource(InputSource):
         except ImportError:
             return False
 
+    @classmethod
+    def get_source_ui_params(cls):
+        from scope.core.nodes.base import NodeParam
+
+        return [
+            NodeParam(
+                name="source_name",
+                param_type="string",
+                default="",
+                description="Spout sender",
+                ui={
+                    "input_kind": "discovered",
+                    "help": "Pick a Spout sender on this Windows machine.",
+                },
+            ),
+        ]
+
     def list_sources(self, timeout_ms: int = 5000) -> list[InputSourceInfo]:
         """List available Spout senders."""
         try:

--- a/src/scope/core/inputs/syphon.py
+++ b/src/scope/core/inputs/syphon.py
@@ -59,6 +59,32 @@ class SyphonInputSource(InputSource):
         except ImportError:
             return False
 
+    @classmethod
+    def get_source_ui_params(cls):
+        from scope.core.nodes.base import NodeParam
+
+        return [
+            NodeParam(
+                name="source_name",
+                param_type="string",
+                default="",
+                description="Syphon server",
+                ui={
+                    "input_kind": "discovered",
+                    "help": "Pick a Syphon server from a running macOS app.",
+                },
+            ),
+            NodeParam(
+                name="source_flip_vertical",
+                param_type="boolean",
+                default=False,
+                description="Flip vertically",
+                ui={
+                    "help": "Flip frames vertically to match the sender's orientation.",
+                },
+            ),
+        ]
+
     def list_sources(self, timeout_ms: int = 5000) -> list[InputSourceInfo]:
         """List available Syphon servers."""
         try:

--- a/src/scope/core/inputs/video_file.py
+++ b/src/scope/core/inputs/video_file.py
@@ -48,6 +48,23 @@ class VideoFileInputSource(InputSource):
         except ImportError:
             return False
 
+    @classmethod
+    def get_source_ui_params(cls):
+        from scope.core.nodes.base import NodeParam
+
+        return [
+            NodeParam(
+                name="source_name",
+                param_type="string",
+                default="",
+                description="Video file",
+                ui={
+                    "input_kind": "asset",
+                    "help": "Pick a video asset or upload a new one.",
+                },
+            ),
+        ]
+
     def list_sources(self, timeout_ms: int = 5000) -> list[InputSourceInfo]:
         """List video files from the assets directory."""
         try:

--- a/src/scope/core/nodes/__init__.py
+++ b/src/scope/core/nodes/__init__.py
@@ -18,6 +18,14 @@ def register_builtin_nodes() -> None:
     NodeRegistry.register(AudioSourceNode)
     NodeRegistry.register(SchedulerNode)
 
+    # Register built-in input sources so their NodeDefinition appears in
+    # /api/v1/nodes/definitions alongside plugin-registered sources. The
+    # frontend renders source-node UI dynamically from these definitions.
+    from scope.core.inputs import get_input_source_classes
+
+    for source_cls in get_input_source_classes().values():
+        NodeRegistry.register(source_cls)
+
 
 __all__ = [
     "AudioSourceNode",

--- a/src/scope/core/nodes/registry.py
+++ b/src/scope/core/nodes/registry.py
@@ -15,22 +15,32 @@ def _derive_node_type_id(node_class: type) -> str | None:
     """Return the registry key for a node class, or None if not derivable.
 
     Plain nodes carry the id as the ``node_type_id`` classvar; pipelines
-    keep it on their config class as ``pipeline_id``.
+    keep it on their config class as ``pipeline_id``; input sources
+    expose it as ``source_id``.
     """
     node_type_id = getattr(node_class, "node_type_id", None)
     if node_type_id is not None:
         return node_type_id
-    # Lazy import: nodes.registry is loaded before pipelines.interface.
-    # Narrow to ImportError so real bugs (AttributeError on a broken
-    # config class, typos in pipeline_id, etc.) surface instead of being
-    # silently swallowed.
+    # Lazy imports: the registry is loaded before pipelines.interface
+    # and inputs.interface. Narrow to ImportError so real bugs
+    # (AttributeError on a broken config class, typos in pipeline_id,
+    # etc.) surface instead of being silently swallowed.
     try:
         from scope.core.pipelines.interface import Pipeline
     except ImportError:
-        return None
+        Pipeline = None  # type: ignore[assignment]
 
-    if issubclass(node_class, Pipeline):
+    if Pipeline is not None and issubclass(node_class, Pipeline):
         return node_class.get_config_class().pipeline_id
+
+    try:
+        from scope.core.inputs.interface import InputSource
+    except ImportError:
+        InputSource = None  # type: ignore[assignment]
+
+    if InputSource is not None and issubclass(node_class, InputSource):
+        return getattr(node_class, "source_id", None)
+
     return None
 
 

--- a/src/scope/core/plugins/manager.py
+++ b/src/scope/core/plugins/manager.py
@@ -559,7 +559,7 @@ class PluginManager:
         The ``registry`` argument is accepted for legacy callers but
         ignored — the unified storage is always used.
         """
-        from scope.core.nodes.registry import NodeRegistry
+        from scope.core.nodes.registry import NodeRegistry, _derive_node_type_id
         from scope.core.pipelines.registry import PipelineRegistry
 
         del registry  # legacy parameter, kept for callsite compat
@@ -569,9 +569,7 @@ class PluginManager:
 
             def register_callback(node_class: Any) -> None:
                 NodeRegistry.register(node_class)
-                node_id = getattr(node_class, "node_type_id", None) or (
-                    node_class.get_config_class().pipeline_id
-                )
+                node_id = _derive_node_type_id(node_class) or node_class.__name__
                 logger.info(f"Registered plugin node: {node_id}")
 
             self._pm.hook.register_nodes(register=register_callback)

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -2423,7 +2423,12 @@ def _resolve_input_source_class(source_type: str):
 
 @app.get("/api/v1/input-sources")
 async def list_input_source_types():
-    """List available input source types with their availability status."""
+    """List available input source types with their availability status.
+
+    Each entry also includes ``params``, the UI controls the frontend
+    should render for this source (see ``InputSource.get_source_ui_params``).
+    This lets new source plugins declare their UI without frontend changes.
+    """
     from scope.core.inputs import get_input_source_classes
 
     sources = []
@@ -2434,6 +2439,7 @@ async def list_input_source_types():
                 "source_name": cls.source_name,
                 "source_description": cls.source_description,
                 "available": cls.is_available(),
+                "params": [p.model_dump() for p in cls.get_source_ui_params()],
             }
         )
 
@@ -2497,6 +2503,11 @@ def get_input_source_resolution(
     """Probe the native resolution of a specific input source."""
     source_class = _resolve_input_source_class(source_type)
 
+    from scope.core.inputs.interface import (
+        InvalidSourceURLError,
+        SourceUnavailableError,
+    )
+
     try:
         instance = source_class()
         try:
@@ -2515,6 +2526,10 @@ def get_input_source_resolution(
             instance.close()
     except HTTPException:
         raise
+    except InvalidSourceURLError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except SourceUnavailableError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Error probing resolution for '{source_type}/{identifier}': {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/scope/server/source_manager.py
+++ b/src/scope/server/source_manager.py
@@ -353,7 +353,7 @@ class SourceManager:
         for node in graph.nodes:
             if node.type != "source":
                 continue
-            if node.source_mode not in ("spout", "ndi", "syphon", "video_file"):
+            if node.source_mode not in input_source_classes:
                 continue
             source_name = node.source_name or ""
             node_id = node.id


### PR DESCRIPTION
Input sources now plug into the unified NodeRegistry and declare their own UI via NodeParam metadata, so a new source type (e.g. YouTube) can appear in the workflow builder's Source node without any core or frontend changes.

Backend
- Add register_nodes hook path for InputSource subclasses: NodeRegistry._derive_node_type_id recognises source_id, and the plugin manager routes InputSource classes through the same register() callback as plain nodes and pipelines.
- InputSource.get_definition() returns a NodeDefinition (category "source", single video output, continuous=true) so every source appears in /api/v1/nodes/definitions.
- InputSource.get_source_ui_params() lets each source declare the widgets it needs (input_kind: url | discovered | asset, plus placeholder/help/probe hints). Built-in NDI/Syphon/Spout/VideoFile all override it.
- /api/v1/input-sources returns the declared params.
- InputSourceError / InvalidSourceURLError / SourceUnavailableError are exposed from the interface, and the probe endpoint maps them to HTTP 400/404.
- source_manager drops its hardcoded source_mode allowlist and validates against the registered source classes.
- register_builtin_nodes registers the built-in input sources so they show up as node definitions alongside plain nodes.

Frontend
- SOURCE_MODE_OPTIONS is gone; the Source node dropdown is populated from the availableInputSources catalog plus the two browser-only modes (video, camera). Plugin-declared sources render a generic UI block driven by the source_name param's ui.input_kind: URL input + debounced getInputSourceResolution probe, or a discovery-select.
- VideoSourceMode relaxed to string; new isServerSideSourceMode() helper replaces the spout||ndi||syphon checks in useVideoSource and StreamPage (graphHasOnlyServerSideSources, per-node mode switch, WebRTC source filter).
- availableInputSources threaded through GraphEditor -> useGraphState -> nodeEnrichment -> SourceNode data.

Verified end-to-end: a YouTube plugin that only registers a source via the register_nodes hook now appears in the Source node dropdown, renders a URL input with placeholder/help from its declared params, and reports "Ready (1920x1080)" after probing.