### PR TITLE
feat: bring livepeer runner Kafka events to parity with cloud-relay

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -44,6 +44,7 @@ import scope.server.app as scope_app_module
 from scope.server.app import app as scope_app
 from scope.server.app import lifespan as scope_lifespan
 from scope.server.frame_processor import FrameProcessor
+from scope.server.kafka_publisher import publish_event
 from scope.server.media_packets import ensure_video_packet
 
 logger = logging.getLogger(__name__)
@@ -113,6 +114,29 @@ class LivepeerSession:
     media_publishes: list[MediaPublish | None] = field(default_factory=list)
     user_id: str | None = None
     connection_id: str | None = None
+    manifest_id: str | None = None
+    session_id: str | None = None
+    connection_info: dict[str, Any] | None = None
+
+
+def _build_connection_info() -> dict[str, Any]:
+    """Mirror the fal-wrapper's connection_info shape from env vars.
+
+    Keeps the runner's events (stream_*, pipeline_*) carrying the same
+    fal-region / runner-id / log-labels the wrapper's websocket_connected
+    uses, so downstream consumers can correlate them.
+    """
+    fal_log_labels_raw = os.getenv("FAL_LOG_LABELS", "unknown")
+    try:
+        fal_log_labels = json.loads(fal_log_labels_raw)
+    except (json.JSONDecodeError, TypeError):
+        fal_log_labels = fal_log_labels_raw
+    return {
+        "gpu_type": os.getenv("FAL_MACHINE_TYPE", "GPU-H100"),
+        "fal_region": os.getenv("NOMAD_DC", "unknown"),
+        "fal_runner_id": os.getenv("FAL_JOB_ID", os.getenv("FAL_RUNNER_ID", "unknown")),
+        "fal_log_labels": fal_log_labels,
+    }
 
 
 async def _shutdown_task(
@@ -327,6 +351,16 @@ async def _stop_stream(session: LivepeerSession) -> None:
         if session.frame_processor is not None:
             session.frame_processor.stop()
             session.frame_processor = None
+            # Pair with the session_created emitted at stream start.
+            if session.session_id is not None:
+                publish_event(
+                    event_type="session_closed",
+                    session_id=session.session_id,
+                    connection_id=session.manifest_id,
+                    user_id=session.user_id,
+                    connection_info=session.connection_info,
+                )
+                session.session_id = None
 
         if session.active_channels:
             channel_urls = [ch["url"] for ch in session.active_channels]
@@ -704,7 +738,10 @@ async def _handle_api_request(
                 "error": f"Failed restart websocket handshake: {exc}",
             }
 
-    # Pass through validated user_id for pipeline load requests.
+    # Pass through validated user_id and the orchestrator-provided
+    # manifest_id for pipeline load requests. Using manifest_id (not the
+    # runner's internal connection_id) so pipeline_loaded events correlate
+    # with the fal wrapper's websocket_connected.connection_id.
     if (
         method == "POST"
         and normalized_path == "/api/v1/pipeline/load"
@@ -712,7 +749,9 @@ async def _handle_api_request(
         and session.user_id
     ):
         body["user_id"] = session.user_id
-        body["connection_id"] = session.connection_id
+        body["connection_id"] = session.manifest_id or session.connection_id
+        if session.connection_info is not None:
+            body["connection_info"] = session.connection_info
 
     client = scope_client
     if client is None:
@@ -1004,8 +1043,25 @@ async def _handle_control_message(
                 "produces_video": produces_video,
                 "produces_audio": produces_audio,
             },
+            session_id=session.session_id,
+            user_id=session.user_id,
+            connection_id=session.manifest_id,
+            connection_info=session.connection_info,
         )
         session.frame_processor.start()
+        # Emit session_created so livepeer-mode event streams match the
+        # cloud-relay shape (webrtc.py:731 fires this in relay mode; we
+        # mirror it here because livepeer doesn't go through the WebRTC
+        # offer handler).
+        publish_event(
+            event_type="session_created",
+            session_id=session.session_id,
+            connection_id=session.manifest_id,
+            pipeline_ids=pipeline_ids if pipeline_ids else None,
+            user_id=session.user_id,
+            metadata={"mode": "livepeer"},
+            connection_info=session.connection_info,
+        )
         session.media_stop_event.clear()
         session.active_channels = active_channels
         session.input_subscribe_urls = input_subscribe_urls
@@ -1303,6 +1359,13 @@ async def websocket_endpoint(ws: WebSocket) -> None:
         # TODO move this into the top level request
         params.pop("daydream_user_id", None)
         session.user_id = user_id
+        # Persist fields needed downstream so Kafka events emitted by the
+        # inner pipeline_manager / FrameProcessor correlate with the fal
+        # wrapper's websocket_connected (which uses manifest_id as
+        # connection_id).
+        session.manifest_id = job_info.manifest_id
+        session.session_id = str(uuid.uuid4())
+        session.connection_info = _build_connection_info()
 
         if not job_info.control_url:
             await ws.send_text(

--- a/src/scope/cloud/livepeer_fal_app.py
+++ b/src/scope/cloud/livepeer_fal_app.py
@@ -390,6 +390,13 @@ class LivepeerScopeApp(fal.App, keep_alive=300):
             "KAFKA_TOPIC",
             "KAFKA_SASL_USERNAME",
             "KAFKA_SASL_PASSWORD",
+            # fal runtime metadata — used by the runner to build
+            # connection_info on Kafka events so they match the wrapper.
+            "NOMAD_DC",
+            "FAL_JOB_ID",
+            "FAL_RUNNER_ID",
+            "FAL_LOG_LABELS",
+            "FAL_MACHINE_TYPE",
         ]
         runner_env = {k: os.environ[k] for k in env_allowlist if k in os.environ}
         runner_env.setdefault("UV_CACHE_DIR", "/tmp/uv-cache")


### PR DESCRIPTION
## Summary

Follow-up to #956. That PR added `websocket_connected` / `websocket_disconnected` from the livepeer fal wrapper, but the rest of the session lifecycle (`pipeline_loaded`, `session_created`, `stream_started`, `stream_heartbeat`, `stream_stopped`, `playback_ready`, `error` variants) was either not firing or firing with null identifiers in livepeer mode. Cloud-relay mode (`fal_app.py` path) already had these events working; this PR brings livepeer mode to the same shape.

## Root causes (all in the runner, \`src/scope/cloud/livepeer_app.py\`)

1. \`FrameProcessor(...)\` was constructed without \`user_id\` / \`connection_id\` / \`session_id\` / \`connection_info\`, so every event it emits (\`stream_started\`, \`stream_heartbeat\`, \`stream_stopped\`, etc.) carried nulls.
2. \`session.manifest_id\` was never populated from \`job_info.manifest_id\`, so there was no identifier available that matched the wrapper's \`websocket_connected.connection_id\`.
3. The pipeline/load body injection used the runner's random internal UUID as \`connection_id\` instead of the manifest_id, so \`pipeline_loaded\` didn't correlate.
4. \`session_created\` / \`session_closed\` are only emitted from \`webrtc.py\`, which isn't on the livepeer code path — they have to be emitted explicitly.
5. \`connection_info\` env vars (\`NOMAD_DC\`, \`FAL_JOB_ID\`, \`FAL_LOG_LABELS\`, etc.) weren't in the runner subprocess allowlist, so the runner couldn't rebuild the dict even if asked.

## Changes

**\`src/scope/cloud/livepeer_app.py\`**
- Add \`manifest_id\` / \`session_id\` / \`connection_info\` fields to \`LivepeerSession\`; populate them right after parsing \`ScopeJobInfo\`.
- New \`_build_connection_info()\` helper that mirrors the shape built by \`livepeer_fal_app.py\` from env vars.
- Pass \`session_id\`, \`user_id\`, \`connection_id=manifest_id\`, \`connection_info\` into \`FrameProcessor\` so every downstream event from \`frame_processor.py\` / \`pipeline_processor.py\` carries identifiers that join with \`websocket_connected\`.
- Emit \`session_created\` right after \`FrameProcessor.start()\`, and \`session_closed\` right after \`FrameProcessor.stop()\`, using the same shape as \`webrtc.py:731\` and \`:1150\`.
- Flip the pipeline/load body injection from \`session.connection_id\` to \`session.manifest_id\`, and pass \`connection_info\` too.

**\`src/scope/cloud/livepeer_fal_app.py\`**
- Add \`NOMAD_DC\`, \`FAL_JOB_ID\`, \`FAL_RUNNER_ID\`, \`FAL_LOG_LABELS\`, \`FAL_MACHINE_TYPE\` to \`env_allowlist\` so the runner subprocess can reconstruct \`connection_info\`.

## Test plan

- [ ] \`uv run ruff check src/\` and \`ruff format --check src/\` pass (already verified)
- [ ] \`uv run daydream-scope\` starts without import/init errors
- [ ] \`./test-cloud-connect.sh --skip-push\` after CI build-cloud succeeds → exit 0 with CONNECTED
- [ ] Manual UI test: connect to cloud, load pipeline (\`longlive\`), start stream ~30s, disconnect
- [ ] ClickHouse query on \`scope_cloud_events\` filtered by \`user_id\` and \`connection_id = <manifest_id>\` shows all of: \`websocket_connected\`, \`pipeline_load_start\`, \`pipeline_loaded\`, \`session_created\`, \`stream_started\`, ≥2 \`stream_heartbeat\`, \`stream_stopped\`, \`session_closed\`, \`websocket_disconnected\` — all sharing the same connection_id
- [ ] Regression check on cloud-relay path (\`fal_app.py\` deploy): no changes, events unchanged

## Not in scope

- Local-scope-side events (\`session_created\` from WebRTC path on user's laptop, \`session_closed\`, webrtc connection errors) still require the user's local env to have \`KAFKA_*\` configured; that's a config concern, not code.
- \`/api/v1/session/start\` not being livepeer-compatible (\`mcp_router.py:252\` TODO) — untouched; only affects headless test flows.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)