### PR TITLE
ci: point electron preview build at scope-livepeer app

### DIFF
--- a/.agents/skills/onboarding-test/SKILL.md
+++ b/.agents/skills/onboarding-test/SKILL.md
@@ -19,7 +19,7 @@ mkdir -p /tmp/scope-onboarding-test/data /tmp/scope-onboarding-test/models
 lsof -ti:8080 | xargs kill -9 2>/dev/null
 DAYDREAM_SCOPE_DIR=/tmp/scope-onboarding-test/data \
 DAYDREAM_SCOPE_MODELS_DIR=/tmp/scope-onboarding-test/models \
-SCOPE_CLOUD_APP_ID="daydream/scope-app/ws" \
+SCOPE_CLOUD_APP_ID="daydream/scope-livepeer/ws" \
 uv run daydream-scope --port 8080 > /tmp/scope-onboarding.log 2>&1 &
 for i in $(seq 1 30); do curl -s http://localhost:8080/health > /dev/null 2>&1 && break; sleep 1; done
 ```

--- a/.github/workflows/build-electron-preview.yml
+++ b/.github/workflows/build-electron-preview.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm run dist:win
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          SCOPE_CLOUD_APP_ID: daydream/scope-app/ws
+          SCOPE_CLOUD_APP_ID: daydream/scope-livepeer/ws
 
       - name: Sign files with Azure Trusted Signing
         if: env.AZURE_CLIENT_ID != ''
@@ -156,7 +156,7 @@ jobs:
         run: npm run dist:mac
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          SCOPE_CLOUD_APP_ID: daydream/scope-app/ws
+          SCOPE_CLOUD_APP_ID: daydream/scope-livepeer/ws
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ env.MACOS_SIGNING_CERT != '' }}
 
       - name: Clean up keychain


### PR DESCRIPTION
## Summary
- Electron preview builds (Windows + macOS) now bake `SCOPE_CLOUD_APP_ID=daydream/scope-livepeer/ws` into `__SCOPE_CLOUD_APP_ID__`, matching the renamed preview fal app.
- Onboarding-test skill updated to the same app_id so local runs match the preview build.

## Why
The old `daydream/scope-app` preview had no orchestrators available (connection attempts surfaced `NoOrchestratorAvailableError: All orchestrators failed (2 tried)` during pre-release onboarding testing). The preview app was renamed to `scope-livepeer`; verified end-to-end by walking the onboarding flow and running all three starter workflows against `daydream/scope-livepeer/ws`.

## Test plan
- [ ] Confirm next `Build Electron Preview` run on `main` produces binaries that auto-connect to the preview cloud without manual re-configuration
- [ ] Run the `onboarding-test` skill against the preview cloud and confirm provider selection → workflow picker → stream works for all three starter workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)