### PR TITLE
Fix starting workflows without a source

### DIFF
--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -2547,8 +2547,11 @@ export function StreamPage() {
       // mode so the backend receives the correct input_mode (e.g. "video")
       let currentMode =
         settings.inputMode || getPipelineDefaultMode(pipelineIdToUse) || "text";
-      if ((graphMode || nonLinearGraph) && graphSourceMode) {
-        currentMode = graphSourceMode as InputMode;
+      if (graphMode || nonLinearGraph) {
+        currentMode = getPipelineDefaultMode(pipelineIdToUse) || "text";
+        if (graphSourceMode) {
+          currentMode = graphSourceMode as InputMode;
+        }
       }
 
       // Use settings.resolution if available, otherwise fall back to videoResolution


### PR DESCRIPTION
If a workflow containing a video (eg, default passthrough) is replaced by a workflow that does not contain an input video (eg, LTX) then starting the new workflow could fail with this message in the browser console:

> Video input required but no local stream available

This is because graph mode retained `settings.inputMode = video` from the previous workflow when there was no source node. Fix this by ignoring the `inputMode` unless the graph actually contains a source node. Graph mode only; Linear workflows are unaffected.