### PR TITLE
fix: preserve video source on view toggle and unstick credits display

### DIFF
--- a/frontend/src/contexts/BillingContext.tsx
+++ b/frontend/src/contexts/BillingContext.tsx
@@ -165,6 +165,8 @@ export function BillingProvider({ children }: { children: ReactNode }) {
   }, [refresh]);
 
   // Poll balance every 15s while cloud-connected (live credit drain updates).
+  // Also refresh once on disconnect so the final post-stream balance shows up
+  // immediately instead of waiting for the 30s background tick.
   useEffect(() => {
     if (isConnected) {
       refresh();
@@ -172,6 +174,7 @@ export function BillingProvider({ children }: { children: ReactNode }) {
     } else {
       if (pollRef.current) clearInterval(pollRef.current);
       pollRef.current = null;
+      refresh();
     }
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);

--- a/frontend/src/hooks/useVideoSource.ts
+++ b/frontend/src/hooks/useVideoSource.ts
@@ -155,9 +155,9 @@ export function useVideoSource(props?: UseVideoSourceProps) {
   );
 
   const createVideoFileStream = useCallback(
-    async (fps: number) => {
+    async (fps: number, overrideSource?: string | File) => {
       const result = await createVideoFileStreamFromFile(
-        selectedVideoFile,
+        overrideSource ?? selectedVideoFile,
         fps
       );
       return result.stream;
@@ -195,7 +195,7 @@ export function useVideoSource(props?: UseVideoSourceProps) {
   }, []);
 
   const switchMode = useCallback(
-    async (newMode: VideoSourceMode) => {
+    async (newMode: VideoSourceMode, file?: string | File) => {
       modeRef.current = newMode;
       setMode(newMode);
       setError(null);
@@ -216,9 +216,15 @@ export function useVideoSource(props?: UseVideoSourceProps) {
       let newStream: MediaStream | null = null;
 
       if (newMode === "video") {
-        // Create video file stream
+        // Create video file stream. When a file is provided, seed
+        // `selectedVideoFile` so subsequent calls (reinitialize, cycle index)
+        // see the right source. Pass it explicitly to createVideoFileStream to
+        // avoid the React render race where the setter hasn't flushed yet.
+        if (file !== undefined) {
+          setSelectedVideoFile(file);
+        }
         try {
-          newStream = await createVideoFileStream(FPS);
+          newStream = await createVideoFileStream(FPS, file);
         } catch (error) {
           console.error("Failed to create video file stream:", error);
           setError("Failed to load test video");
@@ -445,6 +451,8 @@ export function useVideoSource(props?: UseVideoSourceProps) {
     error,
     mode,
     videoResolution,
+    selectedVideoFile,
+    setSelectedVideoFile,
     switchMode,
     stopVideo,
     handleVideoFileUpload,

--- a/frontend/src/lib/billing.ts
+++ b/frontend/src/lib/billing.ts
@@ -41,10 +41,17 @@ export async function fetchCreditsBalance(
   apiKey: string,
   deviceId?: string
 ): Promise<CreditsBalance> {
-  const url = deviceId
-    ? `${DAYDREAM_API_BASE}/credits/balance?deviceId=${encodeURIComponent(deviceId)}`
-    : `${DAYDREAM_API_BASE}/credits/balance`;
-  const res = await fetch(url, { headers: headers(apiKey) });
+  // Cache-bust with a timestamp param so intermediary caches (Electron's HTTP
+  // cache, any service worker, CDN heuristic caching) can't pin the balance
+  // between polls. `cache: "no-store"` handles the browser-side cache.
+  const params = new URLSearchParams();
+  if (deviceId) params.set("deviceId", deviceId);
+  params.set("_", String(Date.now()));
+  const url = `${DAYDREAM_API_BASE}/credits/balance?${params.toString()}`;
+  const res = await fetch(url, {
+    headers: headers(apiKey),
+    cache: "no-store",
+  });
   if (!res.ok)
     throw new Error(`Failed to fetch credits balance: ${res.status}`);
   return res.json();

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -818,6 +818,7 @@ export function StreamPage() {
     switchMode,
     handleVideoFileUpload,
     cycleSampleVideo,
+    selectedVideoFile,
   } = useVideoSource({
     onStreamUpdate: updateVideoTrack,
     onStopStream: stopStream,
@@ -843,6 +844,11 @@ export function StreamPage() {
   >({});
   const nodeLocalStreamsRef = useRef(nodeLocalStreams);
   nodeLocalStreamsRef.current = nodeLocalStreams;
+
+  // Per-source-node selected video file (File for uploads, URL string for
+  // sample videos). Used to carry the user's choice across Graph ↔ Perform
+  // toggles so the stock test.mp4 doesn't silently replace it.
+  const nodeVideoSourcesRef = useRef<Record<string, string | File>>({});
 
   // Shared camera stream ref so multiple source nodes (or repeated mode
   // switches) reuse the same getUserMedia stream instead of prompting again.
@@ -963,6 +969,9 @@ export function StreamPage() {
           oldStream.getTracks().forEach(t => t.stop());
         }
         setNodeLocalStreams(prev => ({ ...prev, [nodeId]: stream }));
+        // Remember the user's upload so Graph → Perform can replay it instead
+        // of resetting to the default sample.
+        nodeVideoSourcesRef.current[nodeId] = file;
         return true;
       } catch (e) {
         console.error(`Failed to create video stream for node ${nodeId}:`, e);
@@ -1014,6 +1023,7 @@ export function StreamPage() {
           video as HTMLVideoElement & { captureStream(): MediaStream }
         ).captureStream();
         setNodeLocalStreams(prev => ({ ...prev, [nodeId]: stream }));
+        nodeVideoSourcesRef.current[nodeId] = nextUrl;
       } catch (e) {
         console.error(`Failed to cycle sample video for node ${nodeId}:`, e);
       }
@@ -1052,6 +1062,7 @@ export function StreamPage() {
         video as HTMLVideoElement & { captureStream(): MediaStream }
       ).captureStream();
       setNodeLocalStreams(prev => ({ ...prev, [nodeId]: stream }));
+      nodeVideoSourcesRef.current[nodeId] = url;
     } catch (e) {
       console.error(`Failed to init sample video for node ${nodeId}:`, e);
     } finally {
@@ -3306,6 +3317,17 @@ export function StreamPage() {
                   /* ignore */
                 }
               }
+              // Carry the perform-mode video choice into the graph's source
+              // node (linear graphs use id "input"). Without this, the graph's
+              // SourceNode calls onInitSampleVideo and resets to test.mp4.
+              if (settings.inputMode === "video") {
+                nodeVideoSourcesRef.current["input"] = selectedVideoFile;
+                if (localStream) {
+                  setNodeLocalStreams(prev =>
+                    prev["input"] ? prev : { ...prev, input: localStream }
+                  );
+                }
+              }
               // Refresh the graph editor so it picks up the current graph
               graphEditorRef.current?.refreshGraph();
             } else {
@@ -3376,6 +3398,15 @@ export function StreamPage() {
                       },
                     });
                     switchMode(sourceMode);
+                  } else if (sourceMode === "video") {
+                    // Carry the user's chosen video (upload or cycled sample)
+                    // from the graph's source node into perform mode. Without
+                    // this, switchMode("video") falls back to selectedVideoFile
+                    // (defaults to /assets/test.mp4) and silently replaces it.
+                    const carriedFile = sourceNode
+                      ? nodeVideoSourcesRef.current[sourceNode.id]
+                      : undefined;
+                    switchMode(sourceMode, carriedFile);
                   } else {
                     switchMode(sourceMode);
                   }


### PR DESCRIPTION
## Summary

Two UI bug fixes observed while streaming:

- **Video source replaced by `test.mp4` on Graph ↔ Perform toggle.** Graph-mode uploads lived in per-node streams, while Perform mode read from `useVideoSource.selectedVideoFile` (default `/assets/test.mp4`). Toggling views silently reset the user's file.
- **Credits didn't deplete in the header/Billing tab during a cloud stream.** The balance fetch had no cache-busting, so Electron's HTTP cache could pin the response between 15 s polls.

## What changed

### Bug 1 — video source carries across the toggle
- `useVideoSource`: `switchMode(newMode, file?)` now accepts an optional file override; it seeds `selectedVideoFile` and passes the value directly to `createVideoFileStream` (also extended with `overrideSource?`) to avoid the React state race. Exposes `selectedVideoFile` / `setSelectedVideoFile` on the hook.
- `StreamPage`: new `nodeVideoSourcesRef: Record<string, string | File>` tracks each source node's chosen file. `handlePerNodeVideoFileUpload` / `handlePerNodeCycleSampleVideo` / `handlePerNodeInitSampleVideo` write into it.
- **Graph → Perform**: when the graph's source is in video mode, the stored file is passed to `switchMode("video", carriedFile)` instead of falling back to the default sample.
- **Perform → Graph**: when seeding the linear graph and `inputMode === "video"`, pre-populates `nodeVideoSourcesRef["input"]` with the current `selectedVideoFile` and, if a `localStream` exists, pushes it into `nodeLocalStreams["input"]` so the graph's source node doesn't re-init to `test.mp4`.

### Bug 2 — credits display sees fresh data
- `lib/billing.ts`: `fetchCreditsBalance` now sends `cache: "no-store"` and appends `_=<Date.now()>` so intermediaries (Electron HTTP cache, any proxy/SW) can't pin the balance between polls.
- `BillingContext`: the polling effect now also calls `refresh()` once on `isConnected → false` transition, so the final post-stream balance lands immediately instead of waiting for the 30 s background tick.

## Test plan

- [x] `npm run lint` — 0 errors (44 pre-existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [ ] Graph → Perform: in Graph mode, upload a custom video on the source node, toggle to Perform — user's video still shows (not the stock cat)
- [ ] Graph → Perform: cycle to a sample (`test1.mp4`) in Graph mode, toggle to Perform — `test1.mp4` carries over
- [ ] Perform → Graph: upload a video in Perform, toggle to Graph — the graph's source node shows the uploaded video
- [ ] Cloud stream: watch the header credit number — drops ~every 15 s; devtools shows `/credits/balance` returning "200 OK" from network (not disk cache) and a decreasing `balance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)