### PR TITLE
Livepeer gateway update

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1332,7 +1332,7 @@ wheels = [
 [[package]]
 name = "livepeer-gateway"
 version = "0.1.0"
-source = { git = "https://github.com/livepeer/livepeer-python-gateway#601a253437976b7eb889dbd5e823cad6655b761a" }
+source = { git = "https://github.com/livepeer/livepeer-python-gateway#de3a3f52b969fa52a296a5a6f62ad0a04a5acb7c" }
 dependencies = [
     { name = "aiohttp" },
     { name = "av" },


### PR DESCRIPTION
Adds a number of reliability updates around media publishing. This helps the case where media can stall out for 1+ minute at a time, eg LTX prompt reloads and avoids downstream timeouts from causing unexpected behavior.

Includes the following changes:

Drain PyAV segments on trickle publish failure.
https://github.com/livepeer/livepeer-python-gateway/commit/fb7301b893179b7ddb9a53773ababea7067f060b

Detect idle publishers and roll trickle segments
https://github.com/livepeer/livepeer-python-gateway/commit/c24a43d38103bf326558a4fb2251ce18a73e25d4

ChannelReader: tolerate empty segments
https://github.com/livepeer/livepeer-python-gateway/commit/8d9ba03c35af7e4116e39cb53d6a45d808b21791

Validate Content-Type on first non-empty media output chunk
https://github.com/livepeer/livepeer-python-gateway/commit/c5566f2e7111556cc248a43defa596301aae378d

Observability for drained bytes and empty segments
https://github.com/livepeer/livepeer-python-gateway/commit/cb0689ea951828e31db4a8c637981cd50d269a8f

Add channel name to MediaPublish logs.
https://github.com/livepeer/livepeer-python-gateway/commit/de3a3f52b969fa52a296a5a6f62ad0a04a5acb7c