### PR TITLE
Check for Livepeer readiness before accepting websocket

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -49,6 +49,8 @@ from scope.server.media_packets import ensure_video_packet
 
 logger = logging.getLogger(__name__)
 scope_client: httpx.AsyncClient | None = None
+_connection_active = False
+_connection_count = 0
 
 STREAM_TASK_SHUTDOWN_GRACE_S = 1.0
 STREAM_TASK_CANCEL_TIMEOUT_S = 1.0
@@ -1199,7 +1201,12 @@ async def _subscribe_control(
     logs_task = asyncio.create_task(_forward_logs_to_events(log_queue))
 
     try:
-        await events_writer.write({"type": "runner_ready"})
+        await events_writer.write(
+            {
+                "type": "runner_ready",
+                "runner_job_id": os.getenv("FAL_JOB_ID") or os.getenv("FAL_RUNNER_ID"),
+            }
+        )
         async for message in JSONLReader(control_url)():
             if stop_event.is_set():
                 break
@@ -1320,10 +1327,24 @@ async def cleanup_session() -> dict[str, Any]:
     }
 
 
+@app.get("/internal/status")
+async def internal_status() -> dict[str, Any]:
+    return {
+        "listener_ready": scope_client is not None,
+        "connection_active": _connection_active,
+        "connection_count": _connection_count,
+    }
+
+
 @app.websocket("/ws")
 async def websocket_endpoint(ws: WebSocket) -> None:
     """Accept a WebSocket connection, read job info, then subscribe to the control channel."""
+    global _connection_active
+    global _connection_count
+
     await ws.accept()
+    _connection_active = True
+    _connection_count += 1
     logger.info("WebSocket client connected")
 
     stop_event = asyncio.Event()
@@ -1440,6 +1461,7 @@ async def websocket_endpoint(ws: WebSocket) -> None:
         await _stop_stream(session)
         if control_task is not None:
             await _shutdown_task(control_task, task_name="control_channel")
+        _connection_active = False
 
 
 def get_daydream_api_base() -> str:

--- a/src/scope/cloud/livepeer_fal_app.py
+++ b/src/scope/cloud/livepeer_fal_app.py
@@ -8,6 +8,7 @@ as a subprocess and provides:
 """
 
 import asyncio
+import json
 import os
 import subprocess as _subprocess
 import time
@@ -26,6 +27,8 @@ RUNNER_STARTUP_TIMEOUT_SECONDS = 90
 RUNNER_RETRY_DELAY_SECONDS = 2.5
 RUNNER_MAX_FAILURES_PER_WINDOW = 20
 RUNNER_FAILURE_WINDOW_SECONDS = 60.0
+RUNNER_STATUS_RETRY_ATTEMPTS = 10
+RUNNER_STATUS_RETRY_DELAY_SECONDS = 1.0
 ASSETS_DIR_PATH = "/tmp/.daydream-scope/assets"
 
 
@@ -187,6 +190,46 @@ async def run_cleanup() -> None:
         await cleanup_runner_session()
     finally:
         event.set()
+
+
+async def check_runner_readiness() -> bool:
+    """Wait until the inner runner listener is ready and has no active connection."""
+    import httpx
+
+    status_url = f"{RUNNER_LOCAL_HTTP_URL}/internal/status"
+    async with httpx.AsyncClient() as client:
+        for attempt in range(1, RUNNER_STATUS_RETRY_ATTEMPTS + 1):
+            try:
+                response = await client.get(status_url, timeout=2.0)
+                if response.status_code == 200:
+                    status = response.json()
+                    if (
+                        status.get("listener_ready") is True
+                        and status.get("connection_active") is False
+                    ):
+                        return True
+                    print(
+                        "Runner status not ready for new websocket "
+                        f"(attempt={attempt}/{RUNNER_STATUS_RETRY_ATTEMPTS}): "
+                        f"{json.dumps(status)}"
+                    )
+                else:
+                    print(
+                        "Runner status endpoint returned "
+                        f"{response.status_code} "
+                        f"(attempt={attempt}/{RUNNER_STATUS_RETRY_ATTEMPTS}): "
+                        f"{response.text[:500]}"
+                    )
+            except Exception as exc:
+                print(
+                    "Runner status check failed "
+                    f"(attempt={attempt}/{RUNNER_STATUS_RETRY_ATTEMPTS}): {exc}"
+                )
+
+            if attempt < RUNNER_STATUS_RETRY_ATTEMPTS:
+                await asyncio.sleep(RUNNER_STATUS_RETRY_DELAY_SECONDS)
+
+    return False
 
 
 def _get_git_sha() -> str:
@@ -446,6 +489,11 @@ class LivepeerScopeApp(fal.App, keep_alive=300):
             InvalidStatus,
         )
 
+        if not await check_runner_readiness():
+            print("Livepeer fal ws rejected: inner runner not ready for connection")
+            await client_ws.close(code=1013, reason="Runner not ready")
+            return
+
         await client_ws.accept()
 
         # Initialize Kafka publisher (lazy, once per process).
@@ -460,8 +508,6 @@ class LivepeerScopeApp(fal.App, keep_alive=300):
         user_id = client_ws.headers.get("daydream-user-id")
         metadata["manifest_id"] = manifest_id
         metadata["user_id"] = user_id
-
-        import json
 
         fal_log_labels_raw = os.getenv("FAL_LOG_LABELS", "unknown")
         try:


### PR DESCRIPTION
We might sometimes get back-to-back (re-)connections on Fal before the runner is ready to handle new connections. To mitigate this, check for runner readiness before accepting the incoming websocket on the outer Fal wrapper.

Adds a minimal status endpoint for the runner at `GET /internal/status` . Response:

```
{
  "listener_ready": true,
  "connection_active": <bool>,
  "connection_count": <connection-counter>
}
```

The Fal runner polls this endpoint up to 10 times until `listener_ready = True` and `connection_active = False` with a 1s sleep in between each retry. If max retries are hit, reject the websocket. 

Also include the fal job id in runner_ready events for better job
correlation.