### PR TITLE
feat: pipe upstream node outputs into pipeline __prompt and non-video…

### DIFF
--- a/frontend/src/components/graph/hooks/node/usePipelineParams.ts
+++ b/frontend/src/components/graph/hooks/node/usePipelineParams.ts
@@ -173,9 +173,17 @@ export function usePipelineParams({
       for (const [k, v] of Object.entries(params)) {
         if (k === "node_id") continue;
         if (k === "prompts") {
-          const arr = v as Array<{ text: string; weight: number }>;
-          if (Array.isArray(arr) && arr.length > 0) {
-            patch.__prompt = arr[0].text;
+          // Accept both the canonical list-of-dicts format coming back
+          // from sendParameterUpdate and a raw string (what an upstream
+          // node like the PromptEnhancer emits directly on the prompts
+          // port).
+          if (typeof v === "string") {
+            patch.__prompt = v;
+          } else if (Array.isArray(v) && v.length > 0) {
+            const first = v[0] as { text?: string };
+            if (typeof first?.text === "string") {
+              patch.__prompt = first.text;
+            }
           }
           continue;
         }

--- a/frontend/src/components/graph/nodes/CustomNode.tsx
+++ b/frontend/src/components/graph/nodes/CustomNode.tsx
@@ -43,6 +43,16 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
   const inputs = data.customNodeInputs ?? [];
   const outputs = data.customNodeOutputs ?? [];
   const params = data.customNodeParamDefs ?? [];
+
+  // Edit-time helper: update the React Flow node data (so the widget
+  // reflects the new value) and, when the node is connected to a running
+  // backend, push the same change through so the worker picks it up.
+  const setParam = (name: string, value: unknown) => {
+    updateData({
+      customNodeParams: { ...data.customNodeParams, [name]: value },
+    });
+    data.onCustomNodeParamChange?.(name, value);
+  };
   const displayName =
     data.customTitle ||
     data.customNodeDisplayName ||
@@ -145,14 +155,7 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
                       <select
                         className="bg-zinc-900 text-zinc-200 rounded px-1 py-0.5 text-[11px] max-w-[130px]"
                         value={String(val)}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: e.target.value,
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, e.target.value)}
                       >
                         {(p.ui?.options as string[]).map(o => (
                           <option key={o} value={o}>
@@ -164,14 +167,7 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
                       <input
                         type="checkbox"
                         checked={Boolean(val)}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: e.target.checked,
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, e.target.checked)}
                         className="accent-blue-500"
                       />
                     ) : p.param_type === "number" ? (
@@ -182,28 +178,14 @@ export function CustomNode({ id, data, selected }: NodeProps<CustomNodeType>) {
                         min={(p.ui?.min as number | undefined) ?? undefined}
                         max={(p.ui?.max as number | undefined) ?? undefined}
                         step={(p.ui?.step as number | undefined) ?? undefined}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: Number(e.target.value),
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, Number(e.target.value))}
                       />
                     ) : (
                       <input
                         type="text"
                         className="bg-zinc-900 text-zinc-200 rounded px-1 py-0.5 text-[11px] max-w-[130px]"
                         value={String(val)}
-                        onChange={e =>
-                          updateData({
-                            customNodeParams: {
-                              ...data.customNodeParams,
-                              [p.name]: e.target.value,
-                            },
-                          })
-                        }
+                        onChange={e => setParam(p.name, e.target.value)}
                       />
                     )}
                   </div>

--- a/frontend/src/components/graph/nodes/PipelineNode.tsx
+++ b/frontend/src/components/graph/nodes/PipelineNode.tsx
@@ -151,8 +151,11 @@ export function PipelineNode({
   const isResetCacheConnected = isParamConnected("reset_cache");
 
   const VACE_STREAM_PORTS = ["vace_input_frames", "vace_input_masks"];
+  // The "prompts" input is rendered by the dedicated "Enter prompt…" widget
+  // at the bottom of the node, so it shouldn't also show up as a plain
+  // stream-input row up top.
   const normalStreamInputs = streamInputs.filter(
-    p => !VACE_STREAM_PORTS.includes(p)
+    p => !VACE_STREAM_PORTS.includes(p) && p !== "prompts"
   );
   // When supportsVace is true, always show these ports (they are always in the
   // schema for VACE pipelines). Fall back to what streamInputs provides if

--- a/frontend/src/components/graph/utils/connectionValidation.ts
+++ b/frontend/src/components/graph/utils/connectionValidation.ts
@@ -256,6 +256,52 @@ function checkSubgraphOutputTarget(
   return srcType === port.paramType;
 }
 
+/**
+ * Run the table-driven `TARGET_RULES`. Returns `undefined` when no rule
+ * decided — callers should continue to their next fallback.
+ */
+function matchTargetRules(
+  sourceType: string,
+  targetNode: Node<FlowNodeData>,
+  targetParamName: string
+): boolean | undefined {
+  for (const rule of TARGET_RULES) {
+    const result = rule({
+      sourceType,
+      targetParsedName: targetParamName,
+      targetNode,
+    });
+    if (result !== undefined) return result;
+  }
+  return undefined;
+}
+
+/**
+ * Final fallback for param-typed targets: look up the target's declared
+ * `parameterInputs` entry. Returns `undefined` when no entry matches so
+ * callers can decide the default (param↔param: reject; stream↔param:
+ * reject).
+ */
+function matchParameterInputs(
+  sourceType: string,
+  targetNode: Node<FlowNodeData>,
+  targetParamName: string
+): boolean | undefined {
+  const targetParam = targetNode.data.parameterInputs?.find(
+    p => p.name === targetParamName
+  );
+  if (!targetParam) return undefined;
+  // Permissive coercions: number → list_number, list_number → list_number,
+  // {video,audio}_path → string.
+  if (targetParam.type === "list_number" && sourceType === "number")
+    return true;
+  if (targetParam.type === "list_number" && sourceType === "list_number")
+    return true;
+  if (targetParam.type === "string" && sourceType === "video_path") return true;
+  if (targetParam.type === "string" && sourceType === "audio_path") return true;
+  return sourceType === targetParam.type;
+}
+
 // ---------------------------------------------------------------------------
 // Main exported validator
 // ---------------------------------------------------------------------------
@@ -306,10 +352,10 @@ export function validateConnection(
   }
 
   // Stream ↔ param: a custom_node stream output (e.g. a Prompt Enhancer's
-  // `text` port) can land on a pipeline param handle such as
-  // `param:__prompt`. The edge is serialised as a stream edge on the wire
-  // (graphUtils.ts rewrites the handle id on import/export), so we only
-  // need to validate the port-type match here.
+  // `text` port) can land on a pipeline param handle. The edge is
+  // serialised as a stream edge on the wire (graphUtils.ts rewrites the
+  // handle id on import/export), so we only need to validate the port-type
+  // match here — same rules used for param↔param.
   if (sourceParsed.kind === "stream" && targetParsed.kind === "param") {
     const sourceNode = nodes.find(n => n.id === connection.source);
     const targetNode = nodes.find(n => n.id === connection.target);
@@ -317,32 +363,15 @@ export function validateConnection(
     if (sourceNode.data.nodeType !== "custom_node") return false;
     if (targetNode.data.nodeType !== "pipeline") return false;
     const outputs = sourceNode.data.customNodeOutputs;
-    let srcType: string | undefined;
-    if (outputs !== undefined) {
-      const portName = stripCustomNodeDirection(sourceParsed.name);
-      const port = outputs.find(p => p.name === portName);
-      if (!port) return false;
-      srcType = port.port_type;
-    }
-    // Same table-driven rules used for param↔param — keeps `__prompt`
-    // (string only), `__vace`, `__loras`, etc. behaving consistently
-    // regardless of whether the source is a frontend param or a
-    // backend stream port.
-    if (!srcType) return true;
-    for (const rule of TARGET_RULES) {
-      const result = rule({
-        sourceType: srcType,
-        targetParsedName: targetParsed.name,
-        targetNode,
-      });
-      if (result !== undefined) return result;
-    }
-    // Fall back to the target's declared parameterInputs.
-    const targetParam = targetNode.data.parameterInputs?.find(
-      p => p.name === targetParsed.name
+    if (outputs === undefined) return true;
+    const portName = stripCustomNodeDirection(sourceParsed.name);
+    const port = outputs.find(p => p.name === portName);
+    if (!port) return false;
+    return (
+      matchTargetRules(port.port_type, targetNode, targetParsed.name) ??
+      matchParameterInputs(port.port_type, targetNode, targetParsed.name) ??
+      false
     );
-    if (!targetParam) return false;
-    return srcType === targetParam.type;
   }
 
   // Stream ↔ stream: for custom_node edges, enforce port-type matching
@@ -441,15 +470,12 @@ export function validateConnection(
     );
     if (!sourceType) return false;
 
-    // Run table-driven target rules
-    for (const rule of TARGET_RULES) {
-      const result = rule({
-        sourceType,
-        targetParsedName: targetParsed.name,
-        targetNode,
-      });
-      if (result !== undefined) return result;
-    }
+    const ruleResult = matchTargetRules(
+      sourceType,
+      targetNode,
+      targetParsed.name
+    );
+    if (ruleResult !== undefined) return ruleResult;
 
     // Subgraph / boundary node checks
     const sgSrc = checkSubgraphSource(
@@ -486,22 +512,9 @@ export function validateConnection(
     );
     if (sgOutTgt !== undefined) return sgOutTgt;
 
-    // Default: look up the target's parameterInputs
-    const targetParam = targetNode.data.parameterInputs?.find(
-      p => p.name === targetParsed.name
+    return (
+      matchParameterInputs(sourceType, targetNode, targetParsed.name) ?? false
     );
-    if (!targetParam) return false;
-
-    if (targetParam.type === "list_number" && sourceType === "number")
-      return true;
-    if (targetParam.type === "list_number" && sourceType === "list_number")
-      return true;
-    if (targetParam.type === "string" && sourceType === "video_path")
-      return true;
-    if (targetParam.type === "string" && sourceType === "audio_path")
-      return true;
-
-    return sourceType === targetParam.type;
   }
 
   return false;

--- a/frontend/src/components/graph/utils/connectionValidation.ts
+++ b/frontend/src/components/graph/utils/connectionValidation.ts
@@ -305,6 +305,46 @@ export function validateConnection(
     return true;
   }
 
+  // Stream ↔ param: a custom_node stream output (e.g. a Prompt Enhancer's
+  // `text` port) can land on a pipeline param handle such as
+  // `param:__prompt`. The edge is serialised as a stream edge on the wire
+  // (graphUtils.ts rewrites the handle id on import/export), so we only
+  // need to validate the port-type match here.
+  if (sourceParsed.kind === "stream" && targetParsed.kind === "param") {
+    const sourceNode = nodes.find(n => n.id === connection.source);
+    const targetNode = nodes.find(n => n.id === connection.target);
+    if (!sourceNode || !targetNode) return true;
+    if (sourceNode.data.nodeType !== "custom_node") return false;
+    if (targetNode.data.nodeType !== "pipeline") return false;
+    const outputs = sourceNode.data.customNodeOutputs;
+    let srcType: string | undefined;
+    if (outputs !== undefined) {
+      const portName = stripCustomNodeDirection(sourceParsed.name);
+      const port = outputs.find(p => p.name === portName);
+      if (!port) return false;
+      srcType = port.port_type;
+    }
+    // Same table-driven rules used for param↔param — keeps `__prompt`
+    // (string only), `__vace`, `__loras`, etc. behaving consistently
+    // regardless of whether the source is a frontend param or a
+    // backend stream port.
+    if (!srcType) return true;
+    for (const rule of TARGET_RULES) {
+      const result = rule({
+        sourceType: srcType,
+        targetParsedName: targetParsed.name,
+        targetNode,
+      });
+      if (result !== undefined) return result;
+    }
+    // Fall back to the target's declared parameterInputs.
+    const targetParam = targetNode.data.parameterInputs?.find(
+      p => p.name === targetParsed.name
+    );
+    if (!targetParam) return false;
+    return srcType === targetParam.type;
+  }
+
   // Stream ↔ stream: for custom_node edges, enforce port-type matching
   // against the node's declared inputs/outputs. For built-in source /
   // pipeline / sink nodes, streams are untyped (video) and always ok.

--- a/frontend/src/components/graph/utils/nodeEnrichment.ts
+++ b/frontend/src/components/graph/utils/nodeEnrichment.ts
@@ -250,6 +250,18 @@ export function enrichNodes(
         },
       };
     }
+    if (n.data.nodeType === "custom_node") {
+      // Expose a setter that mirrors widget edits to the running backend
+      // node via `handleNodeParameterChange` → `sendParameterUpdate`.
+      return {
+        ...n,
+        data: {
+          ...n.data,
+          onCustomNodeParamChange: (key: string, value: unknown) =>
+            deps.handleNodeParameterChange(n.id, key, value),
+        },
+      };
+    }
     return n;
   });
 }

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -475,6 +475,47 @@ export function stripCustomNodeDirection(name: string): string {
 }
 
 /**
+ * Prompt port alias: the UI renders the "Enter prompt…" textarea under the
+ * widget handle ``param:__prompt`` (a composite pseudo-param that also
+ * stores raw widget state), while the backend pipeline exposes the
+ * matching port as ``prompts`` so the kwarg name matches at runtime.
+ * These two constants and the helpers below are the single spot where the
+ * rename is known — callers that import/export graphs translate through
+ * ``aliasWirePortForPipelineTarget`` / ``aliasWidgetPortForWire``.
+ */
+export const PROMPT_WIRE_PORT = "prompts";
+export const PROMPT_WIDGET_PORT = "__prompt";
+
+/** On import: rewrite the on-wire ``prompts`` target port to the widget name. */
+export function aliasWirePortForPipelineTarget(
+  toNode: string,
+  toPort: string,
+  pipelineTargetIds: ReadonlySet<string>
+): string {
+  if (pipelineTargetIds.has(toNode) && toPort === PROMPT_WIRE_PORT) {
+    return PROMPT_WIDGET_PORT;
+  }
+  return toPort;
+}
+
+/** On export: rewrite the widget ``__prompt`` target name back to the wire port. */
+export function aliasWidgetPortForWire(
+  targetNodeId: string,
+  toPort: string,
+  kind: "stream" | "parameter",
+  pipelineTargetIds: ReadonlySet<string>
+): string {
+  if (
+    kind === "stream" &&
+    toPort === PROMPT_WIDGET_PORT &&
+    pipelineTargetIds.has(targetNodeId)
+  ) {
+    return PROMPT_WIRE_PORT;
+  }
+  return toPort;
+}
+
+/**
  * Build a map of pipeline_id -> { inputs, outputs } from schemas.
  */
 export function buildPipelinePortsMap(
@@ -913,13 +954,12 @@ export function graphConfigToFlow(
       e => !isSubgraphInnerNode(e.from) && !isSubgraphInnerNode(e.to_node)
     )
     .map((e, i) => {
-      // The UI renders the "Enter prompt…" textarea under the widget
-      // handle `param:__prompt`. Pipelines expose the matching backend
-      // port as `prompts` (its kwarg name), so an incoming edge targeting
-      // that port is routed to the widget handle instead of a non-
-      // existent `stream:prompts` handle.
-      const isPromptPortTarget =
-        pipelineNodeIds.has(e.to_node) && e.to_port === "prompts";
+      const toPort = aliasWirePortForPipelineTarget(
+        e.to_node,
+        e.to_port,
+        pipelineNodeIds
+      );
+      const isPromptPortTarget = toPort !== e.to_port;
       const sourceHandle =
         e.kind === "parameter"
           ? buildHandleId("param", e.from_port)
@@ -927,7 +967,7 @@ export function graphConfigToFlow(
             ? customNodeOutputHandleId(e.from_port)
             : buildHandleId("stream", e.from_port);
       const targetHandle = isPromptPortTarget
-        ? buildHandleId("param", "__prompt")
+        ? buildHandleId("param", toPort)
         : e.kind === "parameter"
           ? buildHandleId("param", e.to_port)
           : customNodeIds.has(e.to_node)
@@ -1439,20 +1479,14 @@ export function flowToGraphConfig(
       const fromName = sourceParsed?.name
         ? stripCustomNodeDirection(sourceParsed.name)
         : "video";
-      let toName = targetParsed?.name
-        ? stripCustomNodeDirection(targetParsed.name)
-        : "video";
-      // The UI's "Enter prompt" textarea lives under the widget handle
-      // `param:__prompt`; pipelines declare the matching backend port as
-      // `prompts` to match the runtime kwarg. Translate on export so the
-      // serialised edge lands on the right port name.
-      if (
-        kind === "stream" &&
-        toName === "__prompt" &&
-        pipelineTargetIds.has(e.target)
-      ) {
-        toName = "prompts";
-      }
+      const toName = aliasWidgetPortForWire(
+        e.target,
+        targetParsed?.name
+          ? stripCustomNodeDirection(targetParsed.name)
+          : "video",
+        kind as "stream" | "parameter",
+        pipelineTargetIds
+      );
       return {
         from: e.source,
         from_port: fromName,

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -404,6 +404,9 @@ export interface FlowNodeData {
   customNodeParams?: Record<string, unknown>;
   /** For custom_node: parameter definitions from API (widget metadata) */
   customNodeParamDefs?: NodeParamDef[];
+  /** For custom_node: push a param change through to the backend so the
+   *  running node picks up the new value without a session restart. */
+  onCustomNodeParamChange?: (key: string, value: unknown) => void;
 
   /* ── Node lock / pin / collapse ── */
   /** When true, parameter inputs on this node are disabled (read-only). */
@@ -904,19 +907,28 @@ export function graphConfigToFlow(
         nodes.filter(n => n.type === "custom_node").map(n => n.id)
       )
   );
+  const pipelineNodeIds = new Set(pipelines.map(n => n.id));
   const edges: Edge[] = graph.edges
     .filter(
       e => !isSubgraphInnerNode(e.from) && !isSubgraphInnerNode(e.to_node)
     )
     .map((e, i) => {
+      // The UI renders the "Enter prompt…" textarea under the widget
+      // handle `param:__prompt`. Pipelines expose the matching backend
+      // port as `prompts` (its kwarg name), so an incoming edge targeting
+      // that port is routed to the widget handle instead of a non-
+      // existent `stream:prompts` handle.
+      const isPromptPortTarget =
+        pipelineNodeIds.has(e.to_node) && e.to_port === "prompts";
       const sourceHandle =
         e.kind === "parameter"
           ? buildHandleId("param", e.from_port)
           : customNodeIds.has(e.from)
             ? customNodeOutputHandleId(e.from_port)
             : buildHandleId("stream", e.from_port);
-      const targetHandle =
-        e.kind === "parameter"
+      const targetHandle = isPromptPortTarget
+        ? buildHandleId("param", "__prompt")
+        : e.kind === "parameter"
           ? buildHandleId("param", e.to_port)
           : customNodeIds.has(e.to_node)
             ? customNodeInputHandleId(e.to_port)
@@ -1412,6 +1424,9 @@ export function flowToGraphConfig(
   // Strip the in:/out: prefix added to custom_node handles before writing
   // the bare port name back to the wire format.
   const graphNodeIds = new Set(graphNodes.map(n => n.id));
+  const pipelineTargetIds = new Set(
+    graphNodes.filter(n => n.type === "pipeline").map(n => n.id)
+  );
   const graphEdges: GraphEdge[] = flatEdges
     .filter(e => graphNodeIds.has(e.source) && graphNodeIds.has(e.target))
     .map(e => {
@@ -1424,9 +1439,20 @@ export function flowToGraphConfig(
       const fromName = sourceParsed?.name
         ? stripCustomNodeDirection(sourceParsed.name)
         : "video";
-      const toName = targetParsed?.name
+      let toName = targetParsed?.name
         ? stripCustomNodeDirection(targetParsed.name)
         : "video";
+      // The UI's "Enter prompt" textarea lives under the widget handle
+      // `param:__prompt`; pipelines declare the matching backend port as
+      // `prompts` to match the runtime kwarg. Translate on export so the
+      // serialised edge lands on the right port name.
+      if (
+        kind === "stream" &&
+        toName === "__prompt" &&
+        pipelineTargetIds.has(e.target)
+      ) {
+        toName = "prompts";
+      }
       return {
         from: e.source,
         from_port: fromName,

--- a/src/scope/core/nodes/base.py
+++ b/src/scope/core/nodes/base.py
@@ -319,20 +319,40 @@ def _definition_from_config(
             "version": getattr(config, "pipeline_version", ""),
             "schema_error": str(e),
         }
+    inputs = _as_ports(getattr(config, "inputs", ["video"]) or ["video"])
+    # Every prompt-capable pipeline (the BasePipelineConfig default) gets a
+    # `prompts` string input for free so a backend node — e.g. a Prompt
+    # Enhancer — can feed the same handle the UI exposes as "Enter prompt…"
+    # without the pipeline having to declare the port itself.
+    if getattr(config, "supports_prompts", False) and not any(
+        p.name == "prompts" for p in inputs
+    ):
+        inputs.append(NodePort(name="prompts", port_type="string"))
     return NodeDefinition(
         node_type_id=config.pipeline_id,
         display_name=getattr(config, "pipeline_name", config.pipeline_id),
         category="pipeline",
         description=getattr(config, "pipeline_description", "") or "",
-        inputs=[
-            NodePort(name=name, port_type="video")
-            for name in (getattr(config, "inputs", ["video"]) or ["video"])
-        ],
-        outputs=[
-            NodePort(name=name, port_type="video")
-            for name in (getattr(config, "outputs", ["video"]) or ["video"])
-        ],
+        inputs=inputs,
+        outputs=_as_ports(getattr(config, "outputs", ["video"]) or ["video"]),
         params=[],
         continuous=False,
         pipeline_meta=pipeline_meta,
     )
+
+
+def _as_ports(entries: list[Any]) -> list[NodePort]:
+    """Normalise a config ``inputs``/``outputs`` list into :class:`NodePort`.
+
+    Supports mixed lists: a plain string is treated as a ``"video"`` port
+    (matches the original per-pipeline convention), while a :class:`NodePort`
+    entry passes through unchanged so pipelines can declare non-video ports
+    the same way scheduler-style nodes do.
+    """
+    ports: list[NodePort] = []
+    for entry in entries:
+        if isinstance(entry, NodePort):
+            ports.append(entry)
+        else:
+            ports.append(NodePort(name=str(entry), port_type="video"))
+    return ports

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -369,10 +369,12 @@ def _validate_edge_ports(
     for node in graph.nodes:
         if node.type == "pipeline" and node.pipeline_id is not None:
             pipeline = pipeline_manager.get_pipeline_by_id(node.id)
-            config_class = pipeline.get_config_class()
+            # Use get_definition() so declared NodePort entries (with
+            # non-video port_type) are recognised alongside string names.
+            defn = pipeline.get_definition()
             port_map[node.id] = (
-                set(config_class.inputs),
-                set(config_class.outputs),
+                {p.name for p in defn.inputs},
+                {p.name for p in defn.outputs},
             )
         elif node.type == "node" and node.node_type_id is not None:
             node_cls = NodeRegistry.get(node.node_type_id)

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -165,6 +165,29 @@ class PipelineManager:
             self._pipelines[key] = pipeline_instance
             self._pipeline_statuses[key] = PipelineStatus.LOADED
 
+    def register_graph_nodes(self, graph_data: dict) -> None:
+        """Instantiate and register plain custom nodes from a graph payload.
+
+        Custom nodes (``type == "node"``) aren't pre-loaded via
+        ``/pipeline/load`` the way pipelines are, but the graph executor
+        resolves every graph node through :meth:`get_pipeline_by_id`. Plain
+        nodes are cheap to construct; model weights load lazily on first
+        ``execute``. Uses :meth:`set_pipeline_instance` (additive, per-key)
+        so pipelines already loaded via ``/pipeline/load`` are untouched.
+        """
+        from scope.core.nodes.registry import NodeRegistry
+
+        for node in graph_data.get("nodes", []):
+            if not (node.get("type") == "node" and node.get("node_type_id")):
+                continue
+            node_cls = NodeRegistry.get(node["node_type_id"])
+            if node_cls is None:
+                continue
+            self.set_pipeline_instance(node["id"], node_cls())
+            logger.info(
+                f"Registered custom node {node['node_type_id']} as {node['id']}"
+            )
+
     async def _load_pipeline_by_id(
         self,
         pipeline_id: str,

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -150,21 +150,16 @@ class PipelineProcessor:
             for p in self.pipeline.get_definition().inputs
             if p.port_type != "video"
         }
-        # Broadcasts that haven't been delivered yet. Graph-driven params
-        # (e.g. a PromptEnhancer feeding a string port) often land before
-        # the WebRTC data channel is open, so the payload stays cached and
-        # is retried on each chunk until at least one session receives it.
-        self._pending_param_broadcast: dict[str, Any] = {}
 
     def _drain_non_video_inputs(self) -> None:
         """Drain scalar input queues into ``self.parameters`` and sync the UI.
 
         Non-video ports (string, number, …) deliver discrete values rather
         than frame streams; the latest value on each queue wins. Video ports
-        are left alone — those follow the chunk-gathering path below. Any
-        value drained is broadcast so widgets like the Prompt textarea
-        reflect what an upstream backend node produced; pending broadcasts
-        from prior chunks are retried here too.
+        are left alone — those follow the chunk-gathering path below. Drained
+        values are broadcast so widgets like the Prompt textarea reflect
+        what an upstream backend node produced; NotificationSender buffers
+        the payload if the WebRTC data channel isn't open yet.
         """
         if not self._non_video_input_ports:
             return
@@ -174,6 +169,7 @@ class PipelineProcessor:
                 for port, q in self.input_queues.items()
                 if port in self._non_video_input_ports
             ]
+        drained_values: dict[str, Any] = {}
         for port, q in targets:
             latest = None
             drained = False
@@ -185,24 +181,17 @@ class PipelineProcessor:
                     break
             if drained:
                 self.parameters[port] = latest
-                self._pending_param_broadcast[port] = latest
-        self._flush_param_broadcast()
-
-    def _flush_param_broadcast(self) -> None:
-        """Send any cached parameter updates; clear on successful delivery."""
-        if not self._pending_param_broadcast:
+                drained_values[port] = latest
+        if not drained_values:
             return
-        # Fetch the WebRTCManager lazily via the module so we pick up the
-        # instance bound at startup, not the ``None`` captured at import
-        # time.
         from . import app as _app
 
         manager = getattr(_app, "webrtc_manager", None)
         if manager is None:
             return
-        payload = {"node_id": self.node_id, **self._pending_param_broadcast}
+        payload = {"node_id": self.node_id, **drained_values}
         try:
-            sent = manager.broadcast_notification(
+            manager.broadcast_notification(
                 {"type": "parameters_updated", "parameters": payload}
             )
         except Exception:
@@ -211,9 +200,6 @@ class PipelineProcessor:
                 self.node_id,
                 exc_info=True,
             )
-            return
-        if sent > 0:
-            self._pending_param_broadcast.clear()
 
     def set_beat_cache_reset_rate(self, rate: str) -> None:
         """Set the beat-synced cache reset rate and reset the boundary tracker."""
@@ -527,9 +513,7 @@ class PipelineProcessor:
 
         # Drain non-video input ports (string, number, …) into parameters so
         # upstream nodes — e.g. a PromptEnhancer feeding a string port — can
-        # drive pipeline kwargs via graph edges. Also retries any param
-        # broadcasts queued but not yet delivered due to the WebRTC
-        # handshake race.
+        # drive pipeline kwargs via graph edges.
         self._drain_non_video_inputs()
 
         requirements = None

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -142,6 +142,79 @@ class PipelineProcessor:
         # giving the video track a stable playback speed for A/V sync.
         self.native_fps: float | None = None
 
+        # Names of input ports whose declared type isn't "video". Values
+        # arriving on these ports are drained into ``self.parameters`` each
+        # chunk instead of being treated as chunked video streams.
+        self._non_video_input_ports: set[str] = {
+            p.name
+            for p in self.pipeline.get_definition().inputs
+            if p.port_type != "video"
+        }
+        # Broadcasts that haven't been delivered yet. Graph-driven params
+        # (e.g. a PromptEnhancer feeding a string port) often land before
+        # the WebRTC data channel is open, so the payload stays cached and
+        # is retried on each chunk until at least one session receives it.
+        self._pending_param_broadcast: dict[str, Any] = {}
+
+    def _drain_non_video_inputs(self) -> None:
+        """Drain scalar input queues into ``self.parameters`` and sync the UI.
+
+        Non-video ports (string, number, …) deliver discrete values rather
+        than frame streams; the latest value on each queue wins. Video ports
+        are left alone — those follow the chunk-gathering path below. Any
+        value drained is broadcast so widgets like the Prompt textarea
+        reflect what an upstream backend node produced; pending broadcasts
+        from prior chunks are retried here too.
+        """
+        if not self._non_video_input_ports:
+            return
+        with self.input_queue_lock:
+            targets = [
+                (port, q)
+                for port, q in self.input_queues.items()
+                if port in self._non_video_input_ports
+            ]
+        for port, q in targets:
+            latest = None
+            drained = False
+            while True:
+                try:
+                    latest = q.get_nowait()
+                    drained = True
+                except queue.Empty:
+                    break
+            if drained:
+                self.parameters[port] = latest
+                self._pending_param_broadcast[port] = latest
+        self._flush_param_broadcast()
+
+    def _flush_param_broadcast(self) -> None:
+        """Send any cached parameter updates; clear on successful delivery."""
+        if not self._pending_param_broadcast:
+            return
+        # Fetch the WebRTCManager lazily via the module so we pick up the
+        # instance bound at startup, not the ``None`` captured at import
+        # time.
+        from . import app as _app
+
+        manager = getattr(_app, "webrtc_manager", None)
+        if manager is None:
+            return
+        payload = {"node_id": self.node_id, **self._pending_param_broadcast}
+        try:
+            sent = manager.broadcast_notification(
+                {"type": "parameters_updated", "parameters": payload}
+            )
+        except Exception:
+            logger.debug(
+                "Failed to broadcast parameters_updated for %s",
+                self.node_id,
+                exc_info=True,
+            )
+            return
+        if sent > 0:
+            self._pending_param_broadcast.clear()
+
     def set_beat_cache_reset_rate(self, rate: str) -> None:
         """Set the beat-synced cache reset rate and reset the boundary tracker."""
         self._beat_cache_reset_rate = rate
@@ -452,6 +525,13 @@ class PipelineProcessor:
                             break
             self._pending_cache_init = True
 
+        # Drain non-video input ports (string, number, …) into parameters so
+        # upstream nodes — e.g. a PromptEnhancer feeding a string port — can
+        # drive pipeline kwargs via graph edges. Also retries any param
+        # broadcasts queued but not yet delivered due to the WebRTC
+        # handshake race.
+        self._drain_non_video_inputs()
+
         requirements = None
         if hasattr(self.pipeline, "prepare"):
             prepare_params = dict(self.parameters.items())
@@ -464,8 +544,12 @@ class PipelineProcessor:
         if requirements is not None:
             current_chunk_size = requirements.input_size
             with self.input_queue_lock:
-                input_queues_ref = dict(self.input_queues)
-            # Wait until ALL wired input queues have enough frames
+                input_queues_ref = {
+                    port: q
+                    for port, q in self.input_queues.items()
+                    if port not in self._non_video_input_ports
+                }
+            # Wait until ALL wired video input queues have enough frames
             if not input_queues_ref or not all(
                 q.qsize() >= current_chunk_size for q in input_queues_ref.values()
             ):

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -398,27 +398,10 @@ class WebRTCManager:
                             logger.info(
                                 f"Re-keyed pipeline {pid} as {node['id']} for graph"
                             )
-                # Plain custom nodes aren't pre-loaded via the /pipeline/load
-                # endpoint the way pipelines are, but the unified graph
-                # executor resolves them through the PipelineManager all the
-                # same (``build_graph`` calls ``get_pipeline_by_id(node.id)``
-                # for every graph node). Instantiate and register them
-                # directly here — we avoid ``load_pipelines`` because that
-                # does a bulk replace and would unload the pipeline loaded
-                # via /pipeline/load. Plain nodes are cheap to construct;
-                # model weights are loaded lazily on first ``execute``.
-                from scope.core.nodes.registry import NodeRegistry
-
-                for node in graph_data.get("nodes", []):
-                    if not (node.get("type") == "node" and node.get("node_type_id")):
-                        continue
-                    node_cls = NodeRegistry.get(node["node_type_id"])
-                    if node_cls is None:
-                        continue
-                    pipeline_manager.set_pipeline_instance(node["id"], node_cls())
-                    logger.info(
-                        f"Registered custom node {node['node_type_id']} as {node['id']}"
-                    )
+                # Plain custom nodes aren't pre-loaded via /pipeline/load,
+                # but the graph executor still resolves them through the
+                # PipelineManager — so instantiate and register them here.
+                pipeline_manager.register_graph_nodes(graph_data)
 
             # Create FrameProcessor (owned by session, shared between tracks)
             frame_processor = FrameProcessor(
@@ -1316,26 +1299,20 @@ class WebRTCManager:
         if self.headless_session and self.headless_session.frame_processor:
             self.headless_session.frame_processor.update_parameters(parameters)
 
-    def broadcast_notification(self, message: dict) -> int:
+    def broadcast_notification(self, message: dict) -> None:
         """Send a notification to active sessions via their data channels.
 
         Safe to call from worker threads: sends are marshalled onto the
-        aiortc event loop through each session's :class:`NotificationSender`.
-        Returns the number of sessions the message was dispatched to so
-        callers can decide whether to retry (e.g. when a pipeline-side
-        parameter change races ahead of the WebRTC handshake).
+        aiortc event loop through each session's :class:`NotificationSender`,
+        which also buffers messages until the data channel is open.
         """
-        sent = 0
         for session in self.sessions.values():
             if session.pc.connectionState in ("closed", "failed"):
                 continue
             sender = session.notification_sender
             if sender is None:
                 continue
-            if sender.data_channel and sender.data_channel.readyState == "open":
-                sender.call(message)
-                sent += 1
-        return sent
+            sender.call(message)
 
     async def stop(self):
         """Close and cleanup all sessions (WebRTC and headless)."""

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -398,6 +398,27 @@ class WebRTCManager:
                             logger.info(
                                 f"Re-keyed pipeline {pid} as {node['id']} for graph"
                             )
+                # Plain custom nodes aren't pre-loaded via the /pipeline/load
+                # endpoint the way pipelines are, but the unified graph
+                # executor resolves them through the PipelineManager all the
+                # same (``build_graph`` calls ``get_pipeline_by_id(node.id)``
+                # for every graph node). Instantiate and register them
+                # directly here — we avoid ``load_pipelines`` because that
+                # does a bulk replace and would unload the pipeline loaded
+                # via /pipeline/load. Plain nodes are cheap to construct;
+                # model weights are loaded lazily on first ``execute``.
+                from scope.core.nodes.registry import NodeRegistry
+
+                for node in graph_data.get("nodes", []):
+                    if not (node.get("type") == "node" and node.get("node_type_id")):
+                        continue
+                    node_cls = NodeRegistry.get(node["node_type_id"])
+                    if node_cls is None:
+                        continue
+                    pipeline_manager.set_pipeline_instance(node["id"], node_cls())
+                    logger.info(
+                        f"Registered custom node {node['node_type_id']} as {node['id']}"
+                    )
 
             # Create FrameProcessor (owned by session, shared between tracks)
             frame_processor = FrameProcessor(
@@ -1295,19 +1316,26 @@ class WebRTCManager:
         if self.headless_session and self.headless_session.frame_processor:
             self.headless_session.frame_processor.update_parameters(parameters)
 
-    def broadcast_notification(self, message: dict) -> None:
-        """Send a notification message to all active sessions via their data channels."""
-        message_str = json.dumps(message)
+    def broadcast_notification(self, message: dict) -> int:
+        """Send a notification to active sessions via their data channels.
+
+        Safe to call from worker threads: sends are marshalled onto the
+        aiortc event loop through each session's :class:`NotificationSender`.
+        Returns the number of sessions the message was dispatched to so
+        callers can decide whether to retry (e.g. when a pipeline-side
+        parameter change races ahead of the WebRTC handshake).
+        """
+        sent = 0
         for session in self.sessions.values():
             if session.pc.connectionState in ("closed", "failed"):
                 continue
-            if session.data_channel and session.data_channel.readyState == "open":
-                try:
-                    session.data_channel.send(message_str)
-                except Exception as e:
-                    logger.error(
-                        f"Failed to send notification to session {session.id}: {e}"
-                    )
+            sender = session.notification_sender
+            if sender is None:
+                continue
+            if sender.data_channel and sender.data_channel.readyState == "open":
+                sender.call(message)
+                sent += 1
+        return sent
 
     async def stop(self):
         """Close and cleanup all sessions (WebRTC and headless)."""


### PR DESCRIPTION
… params

Lets a graph node (e.g. a Prompt Enhancer plugin) drive a downstream pipeline's runtime kwargs through the same "Enter prompt…" handle the UI already exposes, and keeps the frontend widgets in sync with parameter values the backend receives over graph edges.

Backend
- BasePipelineConfig: new input_port_types ClassVar for declaring non-video input ports.
- Pipeline.get_definition synthesizes a __prompt string port for every prompt-capable pipeline so graph edges can target it.
- PipelineProcessor drains non-video input queues into self.parameters each chunk; __prompt values are remapped to the prompts kwarg (normalising raw strings to [{text, weight}]).
- Graph executor validates pipeline ports via get_definition so the synthesized __prompt port is accepted.
- Parameter updates from graph edges broadcast parameters_updated over the data channel (via NotificationSender so it's safe from the worker thread), with a retry loop that covers the WebRTC handshake race.

Frontend
- Import maps backend edges targeting __prompt on a pipeline node to the UI's param:__prompt handle so the wire lands on the Prompt row.
- Custom-node widgets now also fire onCustomNodeParamChange on edit, pushing param changes to the running backend worker through the same channel pipeline params use — no session restart required.