### PR TITLE
Update scope-ltx-2 plugin to latest commit

### DIFF
--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -47,8 +47,8 @@ COPY src/ /app/src/
 
 # Pre-install bundled plugins (cannot be removed by users)
 ENV DAYDREAM_SCOPE_BUNDLED_PLUGINS_FILE="/app/bundled-plugins.txt"
-RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git@21c3656a13361ffc664126c38e8b3ee0421fc90f" > /app/bundled-plugins.txt
-RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git@21c3656a13361ffc664126c38e8b3ee0421fc90f
+RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git@69d2a1dfdfd810011ba4be084abcb28389826518" > /app/bundled-plugins.txt
+RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git@69d2a1dfdfd810011ba4be084abcb28389826518
 
 # Expose port 8000 for RunPod HTTP proxy
 EXPOSE 8000


### PR DESCRIPTION
Bump pinned scope-ltx-2 commit in Dockerfile.cloud from 21c3656a to 69d2a1df (current HEAD of daydreamlive/scope-ltx-2).