### PR TITLE
Ensure local media is uploaded to cloud

### DIFF
--- a/frontend/src/components/graph/hooks/value/useValueForwarding.ts
+++ b/frontend/src/components/graph/hooks/value/useValueForwarding.ts
@@ -1,5 +1,12 @@
 import { useEffect, useRef, useMemo } from "react";
 import type { Edge, Node } from "@xyflow/react";
+import { toast } from "sonner";
+import { useCloudStatus } from "../../../../hooks/useCloudStatus";
+import {
+  createUploadCache,
+  assetPath,
+  type AssetKind,
+} from "../../../../lib/assetUpload";
 import type { FlowNodeData, SubgraphPort } from "../../../../lib/graphUtils";
 import { parseHandleId } from "../../../../lib/graphUtils";
 import { getAnyValueFromNode } from "../../utils/getValueFromNode";
@@ -29,6 +36,17 @@ function valuesEqual(a: unknown, b: unknown): boolean {
     return true;
   }
   return false;
+}
+
+function getNodeMediaType(node: Node<FlowNodeData>): AssetKind | null {
+  if (node.data.nodeType === "image") {
+    return node.data.mediaType === "video" ? "video" : "image";
+  }
+  if (node.data.nodeType === "audio") {
+    return "audio";
+  }
+  // not a node with a recognized media type
+  return null;
 }
 
 const PRODUCER_TYPES = new Set<FlowNodeData["nodeType"]>([
@@ -142,7 +160,10 @@ export function useValueForwarding(
     ((nodeId: string, text: string) => void) | undefined
   >
 ) {
+  const { isConnected: isCloudConnected } = useCloudStatus();
   const lastForwardTimeRef = useRef<Record<string, number>>({});
+  const uploadCacheRef = useRef(createUploadCache());
+  const lastUploadErrorRef = useRef<string>("");
 
   // Track previous node data to skip backend sends when only positions changed
   const prevNodeDataRef = useRef<Map<string, FlowNodeData>>(new Map());
@@ -167,6 +188,11 @@ export function useValueForwarding(
       ref.clear();
     };
   }, []);
+
+  useEffect(() => {
+    uploadCacheRef.current = createUploadCache();
+    lastUploadErrorRef.current = "";
+  }, [isCloudConnected]);
 
   // Detect streaming session start (false→true) and clear dedup state so the
   // new backend session receives all parameter values, even if they haven't
@@ -203,6 +229,18 @@ export function useValueForwarding(
       if (valuesEqual(lastSentRef.current.get(dedupKey), value)) return;
       lastSentRef.current.set(dedupKey, value);
       onNodeParamChangeRef.current!(backendId, paramName, value);
+    };
+
+    const getMediaPath = async (
+      sourceNode: Node<FlowNodeData>,
+      value: unknown
+    ): Promise<unknown> => {
+      const kind = getNodeMediaType(sourceNode);
+      if (!kind || typeof value !== "string" || !isCloudConnected) {
+        return value;
+      }
+
+      return assetPath(value, kind, uploadCacheRef.current);
     };
 
     // Check if any producer node data actually changed (not just positions)
@@ -486,7 +524,28 @@ export function useValueForwarding(
             sendPrompt();
           }
         } else {
-          sendParam(resolvedBackendId, resolvedParamName, entry.value);
+          void getMediaPath(node, entry.value)
+            .then(resolvedMediaPath => {
+              sendParam(
+                resolvedBackendId,
+                resolvedParamName,
+                resolvedMediaPath
+              );
+            })
+            .catch((error: unknown) => {
+              const message =
+                error instanceof Error
+                  ? error.message
+                  : "Could not upload cloud asset";
+              console.error("Error uploading graph cloud asset:", error);
+              if (lastUploadErrorRef.current === message) {
+                return;
+              }
+              lastUploadErrorRef.current = message;
+              toast.error("Could not upload cloud asset", {
+                description: message,
+              });
+            });
         }
 
         // Auto-forward tempo meta-settings to connected pipelines
@@ -521,6 +580,8 @@ export function useValueForwarding(
     isStreaming,
     sessionTick,
     onNodeParamChangeRef,
+    onPromptForwardRef,
+    isCloudConnected,
   ]);
 
   const nodesRef = useRef(nodes);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -521,6 +521,10 @@ export const uploadAsset = async (file: File): Promise<AssetFileInfo> => {
 };
 
 export const getAssetUrl = (assetPath: string): string => {
+  if (assetPath.startsWith("blob:") || assetPath.startsWith("data:")) {
+    return assetPath;
+  }
+
   // The backend returns full absolute paths, but we need to extract the relative path
   // from the assets directory for the serving endpoint
   // Example: C:\Users\...\assets\myimage.png -> myimage.png

--- a/frontend/src/lib/assetUpload.ts
+++ b/frontend/src/lib/assetUpload.ts
@@ -1,0 +1,159 @@
+import {
+  getAssetUrl,
+  listAssets,
+  uploadAsset as uploadAssetFile,
+  type AssetFileInfo,
+} from "./api";
+
+export type AssetKind = "image" | "video" | "audio";
+
+export interface UploadCache {
+  assetsByKind: Partial<Record<AssetKind, AssetFileInfo[]>>;
+  uploads: Map<string, Promise<string>>;
+}
+
+export interface AssetFieldSpec {
+  key: string;
+  kind: AssetKind;
+}
+
+const WINDOWS_ABSOLUTE_PATH_RE = /^[A-Za-z]:[\\/]/;
+
+export function createUploadCache(): UploadCache {
+  return {
+    assetsByKind: {},
+    uploads: new Map(),
+  };
+}
+
+function getBasename(assetPath: string): string {
+  const parts = assetPath.split(/[/\\]/);
+  return parts[parts.length - 1] || assetPath;
+}
+
+function isFilesystemAssetPath(assetPath: string): boolean {
+  if (!assetPath) return false;
+  if (
+    assetPath.startsWith("blob:") ||
+    assetPath.startsWith("data:") ||
+    assetPath.startsWith("http://") ||
+    assetPath.startsWith("https://")
+  ) {
+    return false;
+  }
+  if (WINDOWS_ABSOLUTE_PATH_RE.test(assetPath)) return true;
+  if (!assetPath.startsWith("/")) return false;
+  return true;
+}
+
+async function getAssetsForKind(
+  kind: AssetKind,
+  cache: UploadCache
+): Promise<AssetFileInfo[]> {
+  const cached = cache.assetsByKind[kind];
+  if (cached) {
+    return cached;
+  }
+  const response = await listAssets(kind);
+  cache.assetsByKind[kind] = response.assets;
+  return response.assets;
+}
+
+function guessMimeType(assetPath: string, kind: AssetKind): string {
+  const ext = assetPath.split(".").pop()?.toLowerCase() ?? "";
+  if (kind === "image") {
+    if (ext === "png") return "image/png";
+    if (ext === "webp") return "image/webp";
+    if (ext === "bmp") return "image/bmp";
+    return "image/jpeg";
+  }
+  if (kind === "audio") {
+    if (ext === "wav") return "audio/wav";
+    if (ext === "flac") return "audio/flac";
+    if (ext === "ogg") return "audio/ogg";
+    return "audio/mpeg";
+  }
+  if (ext === "webm") return "video/webm";
+  if (ext === "mov") return "video/quicktime";
+  return "video/mp4";
+}
+
+export async function assetPath(
+  path: string,
+  kind: AssetKind,
+  cache: UploadCache
+): Promise<string> {
+  if (!path || !isFilesystemAssetPath(path)) {
+    return path;
+  }
+
+  const assets = await getAssetsForKind(kind, cache);
+  const exactMatch = assets.find(asset => asset.path === path);
+  if (exactMatch) {
+    return exactMatch.path;
+  }
+
+  const uploadKey = `${kind}\0${path}`;
+  const existingUpload = cache.uploads.get(uploadKey);
+  if (existingUpload) {
+    return existingUpload;
+  }
+
+  const uploadPromise = (async () => {
+    const response = await fetch(getAssetUrl(path));
+    if (!response.ok) {
+      throw new Error(
+        `Could not read local asset '${path}' (${response.status})`
+      );
+    }
+
+    const blob = await response.blob();
+    const file = new File([blob], getBasename(path), {
+      type: blob.type || guessMimeType(path, kind),
+    });
+    const uploaded = await uploadAssetFile(file);
+
+    if (cache.assetsByKind[kind]) {
+      cache.assetsByKind[kind] = [uploaded, ...cache.assetsByKind[kind]!];
+    }
+
+    return uploaded.path;
+  })();
+
+  cache.uploads.set(uploadKey, uploadPromise);
+
+  try {
+    return await uploadPromise;
+  } catch (error) {
+    cache.uploads.delete(uploadKey);
+    throw error;
+  }
+}
+
+export async function rewriteAssetFields<T extends Record<string, unknown>>(
+  params: T,
+  specs: AssetFieldSpec[],
+  cache: UploadCache
+): Promise<T> {
+  const nextParams: Record<string, unknown> = { ...params };
+
+  for (const spec of specs) {
+    const value = nextParams[spec.key];
+    if (value == null) continue;
+
+    if (Array.isArray(value)) {
+      const rewritten = await Promise.all(
+        value.map(item =>
+          typeof item === "string" ? assetPath(item, spec.kind, cache) : item
+        )
+      );
+      nextParams[spec.key] = rewritten;
+      continue;
+    }
+
+    if (typeof value !== "string") continue;
+    nextParams[spec.key] = await assetPath(value, spec.kind, cache);
+  }
+
+  return nextParams as T;
+}

--- a/frontend/src/lib/assetUpload.ts
+++ b/frontend/src/lib/assetUpload.ts
@@ -31,14 +31,14 @@ function getBasename(assetPath: string): string {
   return parts[parts.length - 1] || assetPath;
 }
 
-function isFilesystemAssetPath(assetPath: string): boolean {
+function isBlobOrDataAssetPath(assetPath: string): boolean {
+  return assetPath.startsWith("blob:") || assetPath.startsWith("data:");
+}
+
+function isUploadableAssetPath(assetPath: string): boolean {
   if (!assetPath) return false;
-  if (
-    assetPath.startsWith("blob:") ||
-    assetPath.startsWith("data:") ||
-    assetPath.startsWith("http://") ||
-    assetPath.startsWith("https://")
-  ) {
+  if (isBlobOrDataAssetPath(assetPath)) return true;
+  if (assetPath.startsWith("http://") || assetPath.startsWith("https://")) {
     return false;
   }
   if (WINDOWS_ABSOLUTE_PATH_RE.test(assetPath)) return true;
@@ -78,12 +78,38 @@ function guessMimeType(assetPath: string, kind: AssetKind): string {
   return "video/mp4";
 }
 
+function extensionForMimeType(mimeType: string, kind: AssetKind): string {
+  if (mimeType === "image/png") return "png";
+  if (mimeType === "image/webp") return "webp";
+  if (mimeType === "image/bmp") return "bmp";
+  if (mimeType === "image/jpeg") return "jpg";
+  if (mimeType === "audio/wav") return "wav";
+  if (mimeType === "audio/flac") return "flac";
+  if (mimeType === "audio/ogg") return "ogg";
+  if (mimeType === "audio/mpeg") return "mp3";
+  if (mimeType === "video/webm") return "webm";
+  if (mimeType === "video/quicktime") return "mov";
+  return kind === "image" ? "jpg" : kind === "audio" ? "mp3" : "mp4";
+}
+
+function getUploadFilename(
+  assetPath: string,
+  mimeType: string,
+  kind: AssetKind
+): string {
+  if (!isBlobOrDataAssetPath(assetPath)) {
+    return getBasename(assetPath);
+  }
+  const extension = extensionForMimeType(mimeType, kind);
+  return `upload-${crypto.randomUUID()}.${extension}`;
+}
+
 export async function assetPath(
   path: string,
   kind: AssetKind,
   cache: UploadCache
 ): Promise<string> {
-  if (!path || !isFilesystemAssetPath(path)) {
+  if (!path || !isUploadableAssetPath(path)) {
     return path;
   }
 
@@ -102,14 +128,13 @@ export async function assetPath(
   const uploadPromise = (async () => {
     const response = await fetch(getAssetUrl(path));
     if (!response.ok) {
-      throw new Error(
-        `Could not read local asset '${path}' (${response.status})`
-      );
+      throw new Error(`Could not read asset '${path}' (${response.status})`);
     }
 
     const blob = await response.blob();
-    const file = new File([blob], getBasename(path), {
-      type: blob.type || guessMimeType(path, kind),
+    const mimeType = blob.type || guessMimeType(path, kind);
+    const file = new File([blob], getUploadFilename(path, mimeType, kind), {
+      type: mimeType,
     });
     const uploaded = await uploadAssetFile(file);
 

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -48,6 +48,7 @@ import {
   fitResolutionToPixelBudget,
   getResolutionScaleFactor,
 } from "../lib/utils";
+import { createUploadCache, rewriteAssetFields } from "../lib/assetUpload";
 import type {
   ExtensionMode,
   InputMode,
@@ -193,6 +194,11 @@ export function StreamPage() {
 
   // Cloud-connected mode tracks backend connection status.
   const isCloudMode = isBackendCloudConnected;
+  const uploadCacheRef = useRef(createUploadCache());
+
+  useEffect(() => {
+    uploadCacheRef.current = createUploadCache();
+  }, [isBackendCloudConnected]);
 
   // After cloud auth during onboarding, the CloudAuthStep fires
   // activateCloudRelay(). Refresh the shared cloud status so the UI
@@ -3133,8 +3139,37 @@ export function StreamPage() {
         graphSinkNodeIds.length > 0 || graphRecordNodeIds.length > 0
           ? [...graphSinkNodeIds, ...graphRecordNodeIds]
           : undefined;
+      let params = initialParameters;
+      if (isCloudMode) {
+        try {
+          params = await rewriteAssetFields(
+            initialParameters,
+            [
+              // Only rewrite preview-page initial parameter fields here; other
+              // graph node media types like audio are forwarded separately and
+              // are not part of this initialParameters payload.
+              { key: "images", kind: "image" },
+              { key: "vace_ref_images", kind: "image" },
+              { key: "first_frame_image", kind: "image" },
+              { key: "last_frame_image", kind: "image" },
+            ],
+            uploadCacheRef.current
+          );
+        } catch (error) {
+          console.error("Error uploading cloud assets:", error);
+          toast.error("Could not upload cloud assets", {
+            description:
+              error instanceof Error
+                ? error.message
+                : "An error occurred while uploading assets for cloud streaming",
+            duration: 5000,
+          });
+          return false;
+        }
+      }
+
       startStream(
-        initialParameters,
+        params,
         sourceNodeStreamsForWebRTC ? undefined : streamToSend,
         webrtcMultiOutputNodeIds,
         sourceNodeStreamsForWebRTC


### PR DESCRIPTION
If media was set before a cloud connection, then the cloud runner
would receive client-local URLs which obviously wouldn't work.
    
Walk the nodes before starting a stream and rewrite any image / audio
source paths if needed, including performing uploads.