### PR TITLE
fix: stop log spam when reference image fails to load

### DIFF
--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -484,6 +484,20 @@ class PipelineProcessor:
             # Pass parameters (excluding prepare-only parameters)
             call_params = dict(self.parameters.items())
 
+            # Clear one-shot parameters from self.parameters now that they are captured
+            # in call_params. Popping before pipeline execution (instead of after success)
+            # ensures a failure — e.g. a bad image URL that raises FileNotFoundError —
+            # does not re-fire the same value on every subsequent chunk, which previously
+            # produced thousands of repeated tracebacks per second.
+            one_shot_params = (
+                "vace_ref_images",
+                "images",
+                "first_frame_image",
+                "last_frame_image",
+            )
+            for param in one_shot_params:
+                self.parameters.pop(param, None)
+
             # Pass reset_cache as init_cache to pipeline
             call_params["init_cache"] = not self.is_prepared or self._pending_cache_init
             if reset_cache:
@@ -557,18 +571,6 @@ class PipelineProcessor:
                 self.is_prepared = True
                 self._pending_cache_init = False
                 return
-
-            # Clear one-shot parameters after use to prevent sending them on subsequent chunks
-            # These parameters should only be sent when explicitly provided in parameter updates
-            one_shot_params = [
-                "vace_ref_images",
-                "images",
-                "first_frame_image",
-                "last_frame_image",
-            ]
-            for param in one_shot_params:
-                if param in call_params and param in self.parameters:
-                    self.parameters.pop(param, None)
 
             # Clear transition when complete
             if "transition" in call_params and "transition" in self.parameters:


### PR DESCRIPTION
## Summary

- One-shot image params (`vace_ref_images`, `images`, `first_frame_image`, `last_frame_image`) were only popped from `self.parameters` *after* a successful pipeline call. When image loading raised `FileNotFoundError` (e.g. a bad fal.media URL), the exception bypassed the clearing block, so the same bad value replayed on every chunk at ~30 fps — each producing a full diffusers traceback plus a scope `exc_info=True` traceback.
- One broken reference image turned into ~18k log lines in the Fal log drain and ~1000× the normal volume on the Livepeer events channel, risking drain cutoff and session termination.
- Move the pop immediately after the params are captured into `call_params`, so a single failure only logs once regardless of whether the pipeline succeeds or raises.

Reported by @j0sh.

## Test plan

- [ ] Start a Scope session with a pipeline that uses VACE reference images (longlive / wan2_1 VACE) and pass a bogus `vace_ref_images` path / URL.
- [ ] Confirm exactly one error burst is logged (diffusers + scope), not one per chunk.
- [ ] Confirm subsequent chunks run normally (no replay of the bad path) and the session stays alive.
- [ ] Verify the same behaviour for `first_frame_image` and `last_frame_image` one-shot params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
