### PR TITLE
feat(frontend): searchable Pipeline/Source/Plugins submenus in node menu

### DIFF
--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -7,8 +7,13 @@ import {
   DialogDescription,
 } from "../ui/dialog";
 import type { FlowNodeData } from "../../lib/graphUtils";
-import type { NodeDefinitionDto } from "../../lib/api";
-import { fetchNodeDefinitions } from "../../lib/api";
+import type { NodeDefinitionDto, InputSourceType } from "../../lib/api";
+import { usePipelinesContext } from "../../contexts/PipelinesContext";
+import { useNodeDefinitions } from "../../hooks/useNodeDefinitions";
+import {
+  BROWSER_SOURCE_MODES,
+  getVisibleBackendSources,
+} from "../../lib/sourceModes";
 
 interface AddNodeModalProps {
   open: boolean;
@@ -44,6 +49,7 @@ interface AddNodeModalProps {
     subType?: string,
     extraData?: Partial<FlowNodeData>
   ) => void;
+  availableInputSources?: InputSourceType[];
 }
 
 interface NodeCatalogItem {
@@ -84,20 +90,6 @@ interface NodeCatalogItem {
 }
 
 const NODE_CATALOG: NodeCatalogItem[] = [
-  {
-    type: "source",
-    name: "Source",
-    description: "Input node for the workflow",
-    color: "#4ade80",
-    category: "I/O",
-  },
-  {
-    type: "pipeline",
-    name: "Pipeline",
-    description: "Processing pipeline node",
-    color: "#60a5fa",
-    category: "I/O",
-  },
   {
     type: "control",
     subType: "float",
@@ -304,6 +296,8 @@ const NODE_CATALOG: NodeCatalogItem[] = [
 
 const CATEGORIES = [
   "All",
+  "Pipelines",
+  "Sources",
   "I/O",
   "Values",
   "Controls",
@@ -401,49 +395,62 @@ export function AddNodeModal({
   open,
   onClose,
   onSelectNodeType,
+  availableInputSources = [],
 }: AddNodeModalProps) {
   const [searchText, setSearchText] = useState("");
   const [activeCategory, setActiveCategory] = useState("All");
-  const [customNodes, setCustomNodes] = useState<NodeCatalogItem[]>([]);
+  const { pipelines } = usePipelinesContext();
+  const { customNodes: customNodeDefs } = useNodeDefinitions();
 
-  useEffect(() => {
-    if (!open) return;
-    const controller = new AbortController();
-    fetchNodeDefinitions({ signal: controller.signal })
-      .then(data => {
-        if (controller.signal.aborted) return;
-        // The unified endpoint returns both pipelines (pipeline_meta != null)
-        // and plain custom nodes. Pipelines are still added via the hardcoded
-        // "Pipeline" catalog entry (placeholder + dropdown); the scheduler
-        // has its own catalog entry with a bespoke widget. Filter both out
-        // of the plugin listing to avoid duplication.
-        const items: NodeCatalogItem[] = (data.nodes ?? [])
-          .filter(
-            n => n.pipeline_meta == null && n.node_type_id !== "scheduler"
-          )
-          .map(n => ({
-            type: "custom_node" as const,
-            subType: n.node_type_id,
-            name: n.display_name || n.node_type_id,
-            description: n.description || "",
-            color: "#9ca3af",
-            category: "Plugins",
-            customNodeDef: n,
-          }));
-        setCustomNodes(items);
-      })
-      .catch((err: unknown) => {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        // Custom nodes won't appear, but log so plugin-registration
-        // regressions don't disappear silently.
-        console.warn("Failed to fetch custom node definitions:", err);
-      });
-    return () => controller.abort();
-  }, [open]);
+  const customNodes = useMemo<NodeCatalogItem[]>(
+    () =>
+      customNodeDefs.map(n => ({
+        type: "custom_node" as const,
+        subType: n.node_type_id,
+        name: n.display_name || n.node_type_id,
+        description: n.description || "",
+        color: "#9ca3af",
+        category: "Plugins",
+        customNodeDef: n,
+      })),
+    [customNodeDefs]
+  );
+
+  const pipelineNodes = useMemo<NodeCatalogItem[]>(() => {
+    if (!pipelines) return [];
+    return Object.entries(pipelines).map(([id, info]) => ({
+      type: "pipeline" as const,
+      subType: id,
+      name: info.name || id,
+      description: info.about || "",
+      color: "#60a5fa",
+      category: "Pipelines",
+    }));
+  }, [pipelines]);
+
+  const sourceNodes = useMemo<NodeCatalogItem[]>(() => {
+    const browser = BROWSER_SOURCE_MODES.map(s => ({
+      type: "source" as const,
+      subType: s.id,
+      name: s.label,
+      description: s.description,
+      color: "#4ade80",
+      category: "Sources",
+    }));
+    const backend = getVisibleBackendSources(availableInputSources).map(s => ({
+      type: "source" as const,
+      subType: s.source_id,
+      name: s.source_name,
+      description: s.source_description || "",
+      color: "#4ade80",
+      category: "Sources",
+    }));
+    return [...browser, ...backend];
+  }, [availableInputSources]);
 
   const fullCatalog = useMemo(
-    () => [...NODE_CATALOG, ...customNodes],
-    [customNodes]
+    () => [...pipelineNodes, ...sourceNodes, ...NODE_CATALOG, ...customNodes],
+    [pipelineNodes, sourceNodes, customNodes]
   );
 
   const filteredItems = useMemo(() => {
@@ -452,7 +459,8 @@ export function AddNodeModal({
       const matchesSearch =
         !lowerSearch ||
         item.name.toLowerCase().includes(lowerSearch) ||
-        item.description.toLowerCase().includes(lowerSearch);
+        item.description.toLowerCase().includes(lowerSearch) ||
+        (item.subType?.toLowerCase().includes(lowerSearch) ?? false);
       const matchesCategory =
         activeCategory === "All" || item.category === activeCategory;
       return matchesSearch && matchesCategory;

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -102,6 +102,7 @@ import { useSubgraphEval } from "./hooks/subgraph/useSubgraphEval";
 import { useSubgraphCallbackSync } from "./hooks/subgraph/useSubgraphCallbackSync";
 import { useSubgraphOperations } from "./hooks/subgraph/useSubgraphOperations";
 import { useNodeDefinitions } from "../../hooks/useNodeDefinitions";
+import { usePipelinesContext } from "../../contexts/PipelinesContext";
 
 const nodeTypes = {
   source: SourceNode,
@@ -595,6 +596,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
       });
 
     const { customNodes: availableCustomNodes } = useNodeDefinitions();
+    const { pipelines } = usePipelinesContext();
 
     const handleDebugNodes = useCallback(() => {
       const DEBUG_NODES: Array<{
@@ -1303,6 +1305,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
                         createSubgraphFromSelection,
                         onOpenBlueprints: () => setShowBlueprintModal(true),
                         availablePipelineIds,
+                        pipelines,
                         availableInputSources,
                         customNodes: availableCustomNodes,
                       })

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -101,6 +101,7 @@ import { useParentValueBridge } from "./hooks/value/useParentValueBridge";
 import { useSubgraphEval } from "./hooks/subgraph/useSubgraphEval";
 import { useSubgraphCallbackSync } from "./hooks/subgraph/useSubgraphCallbackSync";
 import { useSubgraphOperations } from "./hooks/subgraph/useSubgraphOperations";
+import { useNodeDefinitions } from "../../hooks/useNodeDefinitions";
 
 const nodeTypes = {
   source: SourceNode,
@@ -592,6 +593,8 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         setEdges,
         setSelectedNodeIds,
       });
+
+    const { customNodes: availableCustomNodes } = useNodeDefinitions();
 
     const handleDebugNodes = useCallback(() => {
       const DEBUG_NODES: Array<{
@@ -1299,6 +1302,9 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
                         edges,
                         createSubgraphFromSelection,
                         onOpenBlueprints: () => setShowBlueprintModal(true),
+                        availablePipelineIds,
+                        availableInputSources,
+                        customNodes: availableCustomNodes,
                       })
                     : buildNodeMenuItems({
                         contextNodeId: contextMenu.nodeId!,
@@ -1322,6 +1328,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
                 setPendingNodePosition(null);
               }}
               onSelectNodeType={handleNodeTypeSelect}
+              availableInputSources={availableInputSources}
             />
 
             <BlueprintBrowserModal

--- a/frontend/src/components/graph/contextMenuItems.tsx
+++ b/frontend/src/components/graph/contextMenuItems.tsx
@@ -29,10 +29,17 @@ import {
   Circle,
   Layers,
   Clock,
+  Puzzle,
+  Component,
 } from "lucide-react";
 import type { Node, Edge } from "@xyflow/react";
 import type { FlowNodeData } from "../../lib/graphUtils";
 import type { ContextMenuItem } from "./ContextMenu";
+import type { InputSourceType, NodeDefinitionDto } from "../../lib/api";
+import {
+  BROWSER_SOURCE_MODES,
+  getVisibleBackendSources,
+} from "../../lib/sourceModes";
 
 /* ── Pane (canvas) context menu ──────────────────────────────────────────── */
 
@@ -63,8 +70,10 @@ type NodeTypeSelectFn = (
     | "tempo"
     | "prompt_list"
     | "prompt_blend"
-    | "scheduler",
-  subType?: string
+    | "scheduler"
+    | "custom_node",
+  subType?: string,
+  extraData?: Partial<FlowNodeData>
 ) => void;
 
 export function buildPaneMenuItems(deps: {
@@ -78,6 +87,9 @@ export function buildPaneMenuItems(deps: {
     selectedIds: string[]
   ) => void;
   onOpenBlueprints: () => void;
+  availablePipelineIds: string[];
+  availableInputSources: InputSourceType[];
+  customNodes: NodeDefinitionDto[];
 }): ContextMenuItem[] {
   const {
     handleNodeTypeSelect,
@@ -86,21 +98,96 @@ export function buildPaneMenuItems(deps: {
     edges,
     createSubgraphFromSelection,
     onOpenBlueprints,
+    availablePipelineIds,
+    availableInputSources,
+    customNodes,
   } = deps;
 
-  return [
-    {
-      label: "Source",
+  const sourceChildren: ContextMenuItem[] = [
+    ...BROWSER_SOURCE_MODES.map(s => ({
+      label: s.label,
       icon: <Camera />,
-      onClick: () => handleNodeTypeSelect("source"),
-      keywords: ["input", "camera", "video"],
-    },
-    {
-      label: "Pipeline",
-      icon: <Workflow />,
-      onClick: () => handleNodeTypeSelect("pipeline"),
-      keywords: ["process", "effect", "filter"],
-    },
+      onClick: () => handleNodeTypeSelect("source", s.id),
+      keywords: ["source", ...s.keywords],
+    })),
+    ...getVisibleBackendSources(availableInputSources).map(s => ({
+      label: s.source_name,
+      icon: <Camera />,
+      onClick: () => handleNodeTypeSelect("source", s.source_id),
+      keywords: ["source", s.source_id, s.source_description],
+    })),
+  ];
+
+  const pipelineChildren: ContextMenuItem[] = availablePipelineIds.map(id => ({
+    label: id,
+    icon: <Workflow />,
+    onClick: () => handleNodeTypeSelect("pipeline", id),
+    keywords: ["pipeline", id],
+  }));
+
+  const pluginChildren: ContextMenuItem[] = customNodes.map(n => ({
+    label: n.display_name || n.node_type_id,
+    icon: <Component />,
+    onClick: () =>
+      handleNodeTypeSelect("custom_node", n.node_type_id, {
+        customNodeTypeId: n.node_type_id,
+        customNodeDisplayName: n.display_name || n.node_type_id,
+        customNodeCategory: n.category || "",
+        customNodeInputs: n.inputs || [],
+        customNodeOutputs: n.outputs || [],
+        customNodeParamDefs: n.params || [],
+        customNodeParams: Object.fromEntries(
+          (n.params || [])
+            .filter(p => p.default != null)
+            .map(p => [p.name, p.default])
+        ),
+      }),
+    keywords: [
+      "plugin",
+      "custom",
+      n.node_type_id,
+      n.plugin_name || "",
+      n.description || "",
+    ],
+  }));
+
+  return [
+    sourceChildren.length > 0
+      ? {
+          label: "Source",
+          icon: <Camera />,
+          children: sourceChildren,
+          keywords: ["input", "camera", "video", "spout", "ndi", "syphon"],
+        }
+      : {
+          label: "Source",
+          icon: <Camera />,
+          onClick: () => handleNodeTypeSelect("source"),
+          keywords: ["input", "camera", "video"],
+        },
+    pipelineChildren.length > 0
+      ? {
+          label: "Pipeline",
+          icon: <Workflow />,
+          children: pipelineChildren,
+          keywords: ["process", "effect", "filter", "ltx", "streamdiffusion"],
+        }
+      : {
+          label: "Pipeline",
+          icon: <Workflow />,
+          onClick: () => handleNodeTypeSelect("pipeline"),
+          keywords: ["process", "effect", "filter"],
+        },
+    ...(pluginChildren.length > 0
+      ? [
+          {
+            label: "Plugins",
+            icon: <Puzzle />,
+            children: pluginChildren,
+            keywords: ["plugin", "custom", "node"],
+          },
+        ]
+      : []),
     {
       label: "Sink",
       icon: <Monitor />,

--- a/frontend/src/components/graph/contextMenuItems.tsx
+++ b/frontend/src/components/graph/contextMenuItems.tsx
@@ -36,6 +36,7 @@ import type { Node, Edge } from "@xyflow/react";
 import type { FlowNodeData } from "../../lib/graphUtils";
 import type { ContextMenuItem } from "./ContextMenu";
 import type { InputSourceType, NodeDefinitionDto } from "../../lib/api";
+import type { PipelineInfo } from "../../types";
 import {
   BROWSER_SOURCE_MODES,
   getVisibleBackendSources,
@@ -88,6 +89,7 @@ export function buildPaneMenuItems(deps: {
   ) => void;
   onOpenBlueprints: () => void;
   availablePipelineIds: string[];
+  pipelines: Record<string, PipelineInfo> | null;
   availableInputSources: InputSourceType[];
   customNodes: NodeDefinitionDto[];
 }): ContextMenuItem[] {
@@ -99,6 +101,7 @@ export function buildPaneMenuItems(deps: {
     createSubgraphFromSelection,
     onOpenBlueprints,
     availablePipelineIds,
+    pipelines,
     availableInputSources,
     customNodes,
   } = deps;
@@ -118,12 +121,15 @@ export function buildPaneMenuItems(deps: {
     })),
   ];
 
-  const pipelineChildren: ContextMenuItem[] = availablePipelineIds.map(id => ({
-    label: id,
-    icon: <Workflow />,
-    onClick: () => handleNodeTypeSelect("pipeline", id),
-    keywords: ["pipeline", id],
-  }));
+  const pipelineChildren: ContextMenuItem[] = availablePipelineIds.map(id => {
+    const info = pipelines?.[id];
+    return {
+      label: info?.name || id,
+      icon: <Workflow />,
+      onClick: () => handleNodeTypeSelect("pipeline", id),
+      keywords: ["pipeline", id, info?.name ?? "", info?.about ?? ""],
+    };
+  });
 
   const pluginChildren: ContextMenuItem[] = customNodes.map(n => ({
     label: n.display_name || n.node_type_id,

--- a/frontend/src/components/graph/hooks/node/useNodeFactories.ts
+++ b/frontend/src/components/graph/hooks/node/useNodeFactories.ts
@@ -525,10 +525,11 @@ export function useNodeFactories({
     (
       key: NodeTypeKey,
       position?: { x: number; y: number },
-      extraData?: Partial<FlowNodeData>
-    ) => {
+      extraData?: Partial<FlowNodeData>,
+      idPrefixOverride?: string
+    ): string => {
       const def = NODE_DEFAULTS[key];
-      const id = generateNodeId(def.idPrefix, existingIds);
+      const id = generateNodeId(idPrefixOverride ?? def.idPrefix, existingIds);
       const newNode: Node<FlowNodeData> = {
         id,
         type: def.type,
@@ -544,6 +545,7 @@ export function useNodeFactories({
         } as FlowNodeData,
       };
       setNodes(nds => enrichNodes([...nds, newNode], enrichDepsRef.current));
+      return id;
     },
     [existingIds, nodes.length, setNodes, enrichDepsRef]
   );
@@ -588,11 +590,25 @@ export function useNodeFactories({
           addNode(`control_${subType}` as NodeTypeKey, pendingNodePosition);
         }
       } else if (type === "pipeline") {
-        addNode("pipeline", pendingNodePosition, {
-          availablePipelineIds,
-          pipelinePortsMap: portsMap,
-          onPipelineSelect: handlePipelineSelect,
-        });
+        const id = addNode(
+          "pipeline",
+          pendingNodePosition,
+          {
+            availablePipelineIds,
+            pipelinePortsMap: portsMap,
+            onPipelineSelect: handlePipelineSelect,
+          },
+          subType
+        );
+        if (subType) {
+          handlePipelineSelect(id, subType);
+        }
+      } else if (type === "source") {
+        addNode(
+          "source",
+          pendingNodePosition,
+          subType ? { sourceMode: subType } : undefined
+        );
       } else if (type === "output") {
         const defaultType = spoutOutputAvailable
           ? "spout"

--- a/frontend/src/hooks/useNodeDefinitions.ts
+++ b/frontend/src/hooks/useNodeDefinitions.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { fetchNodeDefinitions } from "@/lib/api";
+import type { NodeDefinitionDto } from "@/lib/api";
+import { usePipelinesContext } from "@/contexts/PipelinesContext";
+
+export interface UseNodeDefinitionsReturn {
+  nodes: NodeDefinitionDto[];
+  customNodes: NodeDefinitionDto[];
+  refresh: () => Promise<void>;
+}
+
+export function useNodeDefinitions(): UseNodeDefinitionsReturn {
+  const [nodes, setNodes] = useState<NodeDefinitionDto[]>([]);
+  const { pipelinesVersion } = usePipelinesContext();
+  const lastPayloadRef = useRef<string>("");
+
+  const refresh = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const data = await fetchNodeDefinitions({ signal });
+      if (signal?.aborted) return;
+      const next = data.nodes ?? [];
+      // Skip the state update when the payload is identical so downstream
+      // useMemos that depend on `nodes` identity don't churn on every refresh.
+      const serialized = JSON.stringify(next);
+      if (serialized === lastPayloadRef.current) return;
+      lastPayloadRef.current = serialized;
+      setNodes(next);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      console.warn("Failed to fetch node definitions:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    refresh(controller.signal);
+    return () => controller.abort();
+  }, [refresh, pipelinesVersion]);
+
+  const customNodes = useMemo(
+    () =>
+      nodes.filter(
+        n => n.pipeline_meta == null && n.node_type_id !== "scheduler"
+      ),
+    [nodes]
+  );
+
+  const refreshPublic = useCallback(() => refresh(), [refresh]);
+
+  return { nodes, customNodes, refresh: refreshPublic };
+}

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -22,13 +22,34 @@ const START_Y = 50;
 
 export type PortType = "stream" | "string" | "number" | "boolean";
 
+export interface BrowserSourceMode {
+  id: string;
+  label: string;
+  description: string;
+  keywords: string[];
+}
+
 /** Source modes provided by the browser (WebRTC). Everything else is a
  *  server-side :class:`InputSource` (built-in spout/ndi/syphon/video_file
- *  or any plugin-registered id). */
-export const BROWSER_SOURCE_MODES = ["video", "camera"] as const;
+ *  or any plugin-registered id). The label/description/keywords are used by
+ *  the canvas context menu and Add Node modal. */
+export const BROWSER_SOURCE_MODES: readonly BrowserSourceMode[] = [
+  {
+    id: "video",
+    label: "File",
+    description: "Upload or cycle sample video files",
+    keywords: ["file", "video", "upload"],
+  },
+  {
+    id: "camera",
+    label: "Camera",
+    description: "Use the browser's webcam",
+    keywords: ["webcam", "camera", "capture"],
+  },
+];
 
 const BROWSER_SOURCE_MODE_SET: ReadonlySet<string> = new Set(
-  BROWSER_SOURCE_MODES
+  BROWSER_SOURCE_MODES.map(m => m.id)
 );
 
 /** True when *mode* is browser-driven (file upload or webcam) and gets a

--- a/frontend/src/lib/sourceModes.ts
+++ b/frontend/src/lib/sourceModes.ts
@@ -1,28 +1,11 @@
 import type { InputSourceType } from "./api";
 
-export interface BrowserSourceMode {
-  id: string;
-  label: string;
-  description: string;
-  keywords: string[];
-}
-
-// Browser-driven (WebRTC) source modes. Not registered by the backend, so
-// they're prepended to the dynamic list from /api/v1/input-sources.
-export const BROWSER_SOURCE_MODES: BrowserSourceMode[] = [
-  {
-    id: "video",
-    label: "File",
-    description: "Upload or cycle sample video files",
-    keywords: ["file", "video", "upload"],
-  },
-  {
-    id: "camera",
-    label: "Camera",
-    description: "Use the browser's webcam",
-    keywords: ["webcam", "camera", "capture"],
-  },
-];
+// Re-exported so source-related UI code can import everything from one place.
+// The canonical definition lives in graphUtils.ts because `isBrowserSourceMode`
+// (and its callers in StreamPage / SourceNode / useVideoSource) need the id
+// list as shared logic, not just menu metadata.
+export type { BrowserSourceMode } from "./graphUtils";
+export { BROWSER_SOURCE_MODES } from "./graphUtils";
 
 // Headless-only alias for the browser "video" mode — never surface in UI.
 export const HIDDEN_BACKEND_SOURCES = new Set(["video_file"]);

--- a/frontend/src/lib/sourceModes.ts
+++ b/frontend/src/lib/sourceModes.ts
@@ -1,0 +1,36 @@
+import type { InputSourceType } from "./api";
+
+export interface BrowserSourceMode {
+  id: string;
+  label: string;
+  description: string;
+  keywords: string[];
+}
+
+// Browser-driven (WebRTC) source modes. Not registered by the backend, so
+// they're prepended to the dynamic list from /api/v1/input-sources.
+export const BROWSER_SOURCE_MODES: BrowserSourceMode[] = [
+  {
+    id: "video",
+    label: "File",
+    description: "Upload or cycle sample video files",
+    keywords: ["file", "video", "upload"],
+  },
+  {
+    id: "camera",
+    label: "Camera",
+    description: "Use the browser's webcam",
+    keywords: ["webcam", "camera", "capture"],
+  },
+];
+
+// Headless-only alias for the browser "video" mode — never surface in UI.
+export const HIDDEN_BACKEND_SOURCES = new Set(["video_file"]);
+
+export function getVisibleBackendSources(
+  inputSources: InputSourceType[]
+): InputSourceType[] {
+  return inputSources.filter(
+    s => s.available && !HIDDEN_BACKEND_SOURCES.has(s.source_id)
+  );
+}


### PR DESCRIPTION
## Summary

- Pipeline, Source, and a new Plugins entry now expand into searchable submenus in the canvas context menu, so users can pick e.g. "scribble" or "Syphon" directly instead of adding a generic Pipeline/Source node and configuring it afterwards.
- The Add Node modal (Tab) gains "Pipelines" and "Sources" category tabs with one tile per pipeline / source. The plugin-registered nodes already lived under "Plugins".
- Search matches name, description, and id — typing "scribble" or "spout" jumps straight to the right item.
- Sources are filtered to those `available` on the current machine (matches the in-node dropdown behavior, so picking Spout on macOS no longer creates a node whose dropdown can't display "Spout").

## Test plan

- [ ] Right-click empty canvas: Source / Pipeline / Plugins each show ">" with their respective submenus
- [ ] Type "scribble" in the menu search: scribble pipeline appears with "Pipeline" parent tag; click adds a scribble pipeline node fully wired up
- [ ] Click Source > Syphon (macOS) or Source > NDI (Linux/Windows): creates a source node with that mode pre-selected and the right per-mode UI rendered
- [ ] Click Plugins > a custom node (e.g. Prompt Enhancer): node is created with its inputs/outputs/params populated
- [ ] Press Tab to open the Add Node modal: "Pipelines" and "Sources" tabs are present; tiles for each pipeline/source are clickable; search across all categories works
- [ ] Sources marked unavailable on the current OS (Spout on macOS, Syphon on Linux/Windows) do NOT appear in either menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
