### PR TITLE
Improved source routing support

### DIFF
--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -222,6 +222,14 @@ def build_graph(
         if per_node:
             source_queues_by_node[node_id] = per_node
 
+    def _attach_source_output_queue(source_node_id: str, q: queue.Queue) -> None:
+        """Attach an output queue directly to a source node fan-out."""
+        per_node = source_queues_by_node.setdefault(source_node_id, [])
+        if q not in per_node:
+            per_node.append(q)
+        if q not in source_queues:
+            source_queues.append(q)
+
     # 4) Identify sinks: find the pipeline nodes that feed into sink nodes.
     # Each sink gets a **dedicated** output queue appended to its feeder
     # processor's output_queues list. The processor's fan-out loop
@@ -235,21 +243,21 @@ def build_graph(
         for e in graph.edges_to(sink_id):
             if e.kind == "stream":
                 feeder_proc = node_processors.get(e.from_node)
+                sink_node = node_by_id[sink_id]
+                sink_mode = sink_node.sink_mode
+                # WebRTC preview reads sink_queues_by_node; NDI/Spout/Syphon threads
+                # must use a separate queue or they steal frames from get_from_sink().
+                sink_q = queue.Queue(maxsize=DEFAULT_INPUT_QUEUE_MAXSIZE)
+                sink_queues_by_node[sink_id] = sink_q
+                queues_to_add = [sink_q]
+                if sink_mode in ("ndi", "spout", "syphon"):
+                    sink_q_hw = queue.Queue(maxsize=DEFAULT_INPUT_QUEUE_MAXSIZE)
+                    sink_hardware_queues_by_node[sink_id] = sink_q_hw
+                    queues_to_add.append(sink_q_hw)
+
+                port = e.from_port
                 if feeder_proc is not None:
                     sink_processors_by_node[sink_id] = feeder_proc
-                    sink_node = node_by_id[sink_id]
-                    sink_mode = sink_node.sink_mode
-                    # WebRTC preview reads sink_queues_by_node; NDI/Spout/Syphon threads
-                    # must use a separate queue or they steal frames from get_from_sink().
-                    sink_q = queue.Queue(maxsize=DEFAULT_INPUT_QUEUE_MAXSIZE)
-                    sink_queues_by_node[sink_id] = sink_q
-                    queues_to_add = [sink_q]
-                    if sink_mode in ("ndi", "spout", "syphon"):
-                        sink_q_hw = queue.Queue(maxsize=DEFAULT_INPUT_QUEUE_MAXSIZE)
-                        sink_hardware_queues_by_node[sink_id] = sink_q_hw
-                        queues_to_add.append(sink_q_hw)
-
-                    port = e.from_port
                     feeder_proc.output_queues.setdefault(port, []).extend(queues_to_add)
                     # Register external refs so _resize_output_queue keeps
                     # SinkManager's cached queue references in sync.
@@ -260,15 +268,26 @@ def build_graph(
                         feeder_proc.external_queue_refs.append(
                             (sink_hardware_queues_by_node, sink_id)
                         )
-                    logger.info(
-                        "Sink %s: dedicated queue(s) on %s port '%s' "
-                        "(webrtc + hardware=%s, total on port: %d)",
-                        sink_id,
-                        e.from_node,
-                        port,
-                        sink_id in sink_hardware_queues_by_node,
-                        len(feeder_proc.output_queues[port]),
-                    )
+                    total_queues = len(feeder_proc.output_queues[port])
+                else:
+                    source_node = node_by_id.get(e.from_node)
+                    if source_node is None or source_node.type != "source":
+                        sink_queues_by_node.pop(sink_id, None)
+                        sink_hardware_queues_by_node.pop(sink_id, None)
+                        continue
+                    for out_q in queues_to_add:
+                        _attach_source_output_queue(source_node.id, out_q)
+                    total_queues = len(source_queues_by_node[source_node.id])
+
+                logger.info(
+                    "Sink %s: dedicated queue(s) on %s port '%s' "
+                    "(webrtc + hardware=%s, total on port: %d)",
+                    sink_id,
+                    e.from_node,
+                    port,
+                    sink_id in sink_hardware_queues_by_node,
+                    total_queues,
+                )
                 break
 
     # Backward compat: first sink determines the primary sink_processor
@@ -312,6 +331,7 @@ def build_graph(
                 continue
             feeder_proc = node_processors.get(e.from_node)
             port = e.from_port
+            source_fallback_id: str | None = None
             if feeder_proc is None:
                 src_node = node_by_id.get(e.from_node)
                 if src_node is not None and src_node.type == "sink":
@@ -319,6 +339,13 @@ def build_graph(
                         if se.kind == "stream":
                             feeder_proc = node_processors.get(se.from_node)
                             port = se.from_port
+                            if feeder_proc is None:
+                                upstream_node = node_by_id.get(se.from_node)
+                                if (
+                                    upstream_node is not None
+                                    and upstream_node.type == "source"
+                                ):
+                                    source_fallback_id = upstream_node.id
                             break
             if feeder_proc is not None:
                 rec_q = queue.Queue(maxsize=DEFAULT_INPUT_QUEUE_MAXSIZE)
@@ -331,6 +358,23 @@ def build_graph(
                     feeder_proc.node_id,
                     port,
                     len(feeder_proc.output_queues[port]),
+                )
+                break
+            source_node = (
+                node_by_id.get(source_fallback_id)
+                if source_fallback_id is not None
+                else node_by_id.get(e.from_node)
+            )
+            if source_node is not None and source_node.type == "source":
+                rec_q = queue.Queue(maxsize=DEFAULT_INPUT_QUEUE_MAXSIZE)
+                record_queues_by_node[rec_id] = rec_q
+                _attach_source_output_queue(source_node.id, rec_q)
+                logger.info(
+                    "Record %s: dedicated queue on source %s port '%s' (total queues: %d)",
+                    rec_id,
+                    source_node.id,
+                    port,
+                    len(source_queues_by_node[source_node.id]),
                 )
                 break
 

--- a/tests/test_graph_executor.py
+++ b/tests/test_graph_executor.py
@@ -1,0 +1,261 @@
+import queue
+
+from scope.server.graph_executor import build_graph
+from scope.server.graph_schema import GraphConfig
+
+
+class _StubRequirements:
+    input_size = 1
+
+
+class _StubPipelineConfig:
+    inputs = ["video"]
+    outputs = ["video"]
+
+
+class _StubPipeline:
+    def get_config_class(self):
+        return _StubPipelineConfig
+
+    def prepare(self, **kwargs):
+        return _StubRequirements()
+
+
+class _StubPipelineManager:
+    def __init__(self):
+        self._pipeline = _StubPipeline()
+
+    def get_pipeline_by_id(self, node_id: str):
+        return self._pipeline
+
+
+def test_build_graph_routes_direct_source_sink_edges():
+    graph = GraphConfig.model_validate(
+        {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "syphon"},
+                {
+                    "id": "passthrough",
+                    "type": "pipeline",
+                    "pipeline_id": "passthrough",
+                },
+                {"id": "preview", "type": "sink"},
+                {
+                    "id": "syphon_out",
+                    "type": "sink",
+                    "sink_mode": "syphon",
+                    "sink_name": "Scope",
+                },
+            ],
+            "edges": [
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "passthrough",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "preview",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "syphon_out",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+            ],
+        }
+    )
+
+    graph_run = build_graph(
+        graph=graph,
+        pipeline_manager=_StubPipelineManager(),
+        initial_parameters={},
+    )
+
+    input_queues = graph_run.source_queues_by_node["input"]
+    assert len(input_queues) == 4
+
+    preview_queue = graph_run.sink_queues_by_node["preview"]
+    syphon_preview_queue = graph_run.sink_queues_by_node["syphon_out"]
+    syphon_hardware_queue = graph_run.sink_hardware_queues_by_node["syphon_out"]
+
+    assert preview_queue in input_queues
+    assert syphon_preview_queue in input_queues
+    assert syphon_hardware_queue in input_queues
+    assert "preview" not in graph_run.sink_processors_by_node
+    assert "syphon_out" not in graph_run.sink_processors_by_node
+
+
+def test_build_graph_routes_direct_source_record_edges():
+    graph = GraphConfig.model_validate(
+        {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "syphon"},
+                {"id": "preview", "type": "sink"},
+                {"id": "record", "type": "record"},
+            ],
+            "edges": [
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "preview",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "record",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+            ],
+        }
+    )
+
+    graph_run = build_graph(
+        graph=graph,
+        pipeline_manager=_StubPipelineManager(),
+        initial_parameters={},
+    )
+
+    record_queue = graph_run.record_queues_by_node["record"]
+    input_queues = graph_run.source_queues_by_node["input"]
+
+    assert isinstance(record_queue, queue.Queue)
+    assert record_queue in input_queues
+    assert graph_run.sink_queues_by_node["preview"] in input_queues
+
+
+def test_build_graph_preserves_pipeline_to_sink_routing():
+    graph = GraphConfig.model_validate(
+        {
+            "nodes": [
+                {"id": "input", "type": "source"},
+                {"id": "pipe", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "output", "type": "sink"},
+            ],
+            "edges": [
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "pipe",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from": "pipe",
+                    "from_port": "video",
+                    "to_node": "output",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+            ],
+        }
+    )
+
+    graph_run = build_graph(
+        graph=graph,
+        pipeline_manager=_StubPipelineManager(),
+        initial_parameters={},
+    )
+
+    assert graph_run.sink_processors_by_node["output"].node_id == "pipe"
+    assert (
+        graph_run.sink_queues_by_node["output"]
+        not in graph_run.source_queues_by_node["input"]
+    )
+
+
+def test_build_graph_preserves_pipeline_to_record_routing():
+    graph = GraphConfig.model_validate(
+        {
+            "nodes": [
+                {"id": "input", "type": "source"},
+                {"id": "pipe", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "output", "type": "sink"},
+                {"id": "record", "type": "record"},
+            ],
+            "edges": [
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "pipe",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from": "pipe",
+                    "from_port": "video",
+                    "to_node": "output",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from": "pipe",
+                    "from_port": "video",
+                    "to_node": "record",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+            ],
+        }
+    )
+
+    graph_run = build_graph(
+        graph=graph,
+        pipeline_manager=_StubPipelineManager(),
+        initial_parameters={},
+    )
+
+    record_queue = graph_run.record_queues_by_node["record"]
+    assert isinstance(record_queue, queue.Queue)
+    assert record_queue not in graph_run.source_queues_by_node["input"]
+
+
+def test_build_graph_routes_source_sink_record_path():
+    graph = GraphConfig.model_validate(
+        {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "syphon"},
+                {"id": "preview", "type": "sink"},
+                {"id": "record", "type": "record"},
+            ],
+            "edges": [
+                {
+                    "from": "input",
+                    "from_port": "video",
+                    "to_node": "preview",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from": "preview",
+                    "from_port": "video",
+                    "to_node": "record",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+            ],
+        }
+    )
+
+    graph_run = build_graph(
+        graph=graph,
+        pipeline_manager=_StubPipelineManager(),
+        initial_parameters={},
+    )
+
+    record_queue = graph_run.record_queues_by_node["record"]
+    input_queues = graph_run.source_queues_by_node["input"]
+
+    assert isinstance(record_queue, queue.Queue)
+    assert record_queue in input_queues
+    assert graph_run.sink_queues_by_node["preview"] in input_queues


### PR DESCRIPTION
Update the graph executor to recognize these patterns:

* source -> sink
* source -> recording
* source -> sink -> recording

Previously recordings and sinks could not attach directly to sources even though this is an allowed behavior in the UI.

There's a deeper refactor needed here to support these bits more generically but this fixes the most immediate issues.

Example workflow:

[multi-recording.scope-workflow.json](https://github.com/user-attachments/files/27113516/multi-recording.scope-workflow.json)

<img width="652" height="341" alt="image" src="https://github.com/user-attachments/assets/c16217a1-ea86-4c5c-bc94-bc7b694509bd" />
