### PR TITLE
Keep record-node queues dedicated to recorder

### DIFF
--- a/src/scope/server/tracks.py
+++ b/src/scope/server/tracks.py
@@ -209,17 +209,6 @@ def SinkOutputTrack(
     )
 
 
-def RecordOutputTrack(
-    frame_processor: FrameProcessor,
-    record_node_id: str,
-) -> NodeOutputTrack:
-    """Create a NodeOutputTrack that reads from a record node's output queue."""
-    return NodeOutputTrack(
-        frame_processor=frame_processor,
-        frame_getter=lambda fp: fp.sink_manager.recording.get(record_node_id),
-    )
-
-
 class SourceInputHandler:
     """Handles input from a WebRTC track and routes frames to a specific source node.
 

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -33,7 +33,6 @@ from .pipeline_manager import PipelineManager
 from .recording import RecordingManager
 from .schema import WebRTCOfferRequest
 from .tracks import (
-    RecordOutputTrack,
     SinkOutputTrack,
     SourceInputHandler,
     VideoProcessingTrack,
@@ -58,6 +57,28 @@ vpx.MAX_FRAME_RATE = 8
 vpx.DEFAULT_BITRATE = 7000000
 vpx.MIN_BITRATE = 5000000
 vpx.MAX_BITRATE = 10000000
+
+
+def _build_extra_output_tracks(
+    frame_processor: FrameProcessor,
+    sink_node_ids: list[str],
+    record_node_ids: list[str],
+) -> list["NodeOutputTrack"]:
+    """Build live WebRTC output tracks for graph outputs.
+
+    Record-node queues are single-consumer recording queues. Attaching them as
+    live WebRTC tracks races with RecordingCoordinator and can drain/corrupt
+    recordings, so only sink nodes get live output tracks here.
+    """
+    if record_node_ids:
+        logger.debug(
+            "Skipping live WebRTC tracks for record nodes: %s",
+            record_node_ids,
+        )
+    return [
+        SinkOutputTrack(frame_processor=frame_processor, sink_node_id=sink_id)
+        for sink_id in sink_node_ids[1:]
+    ]
 
 
 def _parse_graph_node_ids(
@@ -454,8 +475,8 @@ class WebRTCManager:
                 # so they can be placed on the correct recvonly transceivers.
 
                 # Eagerly initialize frame processor when graph has sources,
-                # sinks, or record nodes, so SourceInputHandler /
-                # SinkOutputTrack / RecordOutputTrack can reference it immediately.
+                # sinks, or record nodes, so SourceInputHandler / SinkOutputTrack
+                # and recording endpoints can reference it immediately.
                 if (
                     webrtc_source_node_ids
                     or has_non_webrtc_sources
@@ -682,23 +703,17 @@ class WebRTCManager:
                         )
                         break
 
-            # Attach extra sink / record output tracks to the recvonly
-            # transceivers that the browser (or cloud client) created.
+            # Attach extra sink output tracks to the recvonly transceivers that
+            # the browser (or cloud client) created. Record nodes are not live
+            # WebRTC outputs because their queues are consumed by recordings.
             # Must happen AFTER setRemoteDescription so the transceivers exist.
             extra_output_tracks: list[NodeOutputTrack] = []
             if video_track is not None and relay is not None:
-                for sink_id in sink_node_ids[1:]:
-                    extra_output_tracks.append(
-                        SinkOutputTrack(
-                            frame_processor=frame_processor, sink_node_id=sink_id
-                        )
-                    )
-                for rec_id in record_node_ids:
-                    extra_output_tracks.append(
-                        RecordOutputTrack(
-                            frame_processor=frame_processor, record_node_id=rec_id
-                        )
-                    )
+                extra_output_tracks = _build_extra_output_tracks(
+                    frame_processor=frame_processor,
+                    sink_node_ids=sink_node_ids,
+                    record_node_ids=record_node_ids,
+                )
 
             if extra_output_tracks:
                 recv_only_video = [

--- a/tests/test_graph_executor.py
+++ b/tests/test_graph_executor.py
@@ -1,5 +1,6 @@
 import queue
 
+from scope.core.nodes import NodeDefinition, NodePort
 from scope.server.graph_executor import build_graph
 from scope.server.graph_schema import GraphConfig
 
@@ -14,6 +15,14 @@ class _StubPipelineConfig:
 
 
 class _StubPipeline:
+    def get_definition(self):
+        return NodeDefinition(
+            node_type_id="passthrough",
+            display_name="Passthrough",
+            inputs=[NodePort(name="video", port_type="video")],
+            outputs=[NodePort(name="video", port_type="video")],
+        )
+
     def get_config_class(self):
         return _StubPipelineConfig
 

--- a/tests/test_recording_coordinator.py
+++ b/tests/test_recording_coordinator.py
@@ -2,6 +2,7 @@ import queue
 
 import pytest
 
+from scope.server import webrtc
 from scope.server.recording_coordinator import RecordingCoordinator
 
 
@@ -42,3 +43,23 @@ async def test_start_recording_drops_stale_record_queue_frames(monkeypatch):
     assert captured["queue_size_on_init"] == 0
     assert captured["fps"] == 29.97
     assert captured["manager_started"] is True
+
+
+def test_record_nodes_are_not_attached_as_live_webrtc_outputs(monkeypatch):
+    constructed_sinks = []
+
+    def fake_sink_output_track(*, frame_processor, sink_node_id):
+        constructed_sinks.append((frame_processor, sink_node_id))
+        return {"kind": "sink", "id": sink_node_id}
+
+    monkeypatch.setattr(webrtc, "SinkOutputTrack", fake_sink_output_track)
+
+    frame_processor = object()
+    tracks = webrtc._build_extra_output_tracks(
+        frame_processor=frame_processor,
+        sink_node_ids=["preview", "secondary"],
+        record_node_ids=["record"],
+    )
+
+    assert tracks == [{"kind": "sink", "id": "secondary"}]
+    assert constructed_sinks == [(frame_processor, "secondary")]


### PR DESCRIPTION
Prevent WebRTC from 'stealing' frames from the recorder. This led to some recordings being low-FPS or empty.

What the recordings looked like
-------------------------------
Sequence with both consumers attached (current trunk before this fix):
    source ──▶ rec_q ──┬──▶ RecordOutputTrack (WebRTC, always-on)
                       │
                       └──▶ QueueVideoTrack  (RecordingManager,
                                              start/stop driven)
    t0  source pushes frames into rec_q
    t1  RecordOutputTrack.recv() drains rec_q  (every ~1/30s)
    t2  user clicks Start: RecordingCoordinator drains stale frames,
        creates QueueVideoTrack on rec_q
    t3  source pushes 1 frame, RecordOutputTrack drains it
    t4  source pushes 1 frame, RecordOutputTrack drains it
    t5  ... QueueVideoTrack only intermittently wins ...
    t6  user clicks Stop: MediaRecorder finalizes with too few
        encoded frames; some segments end up 0/invalid MP4
    t7  user clicks Start again: rec_q re-drained, but the same race
        starts over for the next segment

After this change there is only one consumer per record queue:
    source ──▶ rec_q ──▶ QueueVideoTrack (RecordingManager only)
Fix
---
- Remove RecordOutputTrack attachment from WebRTCManager.handle_offer.
- Factor extra-output construction into `_build_extra_output_tracks`, which only emits SinkOutputTrack instances for non-primary sink nodes. Record nodes are intentionally skipped and logged.
- Record nodes remain available through the existing recording HTTP endpoints (`/api/v1/recordings/{session_id}/{start,stop}` and the download route); only the live WebRTC track was wrong.

Tests
-----
- New `test_record_nodes_are_not_attached_as_live_webrtc_outputs` in `tests/test_recording_coordinator.py` (placed there because the invariant being protected is "record queues belong to recording"; WebRTC is just where the violation lived).
- Existing `test_start_recording_drops_stale_record_queue_frames` still covers the stale-frame drain on Start. source -> sink -> record routing remain green.