### PR TITLE
Expose any node param via OSC + per-param opt-in + defaults in docs

### DIFF
--- a/docs/osc.md
+++ b/docs/osc.md
@@ -1,0 +1,279 @@
+# Using OSC
+
+Scope exposes its parameters over [OSC (Open Sound Control)](https://opensoundcontrol.stanford.edu/) so external tools — TouchDesigner, Resolume, MaxMSP, hardware controllers, custom Python scripts — can drive the running graph in real time. The OSC server is always on; it shares a UDP socket with the HTTP API on the same port (default `8000`).
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [What's Reachable via OSC](#whats-reachable-via-osc)
+- [Configure OSC per Node](#configure-osc-per-node)
+- [Address Format](#address-format)
+- [Discovering Paths](#discovering-paths)
+- [Defaults in the Description](#defaults-in-the-description)
+- [Validation](#validation)
+- [Routing Internals](#routing-internals)
+- [TouchDesigner Setup](#touchdesigner-setup)
+- [Python Examples](#python-examples)
+- [REST API](#rest-api)
+- [Limitations](#limitations)
+
+---
+
+## Quick Start
+
+1. Start Scope (`uv run daydream-scope`). The OSC server starts automatically and listens on UDP `8000`.
+2. Send a message:
+
+   ```python
+   from pythonosc.udp_client import SimpleUDPClient
+   client = SimpleUDPClient("127.0.0.1", 8000)
+   client.send_message("/scope/prompt", "a beautiful sunset over the ocean")
+   client.send_message("/scope/noise_scale", 0.5)
+   ```
+
+3. Open the live OSC reference at `http://localhost:8000/api/v1/osc/docs` to see every address, type, range, default, and a copy-paste example.
+
+> [!NOTE]
+> Set the OSC port via the `SCOPE_PORT` environment variable. UDP and HTTP coexist on the same port, so changing one changes both.
+
+---
+
+## What's Reachable via OSC
+
+Scope exposes three layers of OSC paths:
+
+| Layer | Source | Default address | Notes |
+|---|---|---|---|
+| **Runtime globals** | Built-in (`prompt`, `noise_scale`, `paused`, `manage_cache`, `reset_cache`, `transition_steps`, `interpolation_method`, …) | `/scope/<param>` | Always on. Backwards-compatible with pre-existing TouchDesigner setups. |
+| **Pipeline runtime params** | Each loaded pipeline's `is_load_param=False` fields | `/scope/<param>` (default) or `/scope/<node>/<param>` (per-instance, opt-in) | One bare-address entry per param while no per-node override is set; switches to namespaced when you customize the node. |
+| **Graph nodes** (Source / Sink / Slider / XYPad / Bool / Trigger / Tempo / Output / Note / Primitive) | The graph editor's per-node `oscConfig` | `/scope/<node>/<param>` | Off by default; opted in via right-click → **Configure OSC…** |
+
+The Source / Sink / UI-node layer is the new piece — previously only pipeline params could be reached.
+
+---
+
+## Configure OSC per Node
+
+The graph editor's right-click menu has a **"Configure OSC…"** item:
+
+1. Right-click any node → **Configure OSC…**
+2. The modal lists every OSC-eligible param for that node type. Each row has:
+
+   | Column | Behavior |
+   |---|---|
+   | **Expose** | Tick to publish this param's address. Off by default (except for pipeline runtime params, which are auto-exposed at the legacy flat address until you customize anything). |
+   | **Address** | Auto-fills as `/scope/<node-slug>/<param>`. Editable — paste any address you want (e.g. `/scope/tempo`, `/scope/main/prompt`). |
+   | **Default** | Advisory metadata published in the OSC docs so external clients can mirror Scope's starting state. Defaults to the node's current value. |
+
+3. **Save**. The graph re-publishes its OSC inventory to the backend within ~300ms; the new address becomes reachable immediately.
+
+`oscConfig` is stored on the node and round-trips with the rest of the graph (saving, exporting, re-importing all preserve it).
+
+> [!NOTE]
+> A param set's default is **advisory** — it appears in the description so OSC clients can initialize their UI to match Scope, but Scope does not auto-emit it on session start. Auto-apply is a deliberate follow-up.
+
+### What to expose, by node type
+
+| Node | Exposable params |
+|---|---|
+| Source | `sourceMode` (enum), `sourceFlipVertical` (bool) |
+| Output | `outputSinkEnabled` (bool), `outputSinkType` (enum) |
+| Slider | `value` (float) |
+| XY Pad | `padX`, `padY` (float) |
+| Bool | `value` (bool) |
+| Trigger | `value` (bool — send `true` to fire) |
+| Tempo | `tempoBpm` (float, 20–999), `tempoEnabled` (bool) |
+| Primitive | `value` (string) |
+| Note | `noteText` (string) |
+| Pipeline | every `is_load_param=False` field from the pipeline's schema |
+
+Composite-shape params (knobs[], MIDI channels[], tuple values[]) are intentionally not exposed in the MVP — they need a richer addressing scheme.
+
+---
+
+## Address Format
+
+```
+/scope/<node-slug>/<param>
+```
+
+`<node-slug>` is derived from the node's display title (the user-editable header), slugified to kebab-case. Falls back to the React Flow node id when the title has no slug-able characters.
+
+Examples:
+
+| Node title | Field | Default address |
+|---|---|---|
+| `Tempo` (Slider) | `value` | `/scope/tempo/value` |
+| `Source` | `sourceMode` | `/scope/source/sourceMode` |
+| `Main` (Pipeline) | `prompt` | `/scope/main/prompt` |
+| `Secondary` (Pipeline) | `prompt` | `/scope/secondary/prompt` |
+
+> [!IMPORTANT]
+> If two nodes resolve to the same slug (two sliders both titled "Tempo"), the most recently re-saved one wins. Rename one or override the address explicitly to avoid collisions. A UI warning is planned.
+
+### Backwards compatibility
+
+Pipeline runtime params keep their **flat** address `/scope/<param>` until you open Configure OSC on the pipeline node and save any change. Existing rigs sending `/scope/prompt`, `/scope/noise_scale`, `/scope/paused`, etc. continue to work without graph-side configuration.
+
+The moment a user opts a pipeline param in (or out) explicitly, the legacy flat alias is replaced by the user's namespaced address for that node. This is what enables driving two pipeline instances independently when they share param names.
+
+---
+
+## Discovering Paths
+
+### In-app
+
+**Settings → OSC** has a "Currently exposed paths" panel. Each row is click-to-copy.
+
+### HTML reference
+
+Open [`http://localhost:8000/api/v1/osc/docs`](http://localhost:8000/api/v1/osc/docs) for an auto-generated reference page. Every path includes its address, type, constraints (min / max / enum), default, and a one-click Python snippet you can paste into TouchDesigner's text DAT.
+
+### Programmatic
+
+```bash
+curl -s http://localhost:8000/api/v1/osc/paths | jq
+```
+
+Response shape:
+
+```json
+{
+  "active": {
+    "Runtime": [
+      { "key": "prompt", "type": "string", "osc_address": "/scope/prompt", … }
+    ],
+    "streamdiffusionv2": [
+      { "key": "noise_scale", "type": "float", "min": 0.0, "max": 1.0, "default": 0.7, "osc_address": "/scope/noise_scale", … }
+    ],
+    "Tempo": [
+      { "osc_address": "/scope/tempo/value", "type": "float", "default": 1.0, "node_id": "slider-1", "param": "value", … }
+    ]
+  },
+  "available": { … },
+  "active_pipeline_ids": ["streamdiffusionv2"]
+}
+```
+
+`active` groups everything currently reachable. `available` lists pipelines that exist in the registry but aren't loaded yet — their addresses become reachable as soon as the pipeline is loaded.
+
+---
+
+## Defaults in the Description
+
+Every path entry that has a default value carries it in two places:
+
+- **`/api/v1/osc/paths`** — `default` field on the entry.
+- **`/api/v1/osc/docs`** — Default column in the rendered table.
+
+Defaults come from (in order):
+
+1. The user-set value in **Configure OSC…** (per node).
+2. The node's current `data.<param>` value (e.g. the slider's current position).
+3. The pipeline schema's `default` (for pipeline runtime params).
+
+This lets external clients initialize their UI to match Scope's starting state without an extra round-trip.
+
+---
+
+## Validation
+
+The OSC server validates every incoming message against the path's type / min / max / enum constraints before broadcasting. Invalid messages are logged but never reach the pipeline. Toggle **Settings → OSC → Log Messages** to see all messages (valid + invalid) in the Scope logs.
+
+| Type | Accepts | Rejection example |
+|---|---|---|
+| `float` / `number` | `int` or `float` | string → "type mismatch" |
+| `integer` | `int` | float → "type mismatch" |
+| `bool` / `boolean` | `bool` / `int` / `float` (truthy = on) | string → "type mismatch" |
+| `string` | `str` | int → "type mismatch" |
+| `integer_list` | non-empty list of ints | list with non-ints → "type mismatch: item N of type …" |
+
+Out-of-range numeric values are rejected with `"value X below minimum Y"` / `"above maximum Y"`. Enum-violating strings get `"value 'foo' not in allowed values […]"`.
+
+---
+
+## Routing Internals
+
+The OSC server splits incoming messages into three routing buckets based on the matched path entry:
+
+1. **Pipeline node** (entry has both `node_id` and `pipeline_id`) — broadcasts `{node_id, <param>: value}` to all WebRTC sessions; `frame_processor.update_parameters` routes it to the matching pipeline processor.
+2. **UI-only node** (entry has `node_id` but no `pipeline_id`) — emits an SSE `osc_command` event the frontend listens to; the React Flow state for the matching node updates locally. No backend processor is involved (Slider / Bool / etc. are frontend-only state).
+3. **Registry-derived flat path** (entry has no `node_id`) — broadcasts `{<key>: value}` to all WebRTC sessions, matching legacy behavior.
+
+In all three cases the SSE stream is also fanned out so the frontend can mirror the param change in the UI.
+
+---
+
+## TouchDesigner Setup
+
+1. Add an **OSC Out CHOP** (or **OSC Out DAT** for strings).
+2. Set **Network Address** to `127.0.0.1` (or the IP of the machine running Scope).
+3. Set **Network Port** to `8000`.
+4. Add a channel with the address you want to drive — `/scope/prompt`, `/scope/noise_scale`, `/scope/tempo/value`, etc.
+5. Animate or bind the channel value to your TD parameters.
+
+> [!TIP]
+> Click the address row in `http://localhost:8000/api/v1/osc/docs` to copy a working Python snippet. Paste it into a TD **Text DAT** for offline testing before wiring up CHOPs.
+
+---
+
+## Python Examples
+
+```python
+from pythonosc.udp_client import SimpleUDPClient
+
+client = SimpleUDPClient("127.0.0.1", 8000)
+
+# Drive the active pipeline's prompt
+client.send_message("/scope/prompt", "a glowing reef at night")
+
+# Animate noise scale
+import time
+for v in (0.0, 0.25, 0.5, 0.75, 1.0):
+    client.send_message("/scope/noise_scale", v)
+    time.sleep(0.5)
+
+# Toggle a per-node Bool you've exposed at /scope/strobe/value
+client.send_message("/scope/strobe/value", True)
+
+# Trigger a node — the same as clicking it once in the UI
+client.send_message("/scope/cue/value", True)
+```
+
+To listen for parameter changes that originate elsewhere (UI clicks, MIDI, other OSC senders), connect to the SSE stream:
+
+```python
+import json, requests
+
+with requests.get("http://localhost:8000/api/v1/osc/stream", stream=True) as r:
+    for line in r.iter_lines():
+        if not line or not line.startswith(b"data:"):
+            continue
+        event = json.loads(line[len(b"data: "):])
+        # event = {"type": "osc_command", "key": "tempo/value", "value": 0.85,
+        #          "node_id": "slider-1", "param": "value"}
+        print(event)
+```
+
+---
+
+## REST API
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/api/v1/osc/status` | Listening state, port, host, log-verbosity flag |
+| `PUT` | `/api/v1/osc/settings` | Toggle `log_all_messages` |
+| `GET` | `/api/v1/osc/paths` | Active + available paths, JSON |
+| `GET` | `/api/v1/osc/docs` | Self-contained HTML reference page |
+| `GET` | `/api/v1/osc/stream` | Server-Sent Events stream of every received OSC command |
+| `POST` | `/api/v1/osc/inventory` | (Internal) Replace the graph-supplied path inventory; called by the frontend whenever `oscConfig` changes |
+
+---
+
+## Limitations
+
+- **Slug collisions** are not yet warned in the UI. Two nodes that share a derived slug share the address; the most recently registered wins.
+- **Composite params** (knobs[], midiChannels[], tupleValues[]) are skipped for now.
+- **Auto-apply of defaults at session start** is intentionally not implemented; the per-param default is description-only metadata.
+- **HDR pipeline params** that don't fit the float/int/bool/string/integer-list type system aren't reachable via OSC.
+- **OSC port** is shared with the HTTP server. To run multiple Scope instances on one machine, give each a different `SCOPE_PORT`.

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -73,6 +73,7 @@ import {
 import { createDaydreamImportSession } from "../../lib/daydreamExport";
 import { openExternalUrl } from "../../lib/openExternal";
 import { buildPaneMenuItems, buildNodeMenuItems } from "./contextMenuItems";
+import { OscConfigDialog } from "./OscConfigDialog";
 import type { FlowNodeData } from "../../lib/graphUtils";
 import {
   AlertDialog,
@@ -87,6 +88,7 @@ import {
 
 import { useRightClickSelect } from "./hooks/ui/useRightClickSelect";
 import { useGraphState } from "./hooks/graph/useGraphState";
+import { useOscInventory } from "./hooks/graph/useOscInventory";
 import { useConnectionLogic } from "./hooks/connection/useConnectionLogic";
 import { useNodeFactories } from "./hooks/node/useNodeFactories";
 import { useValueForwarding } from "./hooks/value/useValueForwarding";
@@ -408,6 +410,8 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
     const [showExportDialog, setShowExportDialog] = useState(false);
     const [showWorkflowExport, setShowWorkflowExport] = useState(false);
     const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
+    // Per-node Configure OSC modal: stores the id of the node being configured.
+    const [oscConfigNodeId, setOscConfigNodeId] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isDaydreamAuthenticated, setIsDaydreamAuthenticated] = useState(
       checkIsAuthenticated()
@@ -919,6 +923,9 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
 
     useParentValueBridge(navStackRef, navDepth, setNodes);
     useSubgraphEval(nodes, edges, setNodes, visible);
+    // Push the user-curated OSC inventory to the backend whenever the
+    // graph or any node's oscConfig overlay changes.
+    useOscInventory(nodes);
 
     resolveRootGraphRef.current = getRootGraph;
     resetNavigationRef.current = resetStack;
@@ -1319,6 +1326,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
                         handleEnterSubgraph,
                         unpackSubgraph,
                         createSubgraphFromSelection,
+                        openOscConfig: id => setOscConfigNodeId(id),
                       })
                 }
               />
@@ -1481,6 +1489,29 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
           <KeyboardShortcutsDialog
             open={showShortcutsDialog}
             onOpenChange={setShowShortcutsDialog}
+          />
+
+          <OscConfigDialog
+            open={oscConfigNodeId !== null}
+            onOpenChange={open => {
+              if (!open) setOscConfigNodeId(null);
+            }}
+            node={
+              oscConfigNodeId
+                ? (nodes.find(n => n.id === oscConfigNodeId) ?? null)
+                : null
+            }
+            onSave={oscConfig => {
+              if (!oscConfigNodeId) return;
+              const targetId = oscConfigNodeId;
+              setNodes(nds =>
+                nds.map(n =>
+                  n.id === targetId
+                    ? { ...n, data: { ...n.data, oscConfig } }
+                    : n
+                )
+              );
+            }}
           />
         </div>
       </div>

--- a/frontend/src/components/graph/OscConfigDialog.tsx
+++ b/frontend/src/components/graph/OscConfigDialog.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import type { Node } from "@xyflow/react";
+import type { FlowNodeData, OscParamConfig } from "../../lib/graphUtils";
+import {
+  getNodeOscParams,
+  readNodeParamValue,
+  slugifyForOsc,
+  type OscParamDescriptor,
+} from "../../lib/oscNodeParams";
+import { usePipelinesContext } from "../../contexts/PipelinesContext";
+import type { PipelineSchemaProperty } from "../../lib/api";
+
+interface OscConfigDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The node being configured. */
+  node: Node<FlowNodeData> | null;
+  /** Update the node's data; called once on Save with the new oscConfig map. */
+  onSave: (oscConfig: Record<string, OscParamConfig>) => void;
+}
+
+/**
+ * Per-node Configure OSC modal.
+ *
+ * Lists every OSC-eligible param for the node (from the static
+ * `oscNodeParams` descriptors for non-pipeline nodes, or from the live
+ * pipeline schema for pipeline nodes). Each row has:
+ *   - an Expose toggle
+ *   - an editable OSC address (placeholder = computed default)
+ *   - an editable default value (placeholder = current node value)
+ *
+ * No backend roundtrip until Save — local edits are staged in component
+ * state. On save we hand the full `oscConfig` map back; the parent
+ * commits to `node.data` via the usual `updateData()`.
+ */
+export function OscConfigDialog({
+  open,
+  onOpenChange,
+  node,
+  onSave,
+}: OscConfigDialogProps) {
+  const { pipelines } = usePipelinesContext();
+
+  // Resolve descriptors for the node. Pipeline nodes pull from the live
+  // schema; everything else uses the static per-node-type table.
+  const descriptors: OscParamDescriptor[] = useMemo(() => {
+    if (!node) return [];
+    if (node.type === "pipeline") {
+      const pid = node.data.pipelineId;
+      if (!pid || !pipelines || !pipelines[pid]) return [];
+      const schema = pipelines[pid].configSchema;
+      if (!schema) return [];
+      const out: OscParamDescriptor[] = [];
+      for (const [key, rawProp] of Object.entries(schema.properties)) {
+        const prop = rawProp as PipelineSchemaProperty;
+        const ui = prop.ui;
+        if (ui?.is_load_param !== false) continue; // runtime params only
+        const t = String(prop.type ?? "any");
+        const oscType =
+          t === "number"
+            ? "float"
+            : t === "integer"
+              ? "integer"
+              : t === "boolean"
+                ? "bool"
+                : "string";
+        out.push({
+          name: key,
+          label: (ui as { label?: string } | undefined)?.label ?? key,
+          type: oscType,
+          min: prop.minimum as number | undefined,
+          max: prop.maximum as number | undefined,
+          enum: prop.enum as string[] | undefined,
+          description: (prop.description as string | undefined) ?? "",
+        });
+      }
+      return out;
+    }
+    return getNodeOscParams(node.type);
+  }, [node, pipelines]);
+
+  const slug = useMemo(() => {
+    if (!node) return "";
+    return slugifyForOsc(node.data.customTitle, node.id);
+  }, [node]);
+
+  // Staged config: deep-clone the node's current oscConfig so cancel is lossless.
+  const [staged, setStaged] = useState<Record<string, OscParamConfig>>({});
+  useEffect(() => {
+    if (!open || !node) return;
+    setStaged({ ...(node.data.oscConfig ?? {}) });
+  }, [open, node]);
+
+  if (!node) return null;
+
+  const computedAddress = (paramName: string) => `/scope/${slug}/${paramName}`;
+
+  const updateRow = (paramName: string, patch: Partial<OscParamConfig>) => {
+    setStaged(prev => {
+      const existing = prev[paramName] ?? { exposed: false };
+      return { ...prev, [paramName]: { ...existing, ...patch } };
+    });
+  };
+
+  const handleSave = () => {
+    // Drop rows where exposed is false AND no override fields, to keep the
+    // saved map small.
+    const cleaned: Record<string, OscParamConfig> = {};
+    for (const [k, v] of Object.entries(staged)) {
+      if (v.exposed || v.address || v.default !== undefined) {
+        cleaned[k] = v;
+      }
+    }
+    onSave(cleaned);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[640px] max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            Configure OSC — {node.data.customTitle || node.data.label || "Node"}
+          </DialogTitle>
+          <DialogDescription>
+            Pick which params external OSC clients (TouchDesigner, etc.) can
+            reach. Defaults are advisory metadata published in the OSC docs.
+          </DialogDescription>
+        </DialogHeader>
+
+        {descriptors.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-6">
+            This node type doesn&apos;t expose OSC-controllable params yet.
+          </p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            <div className="grid grid-cols-[auto_auto_1fr_minmax(120px,160px)] gap-x-3 gap-y-2 text-xs items-center">
+              <div className="font-semibold text-muted-foreground uppercase tracking-wider">
+                Param
+              </div>
+              <div className="font-semibold text-muted-foreground uppercase tracking-wider text-center">
+                Expose
+              </div>
+              <div className="font-semibold text-muted-foreground uppercase tracking-wider">
+                Address
+              </div>
+              <div className="font-semibold text-muted-foreground uppercase tracking-wider">
+                Default
+              </div>
+              {descriptors.map(d => {
+                const row = staged[d.name];
+                const exposed = row?.exposed ?? false;
+                const currentValue = readNodeParamValue(node.data, d);
+                return (
+                  <ConfigRow
+                    key={d.name}
+                    descriptor={d}
+                    row={row}
+                    exposed={exposed}
+                    currentValue={currentValue}
+                    placeholderAddress={computedAddress(d.name)}
+                    onToggle={v => updateRow(d.name, { exposed: v })}
+                    onAddress={v =>
+                      updateRow(d.name, {
+                        address: v.trim() === "" ? undefined : v.trim(),
+                      })
+                    }
+                    onDefault={v =>
+                      updateRow(d.name, {
+                        default: v === "" ? undefined : v,
+                      })
+                    }
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter className="mt-4">
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ConfigRowProps {
+  descriptor: OscParamDescriptor;
+  row: OscParamConfig | undefined;
+  exposed: boolean;
+  currentValue: unknown;
+  placeholderAddress: string;
+  onToggle: (v: boolean) => void;
+  onAddress: (v: string) => void;
+  onDefault: (v: string) => void;
+}
+
+function ConfigRow({
+  descriptor,
+  row,
+  exposed,
+  currentValue,
+  placeholderAddress,
+  onToggle,
+  onAddress,
+  onDefault,
+}: ConfigRowProps) {
+  const placeholderDefault =
+    currentValue === undefined || currentValue === null
+      ? ""
+      : typeof currentValue === "object"
+        ? JSON.stringify(currentValue)
+        : String(currentValue);
+
+  return (
+    <>
+      <div className="text-sm">
+        <div className="font-medium">{descriptor.label}</div>
+        <div className="text-[10px] text-muted-foreground font-mono">
+          {descriptor.name} · {descriptor.type}
+        </div>
+      </div>
+      <div className="flex items-center justify-center">
+        <input
+          type="checkbox"
+          checked={exposed}
+          onChange={e => onToggle(e.target.checked)}
+          className="h-4 w-4"
+        />
+      </div>
+      <Input
+        type="text"
+        value={row?.address ?? ""}
+        placeholder={placeholderAddress}
+        onChange={e => onAddress(e.target.value)}
+        disabled={!exposed}
+        className="h-8 text-xs font-mono"
+      />
+      <Input
+        type="text"
+        value={row?.default === undefined ? "" : String(row.default)}
+        placeholder={placeholderDefault || "—"}
+        onChange={e => onDefault(e.target.value)}
+        disabled={!exposed}
+        className="h-8 text-xs font-mono"
+      />
+    </>
+  );
+}

--- a/frontend/src/components/graph/OscConfigDialog.tsx
+++ b/frontend/src/components/graph/OscConfigDialog.tsx
@@ -12,13 +12,14 @@ import { Input } from "../ui/input";
 import type { Node } from "@xyflow/react";
 import type { FlowNodeData, OscParamConfig } from "../../lib/graphUtils";
 import {
+  coerceDefaultForType,
   getNodeOscParams,
+  pickPipelineOscParams,
   readNodeParamValue,
   slugifyForOsc,
   type OscParamDescriptor,
 } from "../../lib/oscNodeParams";
 import { usePipelinesContext } from "../../contexts/PipelinesContext";
-import type { PipelineSchemaProperty } from "../../lib/api";
 
 interface OscConfigDialogProps {
   open: boolean;
@@ -58,33 +59,7 @@ export function OscConfigDialog({
     if (node.type === "pipeline") {
       const pid = node.data.pipelineId;
       if (!pid || !pipelines || !pipelines[pid]) return [];
-      const schema = pipelines[pid].configSchema;
-      if (!schema) return [];
-      const out: OscParamDescriptor[] = [];
-      for (const [key, rawProp] of Object.entries(schema.properties)) {
-        const prop = rawProp as PipelineSchemaProperty;
-        const ui = prop.ui;
-        if (ui?.is_load_param !== false) continue; // runtime params only
-        const t = String(prop.type ?? "any");
-        const oscType =
-          t === "number"
-            ? "float"
-            : t === "integer"
-              ? "integer"
-              : t === "boolean"
-                ? "bool"
-                : "string";
-        out.push({
-          name: key,
-          label: (ui as { label?: string } | undefined)?.label ?? key,
-          type: oscType,
-          min: prop.minimum as number | undefined,
-          max: prop.maximum as number | undefined,
-          enum: prop.enum as string[] | undefined,
-          description: (prop.description as string | undefined) ?? "",
-        });
-      }
-      return out;
+      return pickPipelineOscParams(pipelines[pid].configSchema);
     }
     return getNodeOscParams(node.type);
   }, [node, pipelines]);
@@ -113,12 +88,26 @@ export function OscConfigDialog({
   };
 
   const handleSave = () => {
-    // Drop rows where exposed is false AND no override fields, to keep the
-    // saved map small.
+    // Coerce each row's default to the descriptor's declared type so the
+    // OSC docs publish typed values (e.g. 0.85, true, [1,2,3]) instead of
+    // the raw strings the modal's text inputs return.
+    const descByName = new Map(descriptors.map(d => [d.name, d]));
     const cleaned: Record<string, OscParamConfig> = {};
     for (const [k, v] of Object.entries(staged)) {
-      if (v.exposed || v.address || v.default !== undefined) {
-        cleaned[k] = v;
+      const desc = descByName.get(k);
+      const coerced = desc
+        ? coerceDefaultForType(v.default, desc.type)
+        : v.default;
+      const entry: OscParamConfig = { ...v };
+      if (coerced === undefined) {
+        delete entry.default;
+      } else {
+        entry.default = coerced;
+      }
+      // Drop rows where exposed is false AND no override fields, to keep
+      // the saved map small.
+      if (entry.exposed || entry.address || entry.default !== undefined) {
+        cleaned[k] = entry;
       }
     }
     onSave(cleaned);

--- a/frontend/src/components/graph/contextMenuItems.tsx
+++ b/frontend/src/components/graph/contextMenuItems.tsx
@@ -31,6 +31,7 @@ import {
   Clock,
   Puzzle,
   Component,
+  Radio,
 } from "lucide-react";
 import type { Node, Edge } from "@xyflow/react";
 import type { FlowNodeData } from "../../lib/graphUtils";
@@ -424,6 +425,8 @@ export function buildNodeMenuItems(deps: {
     edges: Edge[],
     selectedIds: string[]
   ) => void;
+  /** Open the per-node Configure OSC modal. Optional — omitted in contexts where OSC is irrelevant. */
+  openOscConfig?: (nodeId: string) => void;
 }): ContextMenuItem[] {
   const {
     contextNodeId,
@@ -435,6 +438,7 @@ export function buildNodeMenuItems(deps: {
     handleEnterSubgraph,
     unpackSubgraph,
     createSubgraphFromSelection,
+    openOscConfig,
   } = deps;
 
   const isInSelection = selectedNodeIds.includes(contextNodeId);
@@ -519,6 +523,15 @@ export function buildNodeMenuItems(deps: {
         );
       },
     },
+    ...(openOscConfig && count === 1
+      ? [
+          {
+            label: "Configure OSC…",
+            icon: <Radio />,
+            onClick: () => openOscConfig(contextNodeId),
+          },
+        ]
+      : []),
     {
       label: count > 1 ? `Delete ${count} nodes` : "Delete",
       icon: <Trash2 />,

--- a/frontend/src/components/graph/hooks/graph/useOscInventory.ts
+++ b/frontend/src/components/graph/hooks/graph/useOscInventory.ts
@@ -3,25 +3,13 @@ import type { Node } from "@xyflow/react";
 import type { FlowNodeData, OscParamConfig } from "../../../../lib/graphUtils";
 import {
   getNodeOscParams,
+  pickPipelineOscParams,
   readNodeParamValue,
   slugifyForOsc,
   type OscParamDescriptor,
 } from "../../../../lib/oscNodeParams";
 import { setOscInventory, type OscInventoryEntry } from "../../../../lib/api";
 import { usePipelinesContext } from "../../../../contexts/PipelinesContext";
-import type { PipelineSchemaProperty } from "../../../../lib/api";
-
-/**
- * Map a frontend OSC type to the JSON schema string the backend expects.
- * Mirrors `OscInventoryEntry["type"]` in api.ts.
- */
-function paramTypeFromSchema(prop: PipelineSchemaProperty): string {
-  const t = String(prop.type ?? "any");
-  if (t === "number") return "float";
-  if (t === "integer") return "integer";
-  if (t === "boolean") return "bool";
-  return "string";
-}
 
 interface ResolvedRow {
   descriptor: OscParamDescriptor;
@@ -78,26 +66,9 @@ export function useOscInventory(nodes: Node<FlowNodeData>[]): void {
       if (node.type === "pipeline") {
         const pid = node.data.pipelineId;
         if (pid && pipelines && pipelines[pid]) {
-          const schema = pipelines[pid].configSchema;
-          if (!schema) {
-            pipelineDescriptors = [];
-            continue;
-          }
-          pipelineDescriptors = [];
-          for (const [key, rawProp] of Object.entries(schema.properties)) {
-            const prop = rawProp as PipelineSchemaProperty;
-            const ui = prop.ui;
-            if (ui?.is_load_param !== false) continue;
-            pipelineDescriptors.push({
-              name: key,
-              label: (ui as { label?: string } | undefined)?.label ?? key,
-              type: paramTypeFromSchema(prop) as OscParamDescriptor["type"],
-              min: prop.minimum as number | undefined,
-              max: prop.maximum as number | undefined,
-              enum: prop.enum as string[] | undefined,
-              description: (prop.description as string | undefined) ?? "",
-            });
-          }
+          pipelineDescriptors = pickPipelineOscParams(
+            pipelines[pid].configSchema
+          );
         }
       }
 

--- a/frontend/src/components/graph/hooks/graph/useOscInventory.ts
+++ b/frontend/src/components/graph/hooks/graph/useOscInventory.ts
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { Node } from "@xyflow/react";
+import type { FlowNodeData, OscParamConfig } from "../../../../lib/graphUtils";
+import {
+  getNodeOscParams,
+  readNodeParamValue,
+  slugifyForOsc,
+  type OscParamDescriptor,
+} from "../../../../lib/oscNodeParams";
+import { setOscInventory, type OscInventoryEntry } from "../../../../lib/api";
+import { usePipelinesContext } from "../../../../contexts/PipelinesContext";
+import type { PipelineSchemaProperty } from "../../../../lib/api";
+
+/**
+ * Map a frontend OSC type to the JSON schema string the backend expects.
+ * Mirrors `OscInventoryEntry["type"]` in api.ts.
+ */
+function paramTypeFromSchema(prop: PipelineSchemaProperty): string {
+  const t = String(prop.type ?? "any");
+  if (t === "number") return "float";
+  if (t === "integer") return "integer";
+  if (t === "boolean") return "bool";
+  return "string";
+}
+
+interface ResolvedRow {
+  descriptor: OscParamDescriptor;
+  config: OscParamConfig;
+  /** Current value on node.data; used as default fallback for the inventory entry. */
+  currentValue: unknown;
+}
+
+function resolveNodeRows(
+  node: Node<FlowNodeData>,
+  pipelineDescriptors: OscParamDescriptor[] | null
+): ResolvedRow[] {
+  const oscConfig = node.data.oscConfig ?? {};
+  const descriptors =
+    node.type === "pipeline"
+      ? (pipelineDescriptors ?? [])
+      : getNodeOscParams(node.type);
+
+  const rows: ResolvedRow[] = [];
+  for (const d of descriptors) {
+    const cfg = oscConfig[d.name];
+    if (!cfg?.exposed) continue;
+    rows.push({
+      descriptor: d,
+      config: cfg,
+      currentValue: readNodeParamValue(node.data, d),
+    });
+  }
+  return rows;
+}
+
+/**
+ * Derive the OSC inventory from the live graph and POST it to the
+ * backend whenever it changes.
+ *
+ * Inventory shape per entry: see `OscInventoryEntry` in api.ts. Two
+ * route paths emerge from this:
+ *
+ *  1. Pipeline node entries — get `pipeline_id` + `node_id` set, so the
+ *     OSC server routes to the right pipeline processor.
+ *  2. Non-pipeline node entries — get `node_id` only; the SSE consumer
+ *     in StreamPage applies them to the matching React Flow node.
+ */
+export function useOscInventory(nodes: Node<FlowNodeData>[]): void {
+  const { pipelines } = usePipelinesContext();
+
+  const inventory = useMemo<OscInventoryEntry[]>(() => {
+    const entries: OscInventoryEntry[] = [];
+
+    for (const node of nodes) {
+      // Resolve descriptors. Pipeline nodes need the live schema; others
+      // use the static per-type table.
+      let pipelineDescriptors: OscParamDescriptor[] | null = null;
+      if (node.type === "pipeline") {
+        const pid = node.data.pipelineId;
+        if (pid && pipelines && pipelines[pid]) {
+          const schema = pipelines[pid].configSchema;
+          if (!schema) {
+            pipelineDescriptors = [];
+            continue;
+          }
+          pipelineDescriptors = [];
+          for (const [key, rawProp] of Object.entries(schema.properties)) {
+            const prop = rawProp as PipelineSchemaProperty;
+            const ui = prop.ui;
+            if (ui?.is_load_param !== false) continue;
+            pipelineDescriptors.push({
+              name: key,
+              label: (ui as { label?: string } | undefined)?.label ?? key,
+              type: paramTypeFromSchema(prop) as OscParamDescriptor["type"],
+              min: prop.minimum as number | undefined,
+              max: prop.maximum as number | undefined,
+              enum: prop.enum as string[] | undefined,
+              description: (prop.description as string | undefined) ?? "",
+            });
+          }
+        }
+      }
+
+      const rows = resolveNodeRows(node, pipelineDescriptors);
+      if (rows.length === 0) continue;
+
+      const slug = slugifyForOsc(node.data.customTitle, node.id);
+      const groupLabel =
+        node.data.customTitle?.trim() || node.data.label || node.id;
+
+      for (const { descriptor, config, currentValue } of rows) {
+        const address =
+          config.address?.trim() || `/scope/${slug}/${descriptor.name}`;
+        const defaultValue =
+          config.default !== undefined ? config.default : currentValue;
+        const entry: OscInventoryEntry = {
+          osc_address: address,
+          type: descriptor.type,
+          description: descriptor.description ?? "",
+          node_id: node.id,
+          param: descriptor.name,
+          group: groupLabel,
+        };
+        if (descriptor.min !== undefined) entry.min = descriptor.min;
+        if (descriptor.max !== undefined) entry.max = descriptor.max;
+        if (descriptor.enum !== undefined) entry.enum = descriptor.enum;
+        if (defaultValue !== undefined) entry.default = defaultValue;
+        if (node.type === "pipeline" && node.data.pipelineId) {
+          entry.pipeline_id = node.data.pipelineId;
+        }
+        entries.push(entry);
+      }
+    }
+
+    return entries;
+  }, [nodes, pipelines]);
+
+  // Push to backend whenever the inventory hash changes. Debounce ~300ms
+  // so rapid graph edits coalesce into a single POST.
+  const lastSerialized = useRef<string>("");
+  useEffect(() => {
+    const serialized = JSON.stringify(inventory);
+    if (serialized === lastSerialized.current) return;
+    const handle = window.setTimeout(() => {
+      lastSerialized.current = serialized;
+      void setOscInventory(inventory).catch(err => {
+        // Non-fatal — OSC just won't see new paths until the next push.
+        console.warn("Failed to push OSC inventory:", err);
+      });
+    }, 300);
+    return () => window.clearTimeout(handle);
+  }, [inventory]);
+}

--- a/frontend/src/components/graph/hooks/node/usePipelineParams.ts
+++ b/frontend/src/components/graph/hooks/node/usePipelineParams.ts
@@ -191,6 +191,23 @@ export function usePipelineParams({
       }
       if (Object.keys(patch).length === 0) return;
 
+      // For a non-pipeline target (Slider, Source, Bool, XYPad, etc.) the
+      // value must land directly on `node.data` — these nodes read their
+      // state from data fields, not from the pipeline `nodeParams` map.
+      if (targetNodeId) {
+        const targetNode = nodesRef.current.find(n => n.id === targetNodeId);
+        if (targetNode && targetNode.data.nodeType !== "pipeline") {
+          setNodes(nds =>
+            nds.map(n =>
+              n.id === targetNodeId
+                ? { ...n, data: { ...n.data, ...patch } }
+                : n
+            )
+          );
+          return;
+        }
+      }
+
       setNodeParams(prev => {
         const next = { ...prev };
         if (targetNodeId) {

--- a/frontend/src/components/settings/OscTab.tsx
+++ b/frontend/src/components/settings/OscTab.tsx
@@ -1,9 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
-import { BookOpenText, Loader2 } from "lucide-react";
+import { BookOpenText, Loader2, Copy, Check } from "lucide-react";
 import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
 import { openExternalUrl } from "@/lib/openExternal";
-import { updateOscSettings, type OscStatusResponse } from "@/lib/api";
+import {
+  fetchOscPaths,
+  updateOscSettings,
+  type OscInventoryEntry,
+  type OscPathsResponse,
+  type OscStatusResponse,
+} from "@/lib/api";
 
 interface OscTabProps {
   isActive: boolean;
@@ -11,8 +17,10 @@ interface OscTabProps {
 
 export function OscTab({ isActive }: OscTabProps) {
   const [status, setStatus] = useState<OscStatusResponse | null>(null);
+  const [paths, setPaths] = useState<OscPathsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isTogglingLog, setIsTogglingLog] = useState(false);
+  const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
 
   const fetchStatus = useCallback(async () => {
     setIsLoading(true);
@@ -28,11 +36,30 @@ export function OscTab({ isActive }: OscTabProps) {
     }
   }, []);
 
+  const refreshPaths = useCallback(async () => {
+    try {
+      setPaths(await fetchOscPaths());
+    } catch (err) {
+      console.error("Failed to fetch OSC paths:", err);
+    }
+  }, []);
+
   useEffect(() => {
     if (isActive) {
       fetchStatus();
+      refreshPaths();
     }
-  }, [isActive, fetchStatus]);
+  }, [isActive, fetchStatus, refreshPaths]);
+
+  const handleCopyAddress = async (address: string) => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopiedAddress(address);
+      window.setTimeout(() => setCopiedAddress(null), 1200);
+    } catch (err) {
+      console.warn("Clipboard write failed:", err);
+    }
+  };
 
   const handleOpenDocs = () => {
     openExternalUrl(`${window.location.origin}/api/v1/osc/docs`);
@@ -134,9 +161,124 @@ export function OscTab({ isActive }: OscTabProps) {
           <code className="bg-muted px-1 py-0.5 rounded text-xs">
             {status?.port ?? "..."}
           </code>{" "}
-          to control pipeline parameters in real time. Click{" "}
-          <strong>Open OSC Docs</strong> for the full path reference.
+          to control pipeline parameters in real time. Right-click any node →
+          <strong> Configure OSC…</strong> to expose its params, or click{" "}
+          <strong>Open OSC Docs</strong> for the full reference.
         </div>
+      </div>
+
+      <LiveInventoryPanel
+        paths={paths}
+        copiedAddress={copiedAddress}
+        onCopy={handleCopyAddress}
+        onRefresh={refreshPaths}
+      />
+    </div>
+  );
+}
+
+interface LiveInventoryPanelProps {
+  paths: OscPathsResponse | null;
+  copiedAddress: string | null;
+  onCopy: (address: string) => void;
+  onRefresh: () => void;
+}
+
+function LiveInventoryPanel({
+  paths,
+  copiedAddress,
+  onCopy,
+  onRefresh,
+}: LiveInventoryPanelProps) {
+  const groups = paths?.active ?? {};
+  const total = Object.values(groups).reduce(
+    (sum, list) => sum + list.length,
+    0
+  );
+
+  return (
+    <div className="rounded-lg bg-muted/50 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium text-foreground">
+          Currently exposed paths
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onRefresh}
+          className="h-7 text-xs"
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {total === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No paths exposed yet. Open the graph editor, right-click a node, and
+          choose <em>Configure OSC…</em> to opt params in.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {Object.entries(groups).map(([groupName, entries]) => (
+            <InventoryGroup
+              key={groupName}
+              name={groupName}
+              entries={entries}
+              copiedAddress={copiedAddress}
+              onCopy={onCopy}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface InventoryGroupProps {
+  name: string;
+  entries: OscInventoryEntry[];
+  copiedAddress: string | null;
+  onCopy: (address: string) => void;
+}
+
+function InventoryGroup({
+  name,
+  entries,
+  copiedAddress,
+  onCopy,
+}: InventoryGroupProps) {
+  return (
+    <div>
+      <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground mb-1">
+        {name}
+      </div>
+      <div className="space-y-1">
+        {entries.map(entry => (
+          <div
+            key={`${name}:${entry.osc_address}`}
+            className="flex items-center gap-2 text-xs"
+          >
+            <button
+              type="button"
+              onClick={() => onCopy(entry.osc_address)}
+              className="font-mono text-foreground hover:underline truncate"
+              title="Click to copy"
+            >
+              {entry.osc_address}
+            </button>
+            <span className="text-muted-foreground">{entry.type}</span>
+            {entry.default !== undefined && entry.default !== null && (
+              <span className="text-muted-foreground/70">
+                default {String(entry.default)}
+              </span>
+            )}
+            {copiedAddress === entry.osc_address ? (
+              <Check className="h-3 w-3 text-green-500" />
+            ) : (
+              <Copy className="h-3 w-3 text-muted-foreground/50" />
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1152,6 +1152,61 @@ export const updateOscSettings = async (
 };
 
 // ---------------------------------------------------------------------------
+// OSC graph inventory + paths
+// ---------------------------------------------------------------------------
+
+export interface OscInventoryEntry {
+  osc_address: string;
+  type: "float" | "integer" | "bool" | "string" | "integer_list";
+  description?: string | null;
+  min?: number | null;
+  max?: number | null;
+  enum?: unknown[] | null;
+  default?: unknown;
+  /** React Flow node id this entry maps to (omit for global registry params). */
+  node_id?: string | null;
+  /** Field name on `node.data` (or pipeline schema property name). */
+  param?: string | null;
+  /** Pipeline id when the target is a pipeline node param. */
+  pipeline_id?: string | null;
+  /** Group label shown in the OSC docs (typically the node's display title). */
+  group?: string | null;
+}
+
+export interface OscPathsResponse {
+  active: Record<string, OscInventoryEntry[]>;
+  available: Record<string, OscInventoryEntry[]>;
+  active_pipeline_ids: string[];
+}
+
+export const setOscInventory = async (
+  paths: OscInventoryEntry[]
+): Promise<{ count: number }> => {
+  const response = await fetch("/api/v1/osc/inventory", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ paths }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Set OSC inventory failed: ${response.status} ${response.statusText}: ${errorText}`
+    );
+  }
+
+  return response.json();
+};
+
+export const fetchOscPaths = async (): Promise<OscPathsResponse> => {
+  const response = await fetch("/api/v1/osc/paths");
+  if (!response.ok) {
+    throw new Error(`Fetch OSC paths failed: ${response.status}`);
+  }
+  return response.json();
+};
+
+// ---------------------------------------------------------------------------
 // DMX settings
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -109,10 +109,28 @@ export interface SerializedSubgraphEdge {
   targetHandle?: string | null;
 }
 
+/**
+ * Per-parameter OSC opt-in / address override / default override.
+ *
+ * Stored on `node.data.oscConfig` keyed by the node-data field name
+ * (e.g. "value" for a slider, "sourceMode" for a source). Computed by
+ * `useOscInventory` into the global OSC inventory POSTed to the
+ * backend. Persists with the rest of the graph.
+ */
+export interface OscParamConfig {
+  exposed: boolean;
+  /** Full OSC address (e.g. "/scope/tempo/value"); auto-derived when omitted. */
+  address?: string;
+  /** Advisory default published in the OSC docs; not auto-applied to the param. */
+  default?: unknown;
+}
+
 export interface FlowNodeData {
   label: string;
   /** User-editable display name; when set, overrides the default header title. */
   customTitle?: string;
+  /** Per-param OSC opt-in/override map. Absent ⇒ no params exposed for this node. */
+  oscConfig?: Record<string, OscParamConfig>;
   pipelineId?: string | null;
   nodeType:
     | "source"

--- a/frontend/src/lib/oscNodeParams.ts
+++ b/frontend/src/lib/oscNodeParams.ts
@@ -1,0 +1,175 @@
+/**
+ * Per-node-type OSC parameter descriptors.
+ *
+ * These describe which fields on a non-pipeline node's `data` are eligible
+ * to be exposed via OSC. Pipeline nodes use the live pipeline schema
+ * instead — see `pickPipelineOscParams` below.
+ *
+ * Keep this list minimal and additive. We deliberately skip composite /
+ * dynamic-shaped fields (knobs[], midiChannels[], tupleValues[]) for the
+ * MVP — those need a richer addressing scheme (e.g. /scope/.../knob_0)
+ * that can be added in a follow-up without a breaking API change.
+ */
+import type { FlowNodeData } from "./graphUtils";
+
+export type OscParamType =
+  | "float"
+  | "integer"
+  | "bool"
+  | "string"
+  | "integer_list";
+
+export interface OscParamDescriptor {
+  /** Field name on `node.data` we read/write. Also the default param name in the OSC address. */
+  name: string;
+  /** Human label for the Configure OSC modal. */
+  label: string;
+  type: OscParamType;
+  /** Optional constraints surfaced in OSC docs + used for validation. */
+  min?: number;
+  max?: number;
+  enum?: string[];
+  /** Brief description shown in OSC docs. */
+  description?: string;
+}
+
+const SOURCE_PARAMS: OscParamDescriptor[] = [
+  {
+    name: "sourceMode",
+    label: "Source mode",
+    type: "string",
+    enum: ["video", "camera", "spout", "ndi", "syphon"],
+    description: "Switch between file / camera / Spout / NDI / Syphon",
+  },
+  {
+    name: "sourceFlipVertical",
+    label: "Flip vertical",
+    type: "bool",
+    description: "Flip incoming frames vertically (Syphon-friendly)",
+  },
+];
+
+const OUTPUT_PARAMS: OscParamDescriptor[] = [
+  {
+    name: "outputSinkEnabled",
+    label: "Enabled",
+    type: "bool",
+    description: "Toggle the output sink on/off",
+  },
+  {
+    name: "outputSinkType",
+    label: "Sink type",
+    type: "string",
+    enum: ["spout", "ndi", "syphon"],
+  },
+];
+
+const SLIDER_PARAMS: OscParamDescriptor[] = [
+  {
+    name: "value",
+    label: "Value",
+    type: "float",
+    description: "Slider value (clamped to slider min/max)",
+  },
+];
+
+const XYPAD_PARAMS: OscParamDescriptor[] = [
+  { name: "padX", label: "X", type: "float" },
+  { name: "padY", label: "Y", type: "float" },
+];
+
+const BOOL_PARAMS: OscParamDescriptor[] = [
+  { name: "value", label: "Value", type: "bool" },
+];
+
+const TRIGGER_PARAMS: OscParamDescriptor[] = [
+  {
+    name: "value",
+    label: "Trigger",
+    type: "bool",
+    description: "Send true to fire the trigger",
+  },
+];
+
+const TEMPO_PARAMS: OscParamDescriptor[] = [
+  {
+    name: "tempoBpm",
+    label: "BPM",
+    type: "float",
+    min: 20,
+    max: 999,
+    description: "Override tempo BPM (when tempo source = manual)",
+  },
+  { name: "tempoEnabled", label: "Tempo enabled", type: "bool" },
+];
+
+const PRIMITIVE_PARAMS: OscParamDescriptor[] = [
+  {
+    name: "value",
+    label: "Value",
+    // Type depends on `valueType` — caller can branch when emitting the
+    // inventory entry. We default to string here as the most permissive.
+    type: "string",
+  },
+];
+
+const NOTE_PARAMS: OscParamDescriptor[] = [
+  { name: "noteText", label: "Note text", type: "string" },
+];
+
+/**
+ * Lookup table keyed by React Flow node `type` (matches the `nodeTypes`
+ * map in GraphEditor.tsx). Nodes not in the table are not OSC-exposable
+ * via this path — pipeline nodes are handled separately because their
+ * params come from the loaded pipeline's schema.
+ */
+export const OSC_NODE_PARAMS: Record<string, OscParamDescriptor[]> = {
+  source: SOURCE_PARAMS,
+  output: OUTPUT_PARAMS,
+  slider: SLIDER_PARAMS,
+  xypad: XYPAD_PARAMS,
+  bool: BOOL_PARAMS,
+  trigger: TRIGGER_PARAMS,
+  tempo: TEMPO_PARAMS,
+  primitive: PRIMITIVE_PARAMS,
+  note: NOTE_PARAMS,
+};
+
+export function getNodeOscParams(
+  nodeType: string | undefined
+): OscParamDescriptor[] {
+  return nodeType ? (OSC_NODE_PARAMS[nodeType] ?? []) : [];
+}
+
+/**
+ * Lowercase, kebab-cased slug suitable for use as the node-namespacing
+ * segment of an OSC address. Falls back to the node id when the title
+ * has no usable characters (e.g. all emoji).
+ */
+export function slugifyForOsc(
+  title: string | undefined,
+  nodeId: string
+): string {
+  const fromTitle = (title ?? "")
+    .normalize("NFKD")
+    // strip combining diacritics so "café" → "cafe"
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  return fromTitle || nodeId;
+}
+
+/**
+ * Read the current value of a descriptor's field off `node.data`.
+ * Used to seed the "default" override field in the Configure OSC modal
+ * and to populate the OSC docs when the user hasn't explicitly set one.
+ */
+export function readNodeParamValue(
+  data: FlowNodeData | undefined,
+  descriptor: OscParamDescriptor
+): unknown {
+  if (!data) return undefined;
+  return (data as Record<string, unknown>)[descriptor.name];
+}

--- a/frontend/src/lib/oscNodeParams.ts
+++ b/frontend/src/lib/oscNodeParams.ts
@@ -11,6 +11,7 @@
  * that can be added in a follow-up without a breaking API change.
  */
 import type { FlowNodeData } from "./graphUtils";
+import type { PipelineConfigSchema, PipelineSchemaProperty } from "./api";
 
 export type OscParamType =
   | "float"
@@ -172,4 +173,95 @@ export function readNodeParamValue(
 ): unknown {
   if (!data) return undefined;
   return (data as Record<string, unknown>)[descriptor.name];
+}
+
+function oscTypeFromSchema(prop: PipelineSchemaProperty): OscParamType {
+  const t = String(prop.type ?? "any");
+  if (t === "number") return "float";
+  if (t === "integer") return "integer";
+  if (t === "boolean") return "bool";
+  if (t === "array") {
+    const items = prop.items as { type?: string } | undefined;
+    if (items?.type === "integer") return "integer_list";
+  }
+  return "string";
+}
+
+/**
+ * Convert a pipeline's JSON-Schema config into OSC param descriptors.
+ *
+ * Only runtime params (`ui.is_load_param === false`) are exposed — load-time
+ * params don't make sense to drive over OSC.
+ */
+export function pickPipelineOscParams(
+  schema: PipelineConfigSchema | null | undefined
+): OscParamDescriptor[] {
+  if (!schema) return [];
+  const out: OscParamDescriptor[] = [];
+  for (const [key, rawProp] of Object.entries(schema.properties)) {
+    const prop = rawProp as PipelineSchemaProperty;
+    const ui = prop.ui;
+    if (ui?.is_load_param !== false) continue;
+    out.push({
+      name: key,
+      label: (ui as { label?: string } | undefined)?.label ?? key,
+      type: oscTypeFromSchema(prop),
+      min: prop.minimum,
+      max: prop.maximum,
+      enum: prop.enum as string[] | undefined,
+      description: prop.description ?? "",
+    });
+  }
+  return out;
+}
+
+/**
+ * Coerce a user-typed default (always a string from the modal's text input)
+ * to the descriptor's declared type. Returns `undefined` for empty or
+ * un-parseable input — callers treat that as "no default set".
+ *
+ * For `integer_list`, accepts comma- or space-separated integers
+ * (e.g. `"1, 2, 3"` or `"1 2 3"`).
+ */
+export function coerceDefaultForType(
+  raw: unknown,
+  type: OscParamType
+): unknown {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "string") return raw;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  switch (type) {
+    case "float": {
+      const n = Number(trimmed);
+      return Number.isFinite(n) ? n : undefined;
+    }
+    case "integer": {
+      const n = Number(trimmed);
+      if (!Number.isFinite(n)) return undefined;
+      const i = Math.trunc(n);
+      return i === n ? i : undefined;
+    }
+    case "bool": {
+      const lower = trimmed.toLowerCase();
+      if (["true", "1", "yes", "on"].includes(lower)) return true;
+      if (["false", "0", "no", "off"].includes(lower)) return false;
+      return undefined;
+    }
+    case "integer_list": {
+      const parts = trimmed.split(/[\s,]+/).filter(Boolean);
+      const ints: number[] = [];
+      for (const p of parts) {
+        const n = Number(p);
+        if (!Number.isFinite(n)) return undefined;
+        const i = Math.trunc(n);
+        if (i !== n) return undefined;
+        ints.push(i);
+      }
+      return ints.length > 0 ? ints : undefined;
+    }
+    case "string":
+    default:
+      return trimmed;
+  }
 }

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -114,6 +114,10 @@ import { trackEvent } from "../lib/analytics";
 interface OscCommand {
   key: string;
   value: unknown;
+  /** Set by the OSC server when the path is bound to a specific React Flow node. */
+  node_id?: string;
+  /** The node-data field name to update (e.g. "value" for a slider). */
+  param?: string;
 }
 
 // Delay before resetting video reinitialization flag (ms)
@@ -1938,7 +1942,19 @@ export function StreamPage() {
   // Keep the OSC command handler ref in sync with current state/handlers
   useEffect(() => {
     oscCommandHandlerRef.current = (cmd: OscCommand) => {
-      const { key, value } = cmd;
+      const { key, value, node_id, param } = cmd;
+
+      // Node-scoped path (e.g. /scope/tempo/value with node_id set):
+      // route directly to the matching React Flow node so per-node
+      // params (Slider, Knobs, Source, etc.) update without going
+      // through the flat-key switch below.
+      if (node_id && param) {
+        graphEditorRef.current?.applyExternalParams(
+          { [param]: value },
+          node_id
+        );
+        return;
+      }
 
       switch (key) {
         case "prompt": {

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -916,10 +916,60 @@ async def update_osc_settings(request: OscSettingsRequest):
 async def osc_paths(
     pm: "PipelineManager" = Depends(get_pipeline_manager),
 ):
-    """Return all OSC paths split into active / available sections."""
+    """Return all OSC paths split into active / available sections.
+
+    Includes the most recently registered graph inventory (see
+    ``POST /api/v1/osc/inventory``) so external clients can discover
+    user-curated node param paths alongside the registry-derived ones.
+    """
     from .osc_docs import get_osc_paths
 
-    return get_osc_paths(pm)
+    srv = get_osc_server()
+    graph_inventory = srv.graph_inventory if srv else None
+    return get_osc_paths(pm, graph_inventory)
+
+
+class OscInventoryEntry(BaseModel):
+    """One graph-supplied OSC path entry.
+
+    Mirrors the dict shape ``osc_docs._normalize_graph_entry`` expects.
+    Validated minimally: required fields are ``osc_address`` (must start
+    with ``/scope/`` or be coerced to it) and ``type``. Anything else
+    flows through as-is so the frontend can attach metadata (group,
+    description, etc.) without a backend schema bump.
+    """
+
+    osc_address: str
+    type: str
+    description: str | None = None
+    min: float | None = None
+    max: float | None = None
+    enum: list | None = None
+    default: Any | None = None
+    node_id: str | None = None
+    param: str | None = None
+    pipeline_id: str | None = None
+    group: str | None = None
+
+
+class OscInventoryRequest(BaseModel):
+    paths: list[OscInventoryEntry]
+
+
+@app.post("/api/v1/osc/inventory")
+async def set_osc_inventory(request: OscInventoryRequest):
+    """Replace the OSC server's per-graph inventory.
+
+    The frontend computes this list from each node's ``oscConfig`` overlay
+    and POSTs whenever the inventory changes (debounced). Empty list
+    clears the inventory and reverts behavior to registry-derived paths
+    only.
+    """
+    srv = get_osc_server()
+    if srv is None:
+        raise HTTPException(status_code=503, detail="OSC server not running")
+    srv.set_graph_inventory([p.model_dump(exclude_none=True) for p in request.paths])
+    return {"count": len(request.paths)}
 
 
 @app.get("/api/v1/osc/stream")
@@ -965,7 +1015,8 @@ async def osc_docs_page(
 
     srv = get_osc_server()
     port = srv.port if srv else 8000
-    html_content = render_osc_docs_html(pm, port)
+    graph_inventory = srv.graph_inventory if srv else None
+    html_content = render_osc_docs_html(pm, port, graph_inventory)
     return Response(content=html_content, media_type="text/html")
 
 

--- a/src/scope/server/osc_docs.py
+++ b/src/scope/server/osc_docs.py
@@ -134,6 +134,8 @@ def _extract_osc_paths_from_schema(
             entry["max"] = prop["maximum"]
         if "enum" in prop:
             entry["enum"] = prop["enum"]
+        if "default" in prop:
+            entry["default"] = prop["default"]
         paths.append(entry)
     return paths
 
@@ -155,12 +157,53 @@ def _collect_pipeline_paths() -> dict[str, list[dict[str, Any]]]:
     return pipeline_paths
 
 
+def _normalize_graph_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one graph-supplied OSC inventory entry.
+
+    Strips the leading ``/scope/`` from ``osc_address`` to derive ``key``
+    (so the existing dispatcher logic in ``osc_server._handle_osc_message``
+    keeps working: it splits incoming addresses on ``/`` and looks up
+    everything after ``/scope/``).
+    """
+    osc_address = str(entry.get("osc_address") or "").strip()
+    if not osc_address.startswith("/scope/"):
+        # Be permissive: allow plain "<key>" or "/<key>" too.
+        cleaned = osc_address.lstrip("/")
+        osc_address = f"/scope/{cleaned}"
+    key = osc_address[len("/scope/") :]
+
+    out: dict[str, Any] = {**entry, "key": key, "osc_address": osc_address}
+    return out
+
+
+def _group_graph_entries(
+    entries: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Group graph inventory entries under stable source labels.
+
+    The frontend may attach a ``group`` field (typically the node's display
+    title); when absent we synthesize one from ``node_id`` so the entry
+    still appears somewhere in the docs.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for e in entries:
+        label = str(e.get("group") or e.get("node_id") or "Graph") or "Graph"
+        grouped.setdefault(label, []).append(e)
+    return grouped
+
+
 def get_osc_paths(
     pipeline_manager: "PipelineManager | None",
+    graph_inventory: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the full OSC path inventory split into *active* and *available* sections.
 
     Each section is a dict mapping source names to lists of path entries.
+
+    ``graph_inventory`` is the user-curated list of paths supplied by the
+    frontend via ``POST /api/v1/osc/inventory``. When provided, those
+    entries appear under their own per-node groups inside *active*. They
+    can override registry-derived addresses on collision (user wins).
     """
     active_pipeline_ids: list[str] = []
     if pipeline_manager:
@@ -178,12 +221,39 @@ def get_osc_paths(
         runtime_list.append({**p, "osc_address": f"/scope/{p['key']}"})
     active_groups["Runtime"] = runtime_list
 
+    # Track addresses already claimed by the graph inventory so we can
+    # suppress the registry-default flat path when the user has bound
+    # the same param somewhere else (e.g. /scope/main/prompt instead of
+    # /scope/prompt). Without this the same OSC address would appear
+    # twice and validation would prefer the wrong entry.
+    user_claimed_keys: set[str] = set()
+    user_claimed_pipeline_params: set[tuple[str, str]] = set()
+    for e in graph_inventory or []:
+        norm = _normalize_graph_entry(e)
+        user_claimed_keys.add(norm["key"])
+        pid = norm.get("pipeline_id")
+        param = norm.get("param")
+        if pid and param:
+            user_claimed_pipeline_params.add((pid, param))
+
     for pid, paths in pipeline_paths.items():
         target = active_groups if pid in active_pipeline_ids else available_groups
         group: list[dict[str, Any]] = []
         for p in paths:
+            # Skip the legacy flat entry when the user has explicitly
+            # bound this pipeline param via the graph inventory.
+            if (pid, p["key"]) in user_claimed_pipeline_params:
+                continue
             group.append({**p, "osc_address": f"/scope/{p['key']}"})
-        target[pid] = group
+        if group:
+            target[pid] = group
+
+    # Append graph-supplied entries under their own per-node groups so
+    # they're easy to scan in the docs page.
+    if graph_inventory:
+        normalized = [_normalize_graph_entry(e) for e in graph_inventory]
+        for label, entries in _group_graph_entries(normalized).items():
+            active_groups[label] = entries
 
     return {
         "active": active_groups,
@@ -194,12 +264,13 @@ def get_osc_paths(
 
 def get_all_known_paths(
     pipeline_manager: "PipelineManager | None",
+    graph_inventory: list[dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Return a flat dict mapping every known OSC key to its path metadata.
 
     Used by the OSC server for validating incoming messages.
     """
-    data = get_osc_paths(pipeline_manager)
+    data = get_osc_paths(pipeline_manager, graph_inventory)
     result: dict[str, dict[str, Any]] = {}
     for groups in (data["active"], data["available"]):
         for paths in groups.values():
@@ -293,7 +364,15 @@ def _path_row_html(path: dict[str, Any], osc_port: int, row_id: str) -> str:
         constraints.append(f"values: {path['enum']}")
     constraint_str = html.escape(", ".join(constraints)) if constraints else ""
 
-    example_val = _example_value(path)
+    default_str = html.escape(repr(path["default"])) if "default" in path else "&mdash;"
+
+    # Use the configured default in the example call when present, so the
+    # snippet reflects the user's chosen starting value rather than a
+    # synthetic mid-range guess.
+    if "default" in path:
+        example_val = repr(path["default"])
+    else:
+        example_val = _example_value(path)
     example_code = html.escape(
         f"from pythonosc.udp_client import SimpleUDPClient\n\n"
         f'client = SimpleUDPClient("127.0.0.1", {osc_port})\n'
@@ -306,10 +385,11 @@ def _path_row_html(path: dict[str, Any], osc_port: int, row_id: str) -> str:
         f"<td>{ptype}</td>"
         f"<td>{desc}</td>"
         f"<td>{constraint_str}</td>"
+        f"<td class='default'>{default_str}</td>"
         f'<td class="chevron">&#9654;</td>'
         f"</tr>\n"
         f'<tr id="{row_id}" class="example-row" style="display:none">'
-        f'<td colspan="5"><pre>{example_code}</pre></td>'
+        f'<td colspan="6"><pre>{example_code}</pre></td>'
         f"</tr>"
     )
 
@@ -329,7 +409,7 @@ def _render_source_group(
         f'<h3 class="source-header">{escaped_name}</h3>\n'
         f"<table><thead><tr>"
         f"<th>OSC Address</th><th>Type</th><th>Description</th>"
-        f"<th>Constraints</th><th></th>"
+        f"<th>Constraints</th><th>Default</th><th></th>"
         f"</tr></thead><tbody>\n{rows}\n</tbody></table>"
     )
 
@@ -337,9 +417,10 @@ def _render_source_group(
 def render_osc_docs_html(
     pipeline_manager: "PipelineManager | None",
     osc_port: int,
+    graph_inventory: list[dict[str, Any]] | None = None,
 ) -> str:
     """Render a self-contained HTML page documenting all current OSC paths."""
-    data = get_osc_paths(pipeline_manager)
+    data = get_osc_paths(pipeline_manager, graph_inventory)
     active_groups: dict[str, list] = data["active"]
     available_groups: dict[str, list] = data["available"]
 

--- a/src/scope/server/osc_server.py
+++ b/src/scope/server/osc_server.py
@@ -43,6 +43,11 @@ class OSCServer:
         # Cached path inventory to avoid rebuilding on every OSC message.
         self._known_paths_cache: dict[str, dict[str, Any]] | None = None
         self._known_paths_cache_time: float = 0.0
+        # Graph-supplied OSC inventory: list of path entries (see osc_docs).
+        # Populated by POST /api/v1/osc/inventory whenever the frontend's
+        # graph oscConfig changes. None means "no graph inventory yet" —
+        # behavior falls back to registry-derived paths only.
+        self._graph_inventory: list[dict[str, Any]] | None = None
 
     @property
     def port(self) -> int:
@@ -74,6 +79,20 @@ class OSCServer:
         # Invalidate the path cache when managers change.
         self._known_paths_cache = None
 
+    def set_graph_inventory(self, paths: list[dict[str, Any]] | None) -> None:
+        """Replace the graph-supplied OSC path inventory.
+
+        Called by ``POST /api/v1/osc/inventory`` whenever the frontend
+        recomputes its OSC paths from the graph. ``None`` clears the
+        inventory and reverts to registry-derived paths only.
+        """
+        self._graph_inventory = paths
+        self._known_paths_cache = None
+
+    @property
+    def graph_inventory(self) -> list[dict[str, Any]] | None:
+        return self._graph_inventory
+
     def subscribe(self) -> "asyncio.Queue[dict[str, Any]]":
         """Register a new SSE subscriber and return its event queue."""
         q: asyncio.Queue = asyncio.Queue(maxsize=100)
@@ -96,7 +115,9 @@ class OSCServer:
         ):
             from .osc_docs import get_all_known_paths
 
-            self._known_paths_cache = get_all_known_paths(self._pipeline_manager)
+            self._known_paths_cache = get_all_known_paths(
+                self._pipeline_manager, self._graph_inventory
+            )
             self._known_paths_cache_time = now
         return self._known_paths_cache
 
@@ -145,14 +166,40 @@ class OSCServer:
         if self._log_all_messages:
             logger.info("OSC OK  %s = %r", address, value)
 
-        # Apply the parameter immediately to all active local sessions so
-        # the pipeline effect takes place without waiting for the frontend
-        # round-trip.
+        # Route the value to the right consumer. Three cases:
+        #
+        #  1. Graph entry that targets a pipeline node — has `node_id` and
+        #     `pipeline_id`. Broadcast to WebRTC with `{node_id, <param>: value}`
+        #     so frame_processor.update_parameters can route to that processor
+        #     (frame_processor.py:828-839 already handles `node_id`).
+        #
+        #  2. Graph entry that targets a UI-only node (slider/knobs/etc.) —
+        #     has `node_id` but no pipeline_id. SSE only; the frontend
+        #     applies the value to the matching node via the React Flow
+        #     state (no backend processor exists for these).
+        #
+        #  3. Registry-derived entry (no `node_id`) — keeps the existing
+        #     flat-broadcast behavior so pre-existing TouchDesigner setups
+        #     using `/scope/prompt` etc. continue to work.
+        node_id = path_info.get("node_id")
+        param = path_info.get("param") or key
+        pipeline_id = path_info.get("pipeline_id")
+
         if self._webrtc_manager:
-            self._webrtc_manager.broadcast_parameter_update({key: value})
+            if node_id and pipeline_id:
+                self._webrtc_manager.broadcast_parameter_update(
+                    {"node_id": node_id, param: value}
+                )
+            elif not node_id:
+                self._webrtc_manager.broadcast_parameter_update({key: value})
 
         # Push to all SSE subscribers so the frontend can sync its UI state.
+        # Include `node_id` when present so the consumer can route to the
+        # specific React Flow node (UI-only nodes rely entirely on this).
         event: dict[str, Any] = {"type": "osc_command", "key": key, "value": value}
+        if node_id:
+            event["node_id"] = node_id
+            event["param"] = param
         for q in list(self._sse_queues):
             try:
                 q.put_nowait(event)


### PR DESCRIPTION
Closes the three OSC pain points reported by a user building a TouchDesigner controller rig:

1. **Source / Sink / Slider / Knobs / etc. now reachable via OSC** — previously only pipeline params from the registry were exposed.
2. **Per-param opt-in** — right-click any node → "Configure OSC…" picks which params external clients can hit.
3. **Defaults in the OSC description** — `/api/v1/osc/paths` and `/api/v1/osc/docs` now include a `default` for each path.

## How it works

- The frontend computes an OSC inventory from the live graph plus each node's new `oscConfig` overlay (`{paramName: {exposed, address?, default?}}`) and POSTs it to a new `POST /api/v1/osc/inventory` endpoint.
- The OSC server merges the graph inventory with the registry-derived paths for validation, broadcast, and discovery.
- Pipeline-targeted OSC messages broadcast to WebRTC with `{node_id, param: value}` so `frame_processor.update_parameters` routes to the right pipeline processor.
- UI-only node messages skip WebRTC and reach the frontend through the existing SSE `osc_command` event; `StreamPage`'s handler now forwards `node_id`+`param` to `graphEditorRef.applyExternalParams(...)`, so any field on `node.data` can be addressed without new backend processors.

## Address format

- Default address: `/scope/<slugified-customTitle>/<param>` (per-node namespacing avoids collisions when you have two pipelines or two sliders).
- Each row in the Configure OSC modal has an editable address — paste any path you want.
- Pipeline runtime params keep their flat `/scope/<param>` back-compat default; the legacy address is only suppressed when the user has explicitly re-bound that param via Configure OSC. Existing TouchDesigner setups don't break.

## Backend changes

- `src/scope/server/osc_docs.py` — `_extract_osc_paths_from_schema` now includes `default`. `get_osc_paths` / `get_all_known_paths` accept a `graph_inventory` arg and merge it; HTML docs render a Default column.
- `src/scope/server/osc_server.py` — new `set_graph_inventory` setter; `_handle_osc_message` routes pipeline params via `{node_id, param: value}` to WebRTC, UI-only params via SSE only.
- `src/scope/server/app.py` — new `POST /api/v1/osc/inventory` endpoint with Pydantic models.

## Frontend changes

- `frontend/src/lib/oscNodeParams.ts` — NEW: per-node-type param descriptors (Source, Output, Slider, XYPad, Bool, Trigger, Tempo, Primitive, Note).
- `frontend/src/components/graph/OscConfigDialog.tsx` — NEW: per-node Configure OSC modal.
- `frontend/src/components/graph/hooks/graph/useOscInventory.ts` — NEW: derives inventory + debounced POST.
- `frontend/src/components/graph/contextMenuItems.tsx` — adds "Configure OSC…" item.
- `frontend/src/components/graph/GraphEditor.tsx` — wires the modal + the inventory hook.
- `frontend/src/lib/graphUtils.ts` — adds `oscConfig` to `FlowNodeData` (round-trips through `ui_state.nodes[*].data`).
- `frontend/src/lib/api.ts` — adds `OscInventoryEntry`, `OscPathsResponse`, `setOscInventory`, `fetchOscPaths`.
- `frontend/src/pages/StreamPage.tsx` — OSC handler routes `node_id`+`param` to `applyExternalParams`.
- `frontend/src/components/settings/OscTab.tsx` — adds a live "Currently exposed paths" panel with click-to-copy.

---

## How to test

Spin up Scope (`uv run daydream-scope`) — OSC listens on UDP `8000` (same port as the HTTP server). All `python-osc` snippets below assume `pip install python-osc` is available; or use `uv run python -c '…'`.

### 1. Quick visual sanity (30s)

- **Settings → OSC tab**: new **"Currently exposed paths"** panel below the existing controls. Empty initially with a hint pointing at "Configure OSC…".
- **Right-click any node** on the canvas: new **"Configure OSC…"** menu item appears between Pin and Delete.

### 2. UI-node opt-in (the headline new case — Slider)

1. Add a **Slider** node (`+` upper right → UI → Slider, or right-click canvas → UI → Slider).
2. Click the title and rename it to e.g. `Tempo` so the auto-address is meaningful.
3. Right-click the slider → **Configure OSC…**
4. In the modal:
   - Tick **Expose** on the `value` row
   - Address auto-fills as `/scope/tempo/value`
   - Default field placeholder shows the current slider value (e.g. `0.5`); leave it or type `1.0`
   - **Save**
5. Settings → OSC → click **Refresh** → confirm `/scope/tempo/value` appears under the "Tempo" group with the default.
6. Click **"Open OSC Docs"** → confirm the path is listed with the **Default** column populated.
7. Drive it from the outside:
   ```bash
   uv run python -c "from pythonosc.udp_client import SimpleUDPClient as C; C('127.0.0.1', 8000).send_message('/scope/tempo/value', 0.85)"
   ```
   Watch the slider snap to 0.85 in real time.

### 3. Source / Output (the originally-blocked case)

1. Add a **Source** node, right-click → Configure OSC.
2. Expose **`sourceMode`** (it's an enum with values `video` / `camera` / `spout` / `ndi` / `syphon`). Save.
3. Send `'/scope/source/sourceMode', 'ndi'` → dropdown switches in the UI.
4. Repeat on an **Output** node with **`outputSinkEnabled`** (bool) — toggle from off → on via OSC.

### 4. Pipeline node namespacing (multi-pipeline collision)

1. Load a workflow with two pipeline nodes that share a runtime param (e.g. both expose `prompt`).
2. Title them `Main` and `Secondary`.
3. Configure OSC on each → expose `prompt` → save.
4. Send to `/scope/main/prompt` vs `/scope/secondary/prompt` independently → only the matching node updates.

### 5. Backwards compatibility

Without configuring anything new, legacy flat addresses still work:
```bash
uv run python -c "from pythonosc.udp_client import SimpleUDPClient as C; C('127.0.0.1', 8000).send_message('/scope/noise_scale', 0.6)"
```
The pipeline's `noise_scale` updates as before. Pre-existing TouchDesigner setups are unaffected.

### 6. Defaults in description

```bash
curl -s http://localhost:8000/api/v1/osc/paths | jq '.active.Runtime[] | {key, default}'
```
Every entry that has a schema default should show it. Open `http://localhost:8000/api/v1/osc/docs` in a browser → the new **Default** column is populated.

### 7. Persistence

Configure OSC on a node, save, refresh the page. The graph reloads with `oscConfig` intact and the inventory is re-pushed to the backend within ~300ms.

### 8. Lint + build

```bash
uv run ruff check src/ && uv run ruff format --check src/
cd frontend && npm run lint && npm run format:check && npm run build
```

## Known limitations (not in this PR)

- **Address slug collisions** aren't surfaced in the UI yet — two same-titled sliders both compute to `/scope/<title>/value`; the latest registered wins. Workaround: rename one or override the address. A warning indicator is planned for a follow-up.
- **Composite-shape params** (knobs[], midiChannels[], tupleValues[]) are skipped for the MVP — they need a richer addressing scheme (per-index sub-paths). Will follow.
- The user-set "default" is **advisory metadata** — it's published in the OSC docs so external clients can match Scope's starting state, but Scope does not auto-emit it on session start. Auto-apply behavior is a deliberate follow-up to keep this PR focused on description vs. behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)