### PR TITLE
Reject Hugging Face /blob/ LoRA URLs with a friendly hint

### DIFF
--- a/frontend/src/components/settings/LoRAsTab.tsx
+++ b/frontend/src/components/settings/LoRAsTab.tsx
@@ -1,7 +1,29 @@
-import { RefreshCw, Trash2 } from "lucide-react";
+import { RefreshCw, Trash2, AlertTriangle } from "lucide-react";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import type { LoRAFileInfo } from "@/lib/api";
+
+/**
+ * Detect a Hugging Face file *preview page* URL. These look like
+ * `https://huggingface.co/<repo>/blob/main/<file>` and are NOT raw
+ * downloads — pasting them silently saves the HTML preview as the
+ * weights file. The HF "Copy download link" button produces the
+ * correct `/resolve/main/` form. We surface this as inline guidance
+ * before submit (and the backend rejects them too).
+ */
+function isHuggingFaceBlobUrl(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return false;
+  }
+  const host = parsed.hostname.toLowerCase();
+  const isHf = host === "huggingface.co" || host.endsWith(".huggingface.co");
+  return isHf && parsed.pathname.includes("/blob/");
+}
 
 interface LoRAsTabProps {
   loraFiles: LoRAFileInfo[];
@@ -26,10 +48,12 @@ export function LoRAsTab({
   isInstalling = false,
   deletingLoRAs = new Set(),
 }: LoRAsTabProps) {
+  const isBlobUrl = isHuggingFaceBlobUrl(installUrl);
+
   const handleInstall = () => {
-    if (installUrl.trim()) {
-      onInstall(installUrl.trim());
-    }
+    const trimmed = installUrl.trim();
+    if (!trimmed || isBlobUrl) return;
+    onInstall(trimmed);
   };
 
   // Group LoRA files by folder
@@ -54,7 +78,7 @@ export function LoRAsTab({
   return (
     <div className="space-y-4">
       {/* Install Section */}
-      <div className="rounded-lg bg-muted/50 p-4 space-y-4">
+      <div className="rounded-lg bg-muted/50 p-4 space-y-2">
         <div className="flex items-center gap-2">
           <Input
             value={installUrl}
@@ -64,16 +88,30 @@ export function LoRAsTab({
             onKeyDown={e => {
               if (e.key === "Enter") handleInstall();
             }}
+            aria-invalid={isBlobUrl || undefined}
           />
           <Button
             onClick={handleInstall}
             variant="outline"
             size="sm"
-            disabled={isInstalling || !installUrl.trim()}
+            disabled={isInstalling || !installUrl.trim() || isBlobUrl}
           >
             {isInstalling ? "Installing..." : "Install"}
           </Button>
         </div>
+        {isBlobUrl && (
+          <div className="flex items-start gap-2 text-xs text-amber-400/90">
+            <AlertTriangle className="h-3.5 w-3.5 mt-[1px] shrink-0" />
+            <span>
+              That looks like a Hugging Face <em>preview</em> page. On the
+              LoRA&rsquo;s file page, click{" "}
+              <strong>&ldquo;Copy download link&rdquo;</strong> and paste that
+              URL instead (the correct one contains{" "}
+              <code className="font-mono">/resolve/main/</code>, not{" "}
+              <code className="font-mono">/blob/main/</code>).
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Installed LoRAs Section */}

--- a/frontend/src/components/settings/LoRAsTab.tsx
+++ b/frontend/src/components/settings/LoRAsTab.tsx
@@ -10,7 +10,12 @@ import type { LoRAFileInfo } from "@/lib/api";
  * weights file. The HF "Copy download link" button produces the
  * correct `/resolve/main/` form. We surface this as inline guidance
  * before submit (and the backend rejects them too).
+ *
+ * Also handles `hf.co`, the official Hugging Face short domain that
+ * redirects to huggingface.co.
  */
+const HUGGING_FACE_HOSTS = ["huggingface.co", "hf.co"];
+
 function isHuggingFaceBlobUrl(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) return false;
@@ -21,7 +26,9 @@ function isHuggingFaceBlobUrl(raw: string): boolean {
     return false;
   }
   const host = parsed.hostname.toLowerCase();
-  const isHf = host === "huggingface.co" || host.endsWith(".huggingface.co");
+  const isHf = HUGGING_FACE_HOSTS.some(
+    h => host === h || host.endsWith(`.${h}`)
+  );
   return isHf && parsed.pathname.includes("/blob/");
 }
 

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -1640,6 +1640,25 @@ async def install_lora_file(
     parsed = urlparse(url)
     hostname = parsed.hostname or ""
     is_civitai = hostname == "civitai.com" or hostname.endswith(".civitai.com")
+    is_huggingface = hostname == "huggingface.co" or hostname.endswith(
+        ".huggingface.co"
+    )
+
+    # Reject HuggingFace "blob" URLs — these point at the file's HTML preview
+    # page (e.g. /Repo/blob/main/file.safetensors), not the raw download.
+    # Pasting one would either 404 or save HTML as a .safetensors file. The
+    # correct URL uses /resolve/main/, which the HF "Copy download link"
+    # button on the file's page produces. Apply this *before* cloud proxying
+    # so users get the same friendly error in both local and cloud modes.
+    if is_huggingface and "/blob/" in parsed.path:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This is a Hugging Face file preview page, not a download link. "
+                'Open the file on the LoRA page and click "Copy download link" '
+                "(it will contain /resolve/main/ instead of /blob/main/)."
+            ),
+        )
 
     if is_civitai:
         query_params = parse_qs(parsed.query)

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -1617,7 +1617,16 @@ class LoRAInstallResponse(BaseModel):
     file: LoRAFileInfo
 
 
-ALLOWED_LORA_HOSTS = {"civitai.com", "huggingface.co"}
+ALLOWED_LORA_HOSTS = {"civitai.com", "huggingface.co", "hf.co"}
+
+# Hosts that resolve to Hugging Face. `hf.co` is the official short
+# domain and redirects to huggingface.co. We treat both identically for
+# blob-vs-resolve detection and provenance tagging.
+_HUGGINGFACE_HOSTS = ("huggingface.co", "hf.co")
+
+
+def _is_huggingface_host(hostname: str) -> bool:
+    return any(hostname == h or hostname.endswith(f".{h}") for h in _HUGGINGFACE_HOSTS)
 
 
 @app.post("/api/v1/loras", response_model=LoRAInstallResponse)
@@ -1640,9 +1649,7 @@ async def install_lora_file(
     parsed = urlparse(url)
     hostname = parsed.hostname or ""
     is_civitai = hostname == "civitai.com" or hostname.endswith(".civitai.com")
-    is_huggingface = hostname == "huggingface.co" or hostname.endswith(
-        ".huggingface.co"
-    )
+    is_huggingface = _is_huggingface_host(hostname)
 
     # Reject HuggingFace "blob" URLs — these point at the file's HTML preview
     # page (e.g. /Repo/blob/main/file.safetensors), not the raw download.
@@ -1809,7 +1816,7 @@ async def install_lora_file(
         source: str
         if is_civitai:
             source = "civitai"
-        elif hostname == "huggingface.co" or hostname.endswith(".huggingface.co"):
+        elif _is_huggingface_host(hostname):
             source = "huggingface"
         else:
             source = "url"


### PR DESCRIPTION
## Summary

Reported case: a user pasted a Hugging Face file *preview page* URL into the LoRA installer:

```
https://huggingface.co/Alissonerdx/LTX-LoRAs/blob/main/ltx23_inpaint_masked_t2v_rank128_v1_02500steps.safetensors
```

That URL points at the HTML preview, not the raw weights — the correct download URL uses `/resolve/main/` and is what the HF **"Copy download link"** button produces. Without this guard the installer would either 404 or silently save HTML as a `.safetensors` file.

## Fix

Detect HF blob URLs and refuse them up front in two places:

- **Backend** ([`src/scope/server/app.py`](src/scope/server/app.py)): `POST /api/v1/loras` returns 400 before any download attempt — runs *before* the cloud proxy so the same friendly error reaches users in both local and cloud-proxy modes.
- **Frontend** ([`frontend/src/components/settings/LoRAsTab.tsx`](frontend/src/components/settings/LoRAsTab.tsx)): inline amber hint shows as soon as the user pastes a blob URL, with the exact phrase **"Copy download link"** so the fix is unambiguous. Install button is disabled until the URL is corrected.

The error message:
> This is a Hugging Face file preview page, not a download link. Open the file on the LoRA page and click "Copy download link" (it will contain `/resolve/main/` instead of `/blob/main/`).

## Smoke test (confirmed)

| URL | Result |
|---|---|
| `https://huggingface.co/<repo>/blob/main/file.safetensors` | 400 with friendly message ✓ |
| Same with `?download=true` query string | 400 ✓ |
| `https://huggingface.co/<repo>/resolve/main/file.safetensors` | passes the blob check ✓ |
| `https://civitai.com/api/download/models/12345` | downloaded successfully ✓ |

## Test plan

- [ ] Paste the reported blob URL → see inline hint, Install disabled
- [ ] Paste blob URL with `?download=true` → still detected
- [ ] Replace `/blob/` with `/resolve/` → hint clears, Install enabled
- [ ] Direct API call (cURL) with blob URL → 400 with the friendly message
- [ ] CivitAI URL still installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)