### PR TITLE
Upload LTX-specific assets

### DIFF
--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -3187,13 +3187,16 @@ export function StreamPage() {
           params = await rewriteAssetFields(
             initialParameters,
             [
-              // Only rewrite preview-page initial parameter fields here; other
-              // graph node media types like audio are forwarded separately and
-              // are not part of this initialParameters payload.
+              // Rewrite known media fields present in initialParameters.
+              // Graph media nodes may also feed these fields through graph
+              // node params; separate graph media forwarding still happens
+              // through useValueForwarding during streaming.
               { key: "images", kind: "image" },
               { key: "vace_ref_images", kind: "image" },
               { key: "first_frame_image", kind: "image" },
               { key: "last_frame_image", kind: "image" },
+              { key: "i2v_image", kind: "image" },
+              { key: "audio_input", kind: "audio" },
             ],
             uploadCacheRef.current
           );


### PR DESCRIPTION
Fix cloud streaming for LTX 2.3 graph workflows that pass an audio reference through initial pipeline parameters by extending the existing frontend asset rewrite path.

Add LTX 2.3 schema media fields to rewriteAssetFields: { key: "audio_input", kind: "audio" }
{ key: "i2v_image", kind: "image" }

Eventually we might want to ensure that pipelines hang off a proper media node which can be processed generically, rather than encoding local paths into slots.

Alternative to the asset-upload changes in https://github.com/daydreamlive/scope/pull/999