### PR TITLE
Delay A/V in WebRTC until both tracks have been seen.

### DIFF
--- a/src/scope/server/audio_track.py
+++ b/src/scope/server/audio_track.py
@@ -88,14 +88,16 @@ class AudioProcessingTrack(MediaStreamTrack):
             raise MediaStreamError
 
         # aiortc timing pattern: monotonic timestamp counter with wall-clock pacing
-        if self._start is not None:
+        if self._start is None:
+            self.frame_processor.notify_first_audio_packet()
+            await asyncio.to_thread(self.frame_processor.wait_for_av_sync_anchor)
+            self._start = time.time()
+            self._timestamp = 0
+        else:
             self._timestamp += self._samples_per_frame
             wait = self._start + (self._timestamp / AUDIO_CLOCK_RATE) - time.time()
             if wait > 0:
                 await asyncio.sleep(wait)
-        else:
-            self._start = time.time()
-            self._timestamp = 0
 
         if self.frame_processor.paused:
             return self._create_silence_frame()

--- a/src/scope/server/audio_track.py
+++ b/src/scope/server/audio_track.py
@@ -87,13 +87,11 @@ class AudioProcessingTrack(MediaStreamTrack):
         if self.readyState != "live":
             raise MediaStreamError
 
-        # aiortc timing pattern: monotonic timestamp counter with wall-clock pacing
+        samples_needed = self._samples_per_frame * self.channels
         if self._start is None:
-            self.frame_processor.notify_first_audio_packet()
-            await asyncio.to_thread(self.frame_processor.wait_for_av_sync_anchor)
-            self._start = time.time()
-            self._timestamp = 0
+            await self._wait_for_initial_audio(samples_needed)
         else:
+            # aiortc timing pattern: monotonic timestamp counter with wall-clock pacing
             self._timestamp += self._samples_per_frame
             wait = self._start + (self._timestamp / AUDIO_CLOCK_RATE) - time.time()
             if wait > 0:
@@ -102,6 +100,76 @@ class AudioProcessingTrack(MediaStreamTrack):
         if self.frame_processor.paused:
             return self._create_silence_frame()
 
+        # Pull in any newly generated packets before deciding whether this
+        # tick has enough buffered audio or should fall back to silence.
+        self._drain_audio_packets()
+        self._trim_buffer()
+
+        # Serve a 20ms frame from the buffer
+        if self._buffered_samples >= samples_needed:
+            frame_parts: list[np.ndarray] = []
+            remaining = samples_needed
+            preserved_pts: int | None = None
+            first_chunk = True
+
+            while remaining > 0 and self._chunks:
+                chunk, pts = self._chunks[0]
+                take = min(len(chunk), remaining)
+                if first_chunk:
+                    # The emitted frame inherits the timestamp of its first
+                    # output sample.
+                    preserved_pts = pts
+                    first_chunk = False
+
+                frame_parts.append(chunk[:take])
+                if take == len(chunk):
+                    self._chunks.popleft()
+                else:
+                    # The leftover tail becomes a new buffered chunk whose
+                    # first-sample PTS advances by the number of consumed
+                    # output samples.
+                    shifted_pts = None if pts is None else pts + (take // self.channels)
+                    self._chunks[0] = (chunk[take:], shifted_pts)
+
+                self._buffered_samples -= take
+                remaining -= take
+
+            frame_samples = np.concatenate(frame_parts)
+            frame_pts = preserved_pts
+            if frame_pts is not None:
+                if (
+                    self._last_preserved_pts is None
+                    or frame_pts > self._last_preserved_pts
+                ):
+                    self._last_preserved_pts = frame_pts
+                else:
+                    logger.warning(
+                        "Ignoring non-monotonic preserved audio timestamp in AudioProcessingTrack"
+                    )
+                    frame_pts = None
+            return self._create_audio_frame(frame_samples, pts_override=frame_pts)
+
+        return self._create_silence_frame()
+
+    async def _wait_for_initial_audio(self, samples_needed: int) -> None:
+        while self._buffered_samples < samples_needed:
+            if self.readyState != "live":
+                raise MediaStreamError
+
+            if not self.frame_processor.paused:
+                self._drain_audio_packets()
+                self._trim_buffer()
+                if self._buffered_samples >= samples_needed:
+                    break
+
+            await asyncio.sleep(0.01)
+
+        self.frame_processor.notify_first_audio_packet()
+        await asyncio.to_thread(self.frame_processor.wait_for_av_sync_anchor)
+        self._start = time.time()
+        self._timestamp = 0
+
+    def _drain_audio_packets(self) -> None:
         # Drain all available audio from the queue to minimise latency
         # for bursty or small-chunk pipelines.
         while True:
@@ -159,6 +227,7 @@ class AudioProcessingTrack(MediaStreamTrack):
             self._chunks.append((interleaved, chunk_pts))
             self._buffered_samples += len(interleaved)
 
+    def _trim_buffer(self) -> None:
         # Cap buffer to prevent unbounded growth.
         # Trim-to-tail: concatenate and keep only the newest samples so a
         # single large chunk (e.g. LTX2 delivering >1s at once) is never
@@ -182,53 +251,6 @@ class AudioProcessingTrack(MediaStreamTrack):
 
         if self._buffered_samples > max_interleaved:
             logger.warning("Audio buffer overflow, dropped oldest chunks")
-
-        # Serve a 20ms frame from the buffer
-        samples_needed = self._samples_per_frame * self.channels
-        if self._buffered_samples >= samples_needed:
-            frame_parts: list[np.ndarray] = []
-            remaining = samples_needed
-            preserved_pts: int | None = None
-            first_chunk = True
-
-            while remaining > 0 and self._chunks:
-                chunk, pts = self._chunks[0]
-                take = min(len(chunk), remaining)
-                if first_chunk:
-                    # The emitted frame inherits the timestamp of its first
-                    # output sample.
-                    preserved_pts = pts
-                    first_chunk = False
-
-                frame_parts.append(chunk[:take])
-                if take == len(chunk):
-                    self._chunks.popleft()
-                else:
-                    # The leftover tail becomes a new buffered chunk whose
-                    # first-sample PTS advances by the number of consumed
-                    # output samples.
-                    shifted_pts = None if pts is None else pts + (take // self.channels)
-                    self._chunks[0] = (chunk[take:], shifted_pts)
-
-                self._buffered_samples -= take
-                remaining -= take
-
-            frame_samples = np.concatenate(frame_parts)
-            frame_pts = preserved_pts
-            if frame_pts is not None:
-                if (
-                    self._last_preserved_pts is None
-                    or frame_pts > self._last_preserved_pts
-                ):
-                    self._last_preserved_pts = frame_pts
-                else:
-                    logger.warning(
-                        "Ignoring non-monotonic preserved audio timestamp in AudioProcessingTrack"
-                    )
-                    frame_pts = None
-            return self._create_audio_frame(frame_samples, pts_override=frame_pts)
-
-        return self._create_silence_frame()
 
     def _create_audio_frame(
         self, samples: np.ndarray, pts_override: int | None = None

--- a/src/scope/server/cloud_track.py
+++ b/src/scope/server/cloud_track.py
@@ -85,6 +85,7 @@ class CloudTrack(MediaStreamTrack):
         self.frame_processor = frame_processor
         self._last_frame: VideoFrame | None = None
         self._started = False
+        self._first_frame_emitted = False
 
         # Multi-source / multi-sink / record (wired up in _start after cloud connects)
         # Store (source_node_id, track). Resolving to a cloud input track index
@@ -269,6 +270,12 @@ class CloudTrack(MediaStreamTrack):
                     packet = ensure_video_packet(frame_packet)
                     frame_np = packet.tensor.numpy()
                     frame = VideoFrame.from_ndarray(frame_np, format="rgb24")
+                    if not self._first_frame_emitted:
+                        self._first_frame_emitted = True
+                        self.frame_processor.notify_first_video_packet()
+                        await asyncio.to_thread(
+                            self.frame_processor.wait_for_av_sync_anchor
+                        )
                     if self.preserve_output_timestamps and packet.timestamp.is_valid:
                         frame.pts = packet.timestamp.pts
                         frame.time_base = packet.timestamp.time_base
@@ -413,7 +420,7 @@ class CloudSinkOutputTrack(MediaStreamTrack):
 
     kind = "video"
 
-    def __init__(self, fps: int = 30):
+    def __init__(self, fps: int = 30, frame_processor: FrameProcessor | None = None):
         super().__init__()
         self._queue: asyncio.Queue[VideoFrame] = asyncio.Queue(maxsize=2)
         self.fps = fps
@@ -421,6 +428,8 @@ class CloudSinkOutputTrack(MediaStreamTrack):
         self._pts: int = 0
         self._last_send_time: float | None = None
         self._last_frame: VideoFrame | None = None
+        self._first_frame_emitted = False
+        self._frame_processor = frame_processor
 
     def put_frame(self, frame: VideoFrame) -> None:
         """Enqueue a frame received from cloud (drop-if-full)."""
@@ -439,6 +448,14 @@ class CloudSinkOutputTrack(MediaStreamTrack):
                 else:
                     await asyncio.sleep(0.01)
                     continue
+
+            if not self._first_frame_emitted:
+                self._first_frame_emitted = True
+                if self._frame_processor is not None:
+                    self._frame_processor.notify_first_video_packet()
+                    await asyncio.to_thread(
+                        self._frame_processor.wait_for_av_sync_anchor
+                    )
 
             # Pace output
             if self._last_send_time is not None:

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -145,6 +145,17 @@ class FrameProcessor:
         self._last_heartbeat_time = time.time()
         self._playback_ready_emitted = False
         self._stream_start_time: float | None = None
+        self._stream_start_wall: float | None = None
+
+        # A/V sync anchor barrier for first RTP packet alignment.
+        self._expects_video = False
+        self._expects_audio = False
+        self._first_video_wall: float | None = None
+        self._first_audio_wall: float | None = None
+        self._first_video_event = threading.Event()
+        self._first_audio_event = threading.Event()
+        self._av_sync_lock = threading.Lock()
+        self._av_sync_logged = False
 
         # Store pipeline_ids from initial_parameters if provided
         pipeline_ids = (initial_parameters or {}).get("pipeline_ids")
@@ -188,7 +199,17 @@ class FrameProcessor:
         self._last_heartbeat_time = time.time()
         self._playback_ready_emitted = False
         self._stream_start_time = time.monotonic()
+        self._stream_start_wall = time.time()
         self._last_stats_time = time.time()
+        self._first_video_wall = None
+        self._first_audio_wall = None
+        self._first_video_event = threading.Event()
+        self._first_audio_event = threading.Event()
+        self._av_sync_logged = False
+        if not self._expects_video:
+            self._first_video_event.set()
+        if not self._expects_audio:
+            self._first_audio_event.set()
 
         if self._cloud_relay is not None:
             # Cloud mode: frames go to cloud instead of local pipelines
@@ -638,6 +659,80 @@ class FrameProcessor:
         if fps is not None:
             return fps
         return self.get_fps()
+
+    def set_expected_kinds(self, video: bool, audio: bool) -> None:
+        """Declare whether this session expects first video/audio packets."""
+        with self._av_sync_lock:
+            self._expects_video = video
+            self._expects_audio = audio
+
+            if not self._expects_video or self._first_video_wall is not None:
+                self._first_video_event.set()
+            else:
+                self._first_video_event.clear()
+            if not self._expects_audio or self._first_audio_wall is not None:
+                self._first_audio_event.set()
+            else:
+                self._first_audio_event.clear()
+
+            self._maybe_log_av_sync_anchor()
+
+    def notify_first_video_packet(self) -> None:
+        """Record first video packet arrival and release barrier participants."""
+        with self._av_sync_lock:
+            if self._first_video_wall is None:
+                self._first_video_wall = time.time()
+            self._first_video_event.set()
+            self._maybe_log_av_sync_anchor()
+
+    def notify_first_audio_packet(self) -> None:
+        """Record first audio packet arrival and release barrier participants."""
+        with self._av_sync_lock:
+            if self._first_audio_wall is None:
+                self._first_audio_wall = time.time()
+            self._first_audio_event.set()
+            self._maybe_log_av_sync_anchor()
+
+    def wait_for_av_sync_anchor(self) -> None:
+        """Wait for expected first audio/video packet arrival events."""
+        self._first_video_event.wait()
+        self._first_audio_event.wait()
+
+    def _maybe_log_av_sync_anchor(self) -> None:
+        if self._av_sync_logged:
+            return
+        if not (self._expects_video and self._expects_audio):
+            return
+        if self._first_video_wall is None or self._first_audio_wall is None:
+            return
+
+        self._av_sync_logged = True
+        delta_ms = int(round((self._first_audio_wall - self._first_video_wall) * 1000))
+        held = "none"
+        if delta_ms < 0:
+            held = "audio"
+        elif delta_ms > 0:
+            held = "video"
+
+        if self._stream_start_wall is None:
+            audio_first_ms = None
+            video_first_ms = None
+        else:
+            audio_first_ms = int(
+                round((self._first_audio_wall - self._stream_start_wall) * 1000)
+            )
+            video_first_ms = int(
+                round((self._first_video_wall - self._stream_start_wall) * 1000)
+            )
+
+        logger.info(
+            "[FRAME-PROCESSOR] A/V sync anchor: audio_first=%sms "
+            "video_first=%sms delta=audio-video=%+dms (held=%s)",
+            audio_first_ms,
+            video_first_ms,
+            delta_ms,
+            held,
+        )
 
     def _on_frame_output(self, packet: VideoPacket) -> None:
         """Common post-output logic: increment counter, emit playback_ready, fan out to sinks."""

--- a/src/scope/server/tracks.py
+++ b/src/scope/server/tracks.py
@@ -171,6 +171,7 @@ class NodeOutputTrack(MediaStreamTrack):
         self._fps_getter = fps_getter
         self._ts = {"fps": 30, "_pts": 0, "_last_send_time": None}
         self._pacing = MediaPacingState()
+        self._first_frame_emitted = False
 
     async def recv(self) -> VideoFrame:
         fp = self._frame_processor
@@ -185,6 +186,12 @@ class NodeOutputTrack(MediaStreamTrack):
                 frame = ensure_even_video_frame(
                     VideoFrame.from_ndarray(packet.tensor.numpy(), format="rgb24")
                 )
+                if not self._first_frame_emitted:
+                    self._first_frame_emitted = True
+                    self._frame_processor.notify_first_video_packet()
+                    await asyncio.to_thread(
+                        self._frame_processor.wait_for_av_sync_anchor
+                    )
                 if packet.timestamp.is_valid:
                     await _pace_preserved_timestamp(self, self._pacing, packet)
                     frame.pts = packet.timestamp.pts
@@ -284,6 +291,7 @@ class VideoProcessingTrack(MediaStreamTrack):
         self._frame_lock = threading.Lock()
         self._ts = {"fps": fps, "_pts": 0, "_last_send_time": None}
         self._pacing = MediaPacingState()
+        self._first_frame_emitted = False
 
         # Server-side input mode - when enabled, frames come from the backend
         # instead of WebRTC (no browser video track needed)
@@ -352,6 +360,12 @@ class VideoProcessingTrack(MediaStreamTrack):
                         )
 
                 if frame is not None:
+                    if not self._first_frame_emitted:
+                        self._first_frame_emitted = True
+                        self.frame_processor.notify_first_video_packet()
+                        await asyncio.to_thread(
+                            self.frame_processor.wait_for_av_sync_anchor
+                        )
                     if packet is not None and packet.timestamp.is_valid:
                         await _pace_preserved_timestamp(self, self._pacing, packet)
                         frame.pts = packet.timestamp.pts

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -353,6 +353,7 @@ class WebRTCManager:
             # used here because they may be stale from a previous pipeline load.
             pipeline_ids = initial_parameters.get("pipeline_ids", [])
             produces_video = NodeRegistry.chain_produces_video(pipeline_ids)
+            produces_audio = NodeRegistry.chain_produces_audio(pipeline_ids)
 
             # Parse graph from initial parameters to find sink/source/record node IDs
             (
@@ -435,6 +436,10 @@ class WebRTCManager:
                 connection_info=request.connection_info,
                 tempo_sync=tempo_sync,
             )
+            frame_processor.set_expected_kinds(
+                video=produces_video,
+                audio=produces_audio,
+            )
             frame_processor.start()
             session.frame_processor = frame_processor
 
@@ -502,7 +507,6 @@ class WebRTCManager:
                     "skipping video track"
                 )
 
-            produces_audio = NodeRegistry.chain_produces_audio(pipeline_ids)
             if produces_audio:
                 audio_track = AudioProcessingTrack(
                     frame_processor=frame_processor,
@@ -886,6 +890,11 @@ class WebRTCManager:
                 )
                 session.audio_track = audio_track
 
+            frame_processor.set_expected_kinds(
+                video=produces_video,
+                audio=produces_audio,
+            )
+
             # Recording setup (local recording from relayed cloud frames)
             recording_param = initial_parameters.get("recording")
             recording_enabled = bool(recording_param)
@@ -1066,7 +1075,7 @@ class WebRTCManager:
                     f"transceivers for {len(sink_node_ids) - 1} extra sink(s)"
                 )
                 for i, sink_id in enumerate(sink_node_ids[1:]):
-                    extra_track = CloudSinkOutputTrack()
+                    extra_track = CloudSinkOutputTrack(frame_processor=frame_processor)
                     extra_sink_tracks.append(extra_track)
                     session.additional_tracks.append(extra_track)
                     relayed = relay.subscribe(extra_track)


### PR DESCRIPTION
[Delay A/V in WebRTC until both tracks have been seen.](https://github.com/daydreamlive/scope/commit/e716e7e64a9896b5a5ffdb703df5c7f7c77a8e85) 
For LTX-2 the cloud runs video VAE decode → audio decode sequentially,
so audio is ready before video is, often several hundred ms.

In aiortc WebRTC, RTCP SR anchors the PTS-to-wallclock mapping based
on the time the first frame was seen. Since both tracks start at
PTS=0, this caused a permanent desync if one track arrived late
relative to the other.

Fix this by waiting until both tracks have been seen.

---

Then a small refactor to how audio tracks are read:

[Wait for audio before starting AV sync](https://github.com/daydreamlive/scope/commit/c91a852202848849ab99416cf15c27be69512d58) 
Delay anchoring audio playback until the first buffered frame is available,
so startup and bursty generation do not emit premature silence that can
throw off AV sync.
