### PR TITLE
Unify plain-node and pipeline loading

### DIFF
--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -2784,8 +2784,24 @@ export function StreamPage() {
 
       const loadItems: PipelineLoadItem[] = graphConfigForStream
         ? graphConfigForStream.nodes
-            .filter(n => n.type === "pipeline" && n.pipeline_id)
+            .filter(
+              n =>
+                (n.type === "pipeline" && n.pipeline_id) ||
+                (n.type === "node" && n.node_type_id)
+            )
             .map(n => {
+              // Plain nodes (type="node") share the same registry as
+              // pipelines after the node/pipeline unification, so route
+              // them through /pipeline/load too. Their classes either
+              // ignore load_params or read defaults from per-node params
+              // at runtime, so an empty load_params is sufficient here.
+              if (n.type === "node") {
+                return {
+                  node_id: n.id,
+                  pipeline_id: n.node_type_id as string,
+                  load_params: {},
+                };
+              }
               const pid = n.pipeline_id as string;
               const pipeSchema = pipelines?.[pid];
               const nodeLoadParams = { ...(loadParams ?? {}) };

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -165,29 +165,6 @@ class PipelineManager:
             self._pipelines[key] = pipeline_instance
             self._pipeline_statuses[key] = PipelineStatus.LOADED
 
-    def register_graph_nodes(self, graph_data: dict) -> None:
-        """Instantiate and register plain custom nodes from a graph payload.
-
-        Custom nodes (``type == "node"``) aren't pre-loaded via
-        ``/pipeline/load`` the way pipelines are, but the graph executor
-        resolves every graph node through :meth:`get_pipeline_by_id`. Plain
-        nodes are cheap to construct; model weights load lazily on first
-        ``execute``. Uses :meth:`set_pipeline_instance` (additive, per-key)
-        so pipelines already loaded via ``/pipeline/load`` are untouched.
-        """
-        from scope.core.nodes.registry import NodeRegistry
-
-        for node in graph_data.get("nodes", []):
-            if not (node.get("type") == "node" and node.get("node_type_id")):
-                continue
-            node_cls = NodeRegistry.get(node["node_type_id"])
-            if node_cls is None:
-                continue
-            self.set_pipeline_instance(node["id"], node_cls(node["id"]))
-            logger.info(
-                f"Registered custom node {node['node_type_id']} as {node['id']}"
-            )
-
     async def _load_pipeline_by_id(
         self,
         pipeline_id: str,

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -419,10 +419,6 @@ class WebRTCManager:
                             logger.info(
                                 f"Re-keyed pipeline {pid} as {node['id']} for graph"
                             )
-                # Plain custom nodes aren't pre-loaded via /pipeline/load,
-                # but the graph executor still resolves them through the
-                # PipelineManager — so instantiate and register them here.
-                pipeline_manager.register_graph_nodes(graph_data)
 
             # Create FrameProcessor (owned by session, shared between tracks)
             frame_processor = FrameProcessor(


### PR DESCRIPTION
## Summary
- Plain custom nodes (`type="node"`) now route through `/api/v1/pipeline/load` like pipelines do, instead of being lazily registered at session start via the separate `register_graph_nodes` hook.
- Fixes a cloud-mode regression where graphs containing a scheduler or plugin node (e.g. `prompt-enhancer`) failed with `Pipeline <node_id> not loaded` because the cloud session-start handler did not call the lazy hook.
- Completes the node/pipeline unification: one registry, one API endpoint, one code path. Cache reuse / re-keying now applies to plain nodes too — useful as nodes start carrying heavier model weights.

## What changed
- `frontend/src/pages/StreamPage.tsx`: include `type === "node"` entries in the `loadItems` sent to `/pipeline/load` (`pipeline_id = node_type_id`, empty `load_params`).
- `src/scope/server/pipeline_manager.py`: delete the now-unused `register_graph_nodes` method. `_load_pipeline_implementation` already had the plain-node branch (returns `node_class(node_id=...)` when `get_config_class()` is `None`).
- `src/scope/server/webrtc.py`: remove the relay-mode call to `register_graph_nodes` — the graph is now fully populated in `pipeline_manager` before the offer arrives.

## Test plan
- [ ] Run the prompt-enhancer workflow from the issue against the cloud — confirm session starts and frames flow.
- [ ] Run a workflow with a `scheduler` node only against the cloud — confirm load and start succeed.
- [ ] Run any pipeline workflow locally (no node-type entries) — confirm no regression in load / re-keying / unload behavior.
- [ ] Reload a workflow with the same plain-node twice in a row — confirm Phase 1 reuse keeps the same instance (no thrash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
