### PR TITLE
Show git commit hash in packaged Electron Settings

### DIFF
--- a/app/build/afterPack.js
+++ b/app/build/afterPack.js
@@ -4,6 +4,7 @@
  */
 const fs = require('fs-extra');
 const path = require('path');
+const { execSync } = require('child_process');
 
 exports.default = async function afterPack(context) {
   const { electronPlatformName, appOutDir } = context;
@@ -57,6 +58,19 @@ exports.default = async function afterPack(context) {
     } catch (err) {
       console.error(`✗ Failed to copy ${src} to ${dest}:`, err.message);
     }
+  }
+
+  // Bake the git commit hash into the bundled Python package so the backend
+  // can report it at runtime (the .git directory isn't shipped).
+  try {
+    const commit = execSync('git rev-parse --short HEAD', { cwd: projectRoot })
+      .toString()
+      .trim();
+    const commitFile = path.join(resourcesPath, 'src', 'scope', '_git_commit.txt');
+    await fs.writeFile(commitFile, commit);
+    console.log(`✓ Wrote git commit ${commit} to ${commitFile}`);
+  } catch (err) {
+    console.warn(`⚠ Failed to record git commit hash: ${err.message}`);
   }
 
   console.log('afterPack hook completed.');

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -267,6 +267,18 @@ def get_git_commit_hash() -> str:
     Returns:
         Git commit hash if available, otherwise a fallback message.
     """
+    # Packaged distributions (e.g. the Electron app) don't ship the .git
+    # directory, so the build pipeline writes the short hash into a sibling
+    # file that we read here.
+    commit_file = Path(__file__).parent.parent / "_git_commit.txt"
+    try:
+        if commit_file.is_file():
+            baked = commit_file.read_text().strip()
+            if baked:
+                return baked
+    except OSError:
+        pass
+
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--short", "HEAD"],


### PR DESCRIPTION
## Summary

- The Settings -> General version line already renders `version (gitCommit)` (see `frontend/src/components/settings/GeneralTab.tsx`) and the backend `/health` endpoint already returns both fields. In packaged Electron builds, however, `get_git_commit_hash()` ran `git rev-parse` against a source tree that had no `.git`, so it always fell back to `unknown (not a git repository)`.
- `app/build/afterPack.js` now captures the short hash from the build host with `git rev-parse --short HEAD` and writes it to `Resources/.../src/scope/_git_commit.txt` after copying the Python source.
- `get_git_commit_hash()` in `src/scope/server/app.py` now reads that baked file first and only falls back to the existing subprocess path for dev checkouts.

## Test plan

- [ ] Dev: `uv run python -c "from scope.server.app import get_git_commit_hash; print(get_git_commit_hash())"` returns the live `git rev-parse --short HEAD` value.
- [ ] Packaged: build the macOS app with `npm run dist:mac`, launch, open Settings -> General, and confirm the version line shows `0.2.3 (<short hash>)`.
- [ ] Packaged: same check on Windows / Linux builds (`dist:win`, `dist:linux`).
- [ ] Repo cleanliness: `_git_commit.txt` does not appear inside `src/scope/` in the working tree after a build (it is only written into the electron-builder output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)