### PR TITLE
feat: Search installed pipelines and plugin nodes from pane context menu

### DIFF
--- a/frontend/src/components/graph/AddNodeModal.tsx
+++ b/frontend/src/components/graph/AddNodeModal.tsx
@@ -9,6 +9,7 @@ import {
 import type { FlowNodeData } from "../../lib/graphUtils";
 import type { NodeDefinitionDto } from "../../lib/api";
 import { fetchNodeDefinitions } from "../../lib/api";
+import { buildCustomNodeExtraData } from "./customNodeExtraData";
 
 interface AddNodeModalProps {
   open: boolean;
@@ -462,20 +463,11 @@ export function AddNodeModal({
   const handleSelect = useCallback(
     (item: NodeCatalogItem) => {
       if (item.type === "custom_node" && item.customNodeDef) {
-        const def = item.customNodeDef;
-        onSelectNodeType("custom_node", item.subType, {
-          customNodeTypeId: def.node_type_id,
-          customNodeDisplayName: def.display_name || def.node_type_id,
-          customNodeCategory: def.category || "",
-          customNodeInputs: def.inputs || [],
-          customNodeOutputs: def.outputs || [],
-          customNodeParamDefs: def.params || [],
-          customNodeParams: Object.fromEntries(
-            (def.params || [])
-              .filter(p => p.default != null)
-              .map(p => [p.name, p.default])
-          ),
-        });
+        onSelectNodeType(
+          "custom_node",
+          item.subType,
+          buildCustomNodeExtraData(item.customNodeDef)
+        );
       } else {
         onSelectNodeType(item.type, item.subType);
       }

--- a/frontend/src/components/graph/ContextMenu.tsx
+++ b/frontend/src/components/graph/ContextMenu.tsx
@@ -14,6 +14,10 @@ export interface ContextMenuItem {
   icon?: ReactNode;
   children?: ContextMenuItem[];
   keywords?: string[];
+  /** When true, the item is excluded from the static menu render but still
+   * participates in search results. Used to surface installed pipelines and
+   * plugin nodes via the search box without enlarging the resting menu. */
+  searchOnly?: boolean;
 }
 
 interface ContextMenuProps {
@@ -197,48 +201,50 @@ export function ContextMenu({
             ))
           )
         ) : (
-          items.map((item, i) => (
-            <div
-              key={i}
-              className="relative"
-              onMouseEnter={() =>
-                item.children ? setActiveSubmenu(i) : setActiveSubmenu(null)
-              }
-              onMouseLeave={() => setActiveSubmenu(null)}
-            >
-              <button
-                onClick={() => {
-                  if (!item.children) handleSelect(item);
-                }}
-                className={`w-full text-left px-3 py-1.5 text-[13px] flex items-center gap-2.5 transition-colors ${
-                  item.danger
-                    ? "text-red-400 hover:bg-[rgba(255,255,255,0.05)] hover:text-red-300"
-                    : "text-[#e0e0e0] hover:bg-[rgba(255,255,255,0.05)]"
-                }`}
+          items
+            .filter(item => !item.searchOnly)
+            .map((item, i) => (
+              <div
+                key={i}
+                className="relative"
+                onMouseEnter={() =>
+                  item.children ? setActiveSubmenu(i) : setActiveSubmenu(null)
+                }
+                onMouseLeave={() => setActiveSubmenu(null)}
               >
-                {item.icon && (
-                  <span className="text-[#777] shrink-0 [&_svg]:w-[15px] [&_svg]:h-[15px]">
-                    {item.icon}
-                  </span>
-                )}
-                <span className="flex-1">{item.label}</span>
-                {item.children && (
-                  <span className="text-[#555] text-[11px] ml-2">
-                    {flipX ? "‹" : "›"}
-                  </span>
-                )}
-              </button>
+                <button
+                  onClick={() => {
+                    if (!item.children) handleSelect(item);
+                  }}
+                  className={`w-full text-left px-3 py-1.5 text-[13px] flex items-center gap-2.5 transition-colors ${
+                    item.danger
+                      ? "text-red-400 hover:bg-[rgba(255,255,255,0.05)] hover:text-red-300"
+                      : "text-[#e0e0e0] hover:bg-[rgba(255,255,255,0.05)]"
+                  }`}
+                >
+                  {item.icon && (
+                    <span className="text-[#777] shrink-0 [&_svg]:w-[15px] [&_svg]:h-[15px]">
+                      {item.icon}
+                    </span>
+                  )}
+                  <span className="flex-1">{item.label}</span>
+                  {item.children && (
+                    <span className="text-[#555] text-[11px] ml-2">
+                      {flipX ? "‹" : "›"}
+                    </span>
+                  )}
+                </button>
 
-              {item.children && activeSubmenu === i && (
-                <SubmenuPanel
-                  items={item.children}
-                  flipX={flipX}
-                  flipY={flipY}
-                  onSelect={handleSelect}
-                />
-              )}
-            </div>
-          ))
+                {item.children && activeSubmenu === i && (
+                  <SubmenuPanel
+                    items={item.children.filter(c => !c.searchOnly)}
+                    flipX={flipX}
+                    flipY={flipY}
+                    onSelect={handleSelect}
+                  />
+                )}
+              </div>
+            ))
         )}
       </div>
     </div>

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -73,6 +73,8 @@ import {
 import { createDaydreamImportSession } from "../../lib/daydreamExport";
 import { openExternalUrl } from "../../lib/openExternal";
 import { buildPaneMenuItems, buildNodeMenuItems } from "./contextMenuItems";
+import { usePipelinesContext } from "../../contexts/PipelinesContext";
+import { useNodeDefinitions } from "../../hooks/useNodeDefinitions";
 import type { FlowNodeData } from "../../lib/graphUtils";
 import {
   AlertDialog,
@@ -398,6 +400,8 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
 
     const [showAddNodeModal, setShowAddNodeModal] = useState(false);
     const [showBlueprintModal, setShowBlueprintModal] = useState(false);
+    const { pipelines: installedPipelines } = usePipelinesContext();
+    const customNodeDefs = useNodeDefinitions();
     const [showClearConfirm, setShowClearConfirm] = useState(false);
     const [showDefaultConfirm, setShowDefaultConfirm] = useState(false);
     const [showExportDialog, setShowExportDialog] = useState(false);
@@ -1296,6 +1300,8 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
                         edges,
                         createSubgraphFromSelection,
                         onOpenBlueprints: () => setShowBlueprintModal(true),
+                        installedPipelines,
+                        customNodeDefs,
                       })
                     : buildNodeMenuItems({
                         contextNodeId: contextMenu.nodeId!,

--- a/frontend/src/components/graph/contextMenuItems.tsx
+++ b/frontend/src/components/graph/contextMenuItems.tsx
@@ -32,7 +32,10 @@ import {
 } from "lucide-react";
 import type { Node, Edge } from "@xyflow/react";
 import type { FlowNodeData } from "../../lib/graphUtils";
+import type { NodeDefinitionDto } from "../../lib/api";
+import type { PipelineInfo } from "../../types";
 import type { ContextMenuItem } from "./ContextMenu";
+import { buildCustomNodeExtraData } from "./customNodeExtraData";
 
 /* ── Pane (canvas) context menu ──────────────────────────────────────────── */
 
@@ -63,8 +66,10 @@ type NodeTypeSelectFn = (
     | "tempo"
     | "prompt_list"
     | "prompt_blend"
-    | "scheduler",
-  subType?: string
+    | "scheduler"
+    | "custom_node",
+  subType?: string,
+  extraData?: Partial<FlowNodeData>
 ) => void;
 
 export function buildPaneMenuItems(deps: {
@@ -78,6 +83,11 @@ export function buildPaneMenuItems(deps: {
     selectedIds: string[]
   ) => void;
   onOpenBlueprints: () => void;
+  /** Installed pipelines, used to surface plugin-provided pipelines via search. */
+  installedPipelines?: Record<string, PipelineInfo> | null;
+  /** Node definitions from /api/v1/nodes/definitions, used to surface plugin
+   *  custom nodes via search. */
+  customNodeDefs?: NodeDefinitionDto[];
 }): ContextMenuItem[] {
   const {
     handleNodeTypeSelect,
@@ -86,9 +96,11 @@ export function buildPaneMenuItems(deps: {
     edges,
     createSubgraphFromSelection,
     onOpenBlueprints,
+    installedPipelines,
+    customNodeDefs,
   } = deps;
 
-  return [
+  const baseItems: ContextMenuItem[] = [
     {
       label: "Source",
       icon: <Camera />,
@@ -309,6 +321,65 @@ export function buildPaneMenuItems(deps: {
         ]
       : []),
   ];
+
+  // Search-only ghost entries: invisible in the static menu, but discoverable
+  // via the search box. One per installed pipeline, one per plugin-provided
+  // custom node. Plugin package names are added to keywords so users can find
+  // a node by typing e.g. "gesture" → "scope-gesture-pipeline".
+  const ghostItems: ContextMenuItem[] = [];
+
+  if (installedPipelines) {
+    for (const [pipelineId, info] of Object.entries(installedPipelines)) {
+      const keywords = [
+        pipelineId,
+        info.pluginName ?? "",
+        "pipeline",
+        ...(info.about?.split(/\s+/).filter(Boolean) ?? []),
+      ].filter(Boolean);
+      ghostItems.push({
+        label: info.name || pipelineId,
+        icon: <Workflow />,
+        keywords,
+        searchOnly: true,
+        onClick: () =>
+          handleNodeTypeSelect("pipeline", undefined, {
+            pipelineId,
+          } as Partial<FlowNodeData>),
+      });
+    }
+  }
+
+  if (customNodeDefs) {
+    for (const def of customNodeDefs) {
+      // Mirror AddNodeModal filtering: skip pipelines (handled above) and the
+      // built-in scheduler (already a top-level entry).
+      if (def.pipeline_meta != null) continue;
+      if (def.node_type_id === "scheduler") continue;
+      // Surface plugin-provided nodes only — built-ins already have static
+      // entries in this menu.
+      if (!def.plugin_name) continue;
+      const keywords = [
+        def.node_type_id,
+        def.plugin_name,
+        def.category,
+        ...(def.description?.split(/\s+/).filter(Boolean) ?? []),
+      ].filter(Boolean);
+      ghostItems.push({
+        label: def.display_name || def.node_type_id,
+        icon: <PackageOpen />,
+        keywords,
+        searchOnly: true,
+        onClick: () =>
+          handleNodeTypeSelect(
+            "custom_node",
+            def.node_type_id,
+            buildCustomNodeExtraData(def)
+          ),
+      });
+    }
+  }
+
+  return [...baseItems, ...ghostItems];
 }
 
 /* ── Node context menu ───────────────────────────────────────────────────── */

--- a/frontend/src/components/graph/customNodeExtraData.ts
+++ b/frontend/src/components/graph/customNodeExtraData.ts
@@ -1,0 +1,20 @@
+import type { NodeDefinitionDto } from "../../lib/api";
+import type { FlowNodeData } from "../../lib/graphUtils";
+
+export function buildCustomNodeExtraData(
+  def: NodeDefinitionDto
+): Partial<FlowNodeData> {
+  return {
+    customNodeTypeId: def.node_type_id,
+    customNodeDisplayName: def.display_name || def.node_type_id,
+    customNodeCategory: def.category || "",
+    customNodeInputs: def.inputs || [],
+    customNodeOutputs: def.outputs || [],
+    customNodeParamDefs: def.params || [],
+    customNodeParams: Object.fromEntries(
+      (def.params || [])
+        .filter(p => p.default != null)
+        .map(p => [p.name, p.default])
+    ),
+  };
+}

--- a/frontend/src/components/graph/hooks/node/useNodeFactories.ts
+++ b/frontend/src/components/graph/hooks/node/useNodeFactories.ts
@@ -520,13 +520,15 @@ export function useNodeFactories({
 }: UseNodeFactoriesArgs) {
   const existingIds = useMemo(() => new Set(nodes.map(n => n.id)), [nodes]);
 
-  /** Generic factory: creates a node from the NODE_DEFAULTS config map. */
+  /** Generic factory: creates a node from the NODE_DEFAULTS config map.
+   *  Returns the new node's id so callers can wire follow-up state (e.g.
+   *  preselecting a pipeline immediately after creation). */
   const addNode = useCallback(
     (
       key: NodeTypeKey,
       position?: { x: number; y: number },
       extraData?: Partial<FlowNodeData>
-    ) => {
+    ): string => {
       const def = NODE_DEFAULTS[key];
       const id = generateNodeId(def.idPrefix, existingIds);
       const newNode: Node<FlowNodeData> = {
@@ -544,6 +546,7 @@ export function useNodeFactories({
         } as FlowNodeData,
       };
       setNodes(nds => enrichNodes([...nds, newNode], enrichDepsRef.current));
+      return id;
     },
     [existingIds, nodes.length, setNodes, enrichDepsRef]
   );
@@ -588,11 +591,19 @@ export function useNodeFactories({
           addNode(`control_${subType}` as NodeTypeKey, pendingNodePosition);
         }
       } else if (type === "pipeline") {
-        addNode("pipeline", pendingNodePosition, {
+        const preselectedPipelineId = (
+          extraData as { pipelineId?: string } | undefined
+        )?.pipelineId;
+        const newId = addNode("pipeline", pendingNodePosition, {
           availablePipelineIds,
           pipelinePortsMap: portsMap,
           onPipelineSelect: handlePipelineSelect,
         });
+        if (preselectedPipelineId) {
+          // Mirror the manual dropdown flow so ports/params/streamInputs
+          // hydrate identically (see PipelineNode.tsx onPipelineSelect call).
+          handlePipelineSelect(newId, preselectedPipelineId);
+        }
       } else if (type === "output") {
         const defaultType = spoutOutputAvailable
           ? "spout"

--- a/frontend/src/hooks/useNodeDefinitions.ts
+++ b/frontend/src/hooks/useNodeDefinitions.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { fetchNodeDefinitions, type NodeDefinitionDto } from "../lib/api";
+
+/** Fetches /api/v1/nodes/definitions once. Used by AddNodeModal and the
+ *  graph pane context menu so plugin-registered nodes are surfaced in
+ *  search without each consumer re-fetching. */
+export function useNodeDefinitions(enabled = true) {
+  const [defs, setDefs] = useState<NodeDefinitionDto[]>([]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const controller = new AbortController();
+    fetchNodeDefinitions({ signal: controller.signal })
+      .then(data => {
+        if (controller.signal.aborted) return;
+        setDefs(data.nodes ?? []);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.warn("Failed to fetch node definitions:", err);
+      });
+    return () => controller.abort();
+  }, [enabled]);
+
+  return defs;
+}


### PR DESCRIPTION
The right-click pane menu's search box only matched the static category labels and their hard-coded keywords, so a pipeline like scope-gesture-pipeline was undiscoverable by name. Add searchOnly ghost entries built from PipelinesContext and /api/v1/nodes/definitions, with the plugin package name included in keywords. Clicking a pipeline result creates a Pipeline node already preselected to that pipeline by routing through the existing handlePipelineSelect path. The static menu is unchanged when the search box is empty.