### PR TITLE
Forward parameter updates via callback

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -124,6 +124,7 @@ class LivepeerSession:
     manifest_id: str | None = None
     session_id: str | None = None
     connection_info: dict[str, Any] | None = None
+    notification_queue: asyncio.Queue[dict | None] | None = None
 
 
 def _build_connection_info() -> dict[str, Any]:
@@ -1042,6 +1043,38 @@ async def _handle_control_message(
         except RuntimeError as exc:
             return {"type": "error", "request_id": request_id, "error": str(exc)}
 
+        # Enqueue notif gets called in non-async code. Capture the loop so
+        # asyncio.Queue can be safely called from non-async / threaded code
+        runner_loop = asyncio.get_running_loop()
+        notification_queue = session.notification_queue
+
+        def _enqueue_notification(message: dict) -> None:
+            if notification_queue is None:
+                return
+
+            # Drop oldest on overflow
+            def _put_with_drop() -> None:
+                try:
+                    # Drained into the events trickle channel
+                    notification_queue.put_nowait(message)
+                except asyncio.QueueFull:
+                    try:
+                        notification_queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        pass
+                    try:
+                        notification_queue.put_nowait(message)
+                    except asyncio.QueueFull:
+                        logger.warning(
+                            "Dropped runner notification under queue pressure"
+                        )
+
+            try:
+                runner_loop.call_soon_threadsafe(_put_with_drop)
+            except RuntimeError:
+                # Loop is closing.
+                pass
+
         session.frame_processor = FrameProcessor(
             pipeline_manager=pipeline_manager,
             initial_parameters={
@@ -1050,6 +1083,7 @@ async def _handle_control_message(
                 "produces_video": produces_video,
                 "produces_audio": produces_audio,
             },
+            notification_callback=_enqueue_notification,
             session_id=session.session_id,
             user_id=session.user_id,
             connection_id=session.manifest_id,
@@ -1207,6 +1241,36 @@ async def _subscribe_control(
     log_queue = log_broadcaster.subscribe(logging_id)
     logs_task = asyncio.create_task(_forward_logs_to_events(log_queue))
 
+    # Forward notifications (parameter updates etc) to scope via event channel
+    # use a queue to backpressure high volume events
+    notification_queue: asyncio.Queue[dict | None] = asyncio.Queue(maxsize=256)
+    session.notification_queue = notification_queue
+
+    async def _forward_notifications_to_events() -> None:
+        try:
+            while not stop_event.is_set():
+                try:
+                    message = await asyncio.wait_for(
+                        notification_queue.get(), timeout=1.0
+                    )
+                except TimeoutError:
+                    continue
+                if message is None:
+                    break
+                try:
+                    await events_writer.write(
+                        {"type": "notification", "payload": message}
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to forward notification to events channel",
+                        exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            pass
+
+    notif_task = asyncio.create_task(_forward_notifications_to_events())
+
     try:
         await events_writer.write(
             {
@@ -1235,6 +1299,17 @@ async def _subscribe_control(
         except asyncio.CancelledError:
             pass
         log_broadcaster.unsubscribe(logging_id)
+        # Wake the notification forwarder so it exits on its own; fall back
+        # to cancellation if the queue is somehow saturated.
+        try:
+            notification_queue.put_nowait(None)
+        except asyncio.QueueFull:
+            notif_task.cancel()
+        try:
+            await notif_task
+        except asyncio.CancelledError:
+            pass
+        session.notification_queue = None
         await _stop_stream(session)
         try:
             await events_writer.close()

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -908,6 +908,7 @@ class FrameProcessor:
             connection_info=self.connection_info,
             tempo_sync=self.tempo_sync,
             modulation_engine=self.modulation_engine,
+            notification_callback=self.notification_callback,
         )
 
         self._sink_processor = graph_run.sink_processor

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import queue
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -67,6 +68,7 @@ def build_graph(
     connection_info: dict | None = None,
     tempo_sync: Any | None = None,
     modulation_engine: Any | None = None,
+    notification_callback: Callable[[dict], None] | None = None,
 ) -> GraphRun:
     """Build executable graph: create queues and processors, wire edges.
 
@@ -75,6 +77,7 @@ def build_graph(
         pipeline_manager: Manager to resolve pipeline_id -> instance.
         initial_parameters: Parameters passed to all pipelines.
         session_id, user_id, connection_id, connection_info: For processors.
+        notification_callback: Notify of pipeline / param updates.
 
     Returns:
         GraphRun with source_queues, sink_processor, processors, pipeline_ids.
@@ -140,6 +143,7 @@ def build_graph(
                 tempo_sync=tempo_sync if node_gets_tempo else None,
                 modulation_engine=modulation_engine if node_gets_tempo else None,
                 node_id=node.id,
+                notification_callback=notification_callback,
             )
             node_processors[node.id] = processor
             pipeline_ids.append(node.pipeline_id)

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -829,6 +829,10 @@ class LivepeerClient:
                     _handle_cloud_logs(event)
                     continue
 
+                if msg_type == "notification":
+                    _forward_runner_notification(event.get("payload"))
+                    continue
+
                 logger.debug(f"Event: {event}")
         except asyncio.CancelledError:
             pass
@@ -1233,3 +1237,18 @@ def _handle_cloud_logs(data: dict[str, Any]) -> None:
         elif " - DEBUG - " in line:
             level = logging.DEBUG
         cloud_logger.log(level, "%s", line)
+
+
+def _forward_runner_notification(payload: Any) -> None:
+    """Re-broadcast a runner-side notification onto local data channels."""
+    if not isinstance(payload, dict):
+        return
+    from . import app as _app
+
+    manager = getattr(_app, "webrtc_manager", None)
+    if manager is None:
+        return
+    try:
+        manager.broadcast_notification(payload)
+    except Exception:
+        logger.debug("Failed to re-broadcast runner notification", exc_info=True)

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -6,6 +6,7 @@ import random
 import threading
 import time
 from collections import deque
+from collections.abc import Callable
 from fractions import Fraction
 from typing import Any
 
@@ -55,6 +56,7 @@ class PipelineProcessor:
         tempo_sync: Any | None = None,
         modulation_engine: Any | None = None,
         node_id: str | None = None,
+        notification_callback: Callable[[dict], None] | None = None,
     ):
         """Initialize a pipeline processor.
 
@@ -69,6 +71,7 @@ class PipelineProcessor:
             tempo_sync: TempoSync instance for beat state injection
             modulation_engine: ModulationEngine for beat-synced param modulation
             node_id: Graph node ID (used for per-node parameter routing in graph mode)
+            notification_callback: Lets consumers know of parameter updates etc
         """
         self.pipeline = pipeline
         self.pipeline_id = pipeline_id
@@ -79,6 +82,7 @@ class PipelineProcessor:
         self.connection_info = connection_info
         self.tempo_sync = tempo_sync
         self.modulation_engine = modulation_engine
+        self.notification_callback = notification_callback
 
         # Port-based queues wired by graph_executor.build_graph()
         self.input_queues: dict[str, queue.Queue] = {}
@@ -157,9 +161,10 @@ class PipelineProcessor:
         Non-video ports (string, number, …) deliver discrete values rather
         than frame streams; the latest value on each queue wins. Video ports
         are left alone — those follow the chunk-gathering path below. Drained
-        values are broadcast so widgets like the Prompt textarea reflect
-        what an upstream backend node produced; NotificationSender buffers
-        the payload if the WebRTC data channel isn't open yet.
+        values are emitted via ``self.notification_callback`` so widgets like
+        the Prompt textarea reflect what an upstream backend node produced.
+        Where the notification ends up (WebRTC data channel, events trickle
+        channel, …) is the constructor caller's concern.
         """
         if not self._non_video_input_ports:
             return
@@ -184,19 +189,16 @@ class PipelineProcessor:
                 drained_values[port] = latest
         if not drained_values:
             return
-        from . import app as _app
-
-        manager = getattr(_app, "webrtc_manager", None)
-        if manager is None:
+        if self.notification_callback is None:
             return
         payload = {"node_id": self.node_id, **drained_values}
         try:
-            manager.broadcast_notification(
+            self.notification_callback(
                 {"type": "parameters_updated", "parameters": payload}
             )
         except Exception:
             logger.debug(
-                "Failed to broadcast parameters_updated for %s",
+                "Failed to notify parameters_updated for %s",
                 self.node_id,
                 exc_info=True,
             )

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -809,6 +809,12 @@ class WebRTCManager:
             )
             self.sessions[session.id] = session
 
+            # NotificationSender forwards runner-side notifications (parameter
+            # updates from cloud nodes like the Prompt Enhancer) onto the
+            # browser data channel so the UI stays in sync.
+            notification_sender = NotificationSender()
+            session.notification_sender = notification_sender
+
             # Parse graph from initial parameters for multi-source/sink/record
             (
                 _,  # webrtc_sink_node_ids (unused — use all_sink_node_ids)
@@ -1000,6 +1006,11 @@ class WebRTCManager:
             def on_data_channel(data_channel):
                 logger.info(f"Data channel: {data_channel.label}")
                 session.data_channel = data_channel
+                notification_sender.set_data_channel(data_channel)
+
+                @data_channel.on("open")
+                def on_data_channel_open():
+                    notification_sender.flush_pending_notifications()
 
                 @data_channel.on("message")
                 def on_data_channel_message(message):


### PR DESCRIPTION
PR #982 added pipeline-driven parameter notifications but sent them down WebRTC, which doesn't exist in cloud mode.

The codebase already has a clean pattern for "deliver a notification from a worker thread to whoever cares": dependency-injected notification_callback. FrameProcessor, ParameterScheduler, VideoProcessingTrack, and cloud_track all take it. The constructor caller — and only the constructor caller — decides what notifications mean.

PipelineProcessor is the one worker class in the chain that doesn't carry it. Add that here.

Changes:

* PipelineProcessor accepts notification_callback
* graph_executor.build_graph forwards the callback
* FrameProcessor passes its own callback into build_graph
* Cloud runner: callback into a queue, drain into events_writer
* Local Scope: Handle notification events, forward into WebRTC