### PR TITLE
Show unavailable integrations with install hints

### DIFF
--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -196,6 +196,9 @@ interface GraphEditorProps {
   ndiAvailable?: boolean;
   syphonAvailable?: boolean;
   availableInputSources?: import("../../lib/api").InputSourceType[];
+  spoutReason?: string | null;
+  ndiReason?: string | null;
+  syphonReason?: string | null;
   onSpoutSourceChange?: (name: string) => void;
   onNdiSourceChange?: (identifier: string) => void;
   onSyphonSourceChange?: (identifier: string) => void;
@@ -247,6 +250,9 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
       ndiAvailable = false,
       syphonAvailable = false,
       availableInputSources = [],
+      spoutReason = null,
+      ndiReason = null,
+      syphonReason = null,
       onSpoutSourceChange,
       onNdiSourceChange,
       onSyphonSourceChange,
@@ -350,6 +356,9 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         ndiOutputAvailable,
         syphonOutputAvailable,
         availableInputSources,
+        spoutReason,
+        ndiReason,
+        syphonReason,
       },
       {
         tempoState,

--- a/frontend/src/components/graph/hooks/graph/useGraphState.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphState.ts
@@ -123,6 +123,9 @@ export interface GraphEditorAvailability {
   ndiOutputAvailable: boolean;
   syphonOutputAvailable: boolean;
   availableInputSources: import("../../../../lib/api").InputSourceType[];
+  spoutReason?: string | null;
+  ndiReason?: string | null;
+  syphonReason?: string | null;
 }
 
 export function useGraphState(
@@ -292,6 +295,9 @@ export function useGraphState(
     ndiOutputAvailable: availability.ndiOutputAvailable,
     syphonOutputAvailable: availability.syphonOutputAvailable,
     availableInputSources: availability.availableInputSources,
+    spoutReason: availability.spoutReason ?? null,
+    ndiReason: availability.ndiReason ?? null,
+    syphonReason: availability.syphonReason ?? null,
     handleEdgeDelete,
     isStreaming: streams.isStreaming,
     isLoading: streams.isLoading ?? false,

--- a/frontend/src/components/graph/nodes/OutputNode.tsx
+++ b/frontend/src/components/graph/nodes/OutputNode.tsx
@@ -12,6 +12,7 @@ import {
   NodePillToggle,
   collapsedHandleStyle,
 } from "../ui";
+import type { NodePillSelectOption } from "../ui/NodePillSelect";
 
 type OutputNodeType = Node<FlowNodeData, "output">;
 
@@ -44,14 +45,23 @@ export function OutputNode({ id, data, selected }: NodeProps<OutputNodeType>) {
   const spoutAvailable = data.spoutAvailable ?? false;
   const ndiAvailable = data.ndiAvailable ?? false;
   const syphonAvailable = data.syphonAvailable ?? false;
+  const spoutReason = data.spoutReason ?? "Spout is unavailable";
+  const ndiReason = data.ndiReason ?? "NDI is unavailable";
+  const syphonReason = data.syphonReason ?? "Syphon is unavailable";
 
-  // Filter output type options based on availability
-  const filteredOptions = OUTPUT_TYPE_OPTIONS.filter(opt => {
-    if (opt.value === "spout") return spoutAvailable;
-    if (opt.value === "ndi") return ndiAvailable;
-    if (opt.value === "syphon") return syphonAvailable;
-    return true;
-  });
+  // Annotate options with per-integration availability so unavailable ones
+  // stay visible but render disabled (with an install hint via `reason`).
+  const annotatedOptions: NodePillSelectOption[] = OUTPUT_TYPE_OPTIONS.map(
+    opt => {
+      if (opt.value === "spout" && !spoutAvailable)
+        return { ...opt, disabled: true, reason: spoutReason };
+      if (opt.value === "ndi" && !ndiAvailable)
+        return { ...opt, disabled: true, reason: ndiReason };
+      if (opt.value === "syphon" && !syphonAvailable)
+        return { ...opt, disabled: true, reason: syphonReason };
+      return opt;
+    }
+  );
 
   const handleTypeChange = (newType: string) => {
     updateData({
@@ -88,13 +98,17 @@ export function OutputNode({ id, data, selected }: NodeProps<OutputNodeType>) {
               <NodePillSelect
                 value={sinkType}
                 onChange={handleTypeChange}
-                options={
-                  filteredOptions.length > 0
-                    ? filteredOptions
-                    : OUTPUT_TYPE_OPTIONS
-                }
+                options={annotatedOptions}
               />
             </NodeParamRow>
+            {(() => {
+              const current = annotatedOptions.find(o => o.value === sinkType);
+              return current?.disabled && current.reason ? (
+                <div className="mt-1 text-[10px] text-amber-400/80 italic">
+                  {current.reason}
+                </div>
+              ) : null;
+            })()}
           </div>
           <div className="px-2">
             <NodeParamRow label="Enabled">

--- a/frontend/src/components/graph/nodes/SourceNode.tsx
+++ b/frontend/src/components/graph/nodes/SourceNode.tsx
@@ -15,6 +15,7 @@ import {
   NodePillSearchableSelect,
   collapsedHandleStyle,
 } from "../ui";
+import type { NodePillSelectOption } from "../ui/NodePillSelect";
 
 type SourceNodeType = Node<FlowNodeData, "source">;
 
@@ -56,6 +57,9 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const currentSourceInfo = availableInputSources.find(
     s => s.source_id === sourceMode
   );
+  const spoutReason = data.spoutReason ?? "Spout is unavailable";
+  const ndiReason = data.ndiReason ?? "NDI is unavailable";
+  const syphonReason = data.syphonReason ?? "Syphon is unavailable";
   const onSpoutSourceChange = data.onSpoutSourceChange as
     | ((name: string) => void)
     | undefined;
@@ -190,17 +194,38 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
   const showFilePicker = sourceMode === "video";
   const handleY = HEADER_H + BODY_PAD + SELECT_ROW_H / 2;
 
-  // Browser-driven options + every available backend source. Plugin-
-  // registered sources appear automatically. If the graph was saved with
-  // a mode that isn't currently available on this machine (e.g. NDI graph
-  // opened on a host without NDI), keep it in the list as "(unavailable)"
-  // so the user can see what's set instead of the dropdown silently
-  // collapsing to a different selection.
-  const filteredSourceModeOptions = [
+  // Browser-driven options + every backend source. Plugin-registered
+  // sources appear automatically. Sources reported as unavailable
+  // (e.g. NDI without the SDK installed) stay in the list but render
+  // disabled with the backend-supplied install hint, so the user sees
+  // the option exists and learns how to enable it instead of the
+  // dropdown silently hiding it.
+  //
+  // If the graph was saved with a mode that isn't even known to the
+  // backend on this machine, keep it as a "(unavailable)" placeholder
+  // so the saved selection is visible.
+  const REASON_BY_SOURCE_ID: Record<string, string | null | undefined> = {
+    spout: spoutReason,
+    ndi: ndiReason,
+    syphon: syphonReason,
+  };
+  const filteredSourceModeOptions: NodePillSelectOption[] = [
     ...BROWSER_SOURCE_OPTIONS,
     ...availableInputSources
-      .filter(s => s.available && !HIDDEN_BACKEND_SOURCES.has(s.source_id))
-      .map(s => ({ value: s.source_id, label: s.source_name })),
+      .filter(s => !HIDDEN_BACKEND_SOURCES.has(s.source_id))
+      .map(s => {
+        if (s.available) {
+          return { value: s.source_id, label: s.source_name };
+        }
+        const reason =
+          REASON_BY_SOURCE_ID[s.source_id] ?? `${s.source_name} is unavailable`;
+        return {
+          value: s.source_id,
+          label: s.source_name,
+          disabled: true,
+          reason,
+        };
+      }),
   ];
   if (
     sourceMode &&
@@ -210,6 +235,7 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
     filteredSourceModeOptions.push({
       value: sourceMode,
       label: `${label} (unavailable)`,
+      disabled: true,
     });
   }
 
@@ -244,6 +270,16 @@ export function SourceNode({ id, data, selected }: NodeProps<SourceNodeType>) {
                 options={filteredSourceModeOptions}
               />
             </NodeParamRow>
+            {(() => {
+              const current = filteredSourceModeOptions.find(
+                o => o.value === sourceMode
+              );
+              return current?.disabled && current.reason ? (
+                <div className="mt-1 text-[10px] text-amber-400/80 italic">
+                  {current.reason}
+                </div>
+              ) : null;
+            })()}
           </div>
 
           {sourceMode === "spout" && (

--- a/frontend/src/components/graph/ui/NodePillSelect.tsx
+++ b/frontend/src/components/graph/ui/NodePillSelect.tsx
@@ -1,10 +1,17 @@
 import { NODE_TOKENS } from "./tokens";
 
+export interface NodePillSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  reason?: string | null;
+}
+
 interface NodePillSelectProps {
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
-  options: Array<{ value: string; label: string }>;
+  options: Array<NodePillSelectOption>;
   className?: string;
 }
 
@@ -23,8 +30,13 @@ export function NodePillSelect({
       className={`${NODE_TOKENS.pillInput} ${NODE_TOKENS.pillInputText} ${className}`}
     >
       {options.map(opt => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
+        <option
+          key={opt.value}
+          value={opt.value}
+          disabled={opt.disabled}
+          title={opt.reason ?? undefined}
+        >
+          {opt.disabled ? `${opt.label} — unavailable` : opt.label}
         </option>
       ))}
     </select>

--- a/frontend/src/components/graph/utils/nodeEnrichment.ts
+++ b/frontend/src/components/graph/utils/nodeEnrichment.ts
@@ -51,6 +51,9 @@ export interface EnrichNodesDeps {
   ndiOutputAvailable: boolean;
   syphonOutputAvailable: boolean;
   availableInputSources: import("../../../lib/api").InputSourceType[];
+  spoutReason?: string | null;
+  ndiReason?: string | null;
+  syphonReason?: string | null;
   handleEdgeDelete: (edgeId: string) => void;
   isStreaming: boolean;
   isLoading: boolean;
@@ -173,6 +176,9 @@ export function enrichNodes(
           ndiAvailable: deps.ndiAvailable,
           syphonAvailable: deps.syphonAvailable,
           availableInputSources: deps.availableInputSources,
+          spoutReason: deps.spoutReason ?? null,
+          ndiReason: deps.ndiReason ?? null,
+          syphonReason: deps.syphonReason ?? null,
           onSpoutSourceChange: (name: string) =>
             deps.onSpoutSourceChangeRef.current?.(name),
           onNdiSourceChange: (identifier: string) =>
@@ -222,6 +228,9 @@ export function enrichNodes(
           spoutAvailable: deps.spoutOutputAvailable,
           ndiAvailable: deps.ndiOutputAvailable,
           syphonAvailable: deps.syphonOutputAvailable,
+          spoutReason: deps.spoutReason ?? null,
+          ndiReason: deps.ndiReason ?? null,
+          syphonReason: deps.syphonReason ?? null,
         },
       };
     }

--- a/frontend/src/hooks/useStreamState.ts
+++ b/frontend/src/hooks/useStreamState.ts
@@ -410,9 +410,12 @@ export function useStreamState() {
   }, []);
 
   // Derive output sink availability from hardware info
-  const spoutAvailable = hardwareInfo?.spout_available ?? false;
-  const ndiOutputAvailable = hardwareInfo?.ndi_available ?? false;
-  const syphonOutputAvailable = hardwareInfo?.syphon_available ?? false;
+  const spoutAvailable = hardwareInfo?.spout?.available ?? false;
+  const ndiOutputAvailable = hardwareInfo?.ndi?.available ?? false;
+  const syphonOutputAvailable = hardwareInfo?.syphon?.available ?? false;
+  const spoutReason = hardwareInfo?.spout?.install_hint ?? null;
+  const ndiReason = hardwareInfo?.ndi?.install_hint ?? null;
+  const syphonReason = hardwareInfo?.syphon?.install_hint ?? null;
 
   return {
     systemMetrics,
@@ -430,6 +433,9 @@ export function useStreamState() {
     spoutAvailable,
     ndiOutputAvailable,
     syphonOutputAvailable,
+    spoutReason,
+    ndiReason,
+    syphonReason,
     availableInputSources,
     refreshPipelineSchemas,
     refreshHardwareInfo,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -224,11 +224,17 @@ export const downloadPipelineModels = async (
   return result;
 };
 
+export interface IntegrationAvailability {
+  available: boolean;
+  reason?: string | null;
+  install_hint?: string | null;
+}
+
 export interface HardwareInfoResponse {
   vram_gb: number | null;
-  spout_available: boolean;
-  ndi_available: boolean;
-  syphon_available: boolean;
+  spout: IntegrationAvailability;
+  ndi: IntegrationAvailability;
+  syphon: IntegrationAvailability;
 }
 
 export const getHardwareInfo = async (): Promise<HardwareInfoResponse> => {

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -255,6 +255,12 @@ export interface FlowNodeData {
    *  (including plugin-registered ones). Used to build the Source
    *  dropdown dynamically. */
   availableInputSources?: import("./api").InputSourceType[];
+  /** For source/output nodes: install hint shown when Spout is unavailable */
+  spoutReason?: string | null;
+  /** For source/output nodes: install hint shown when NDI is unavailable */
+  ndiReason?: string | null;
+  /** For source/output nodes: install hint shown when Syphon is unavailable */
+  syphonReason?: string | null;
   /** For source nodes: callback when Spout receiver name changes */
   onSpoutSourceChange?: (name: string) => void;
   /** For source nodes: callback when NDI source changes */

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -250,6 +250,9 @@ export function StreamPage() {
     spoutAvailable,
     ndiOutputAvailable,
     syphonOutputAvailable,
+    spoutReason,
+    ndiReason,
+    syphonReason,
     availableInputSources,
     refreshPipelineSchemas,
     refreshHardwareInfo,
@@ -3559,6 +3562,9 @@ export function StreamPage() {
             ndiAvailable={ndiAvailable}
             syphonAvailable={syphonAvailable}
             availableInputSources={availableInputSources}
+            spoutReason={spoutReason}
+            ndiReason={ndiReason}
+            syphonReason={syphonReason}
             onSpoutSourceChange={handleSpoutSourceChange}
             onNdiSourceChange={handleNdiSourceChange}
             onSyphonSourceChange={handleSyphonSourceChange}

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -106,6 +106,7 @@ from .schema import (
     IceCandidateRequest,
     IceServerConfig,
     IceServersResponse,
+    IntegrationAvailability,
     NodeDefinitionsResponse,
     PipelineLoadRequest,
     PipelineSchemasResponse,
@@ -2449,6 +2450,48 @@ def is_syphon_output_available() -> bool:
         return False
 
 
+def get_spout_availability() -> IntegrationAvailability:
+    if is_spout_available():
+        return IntegrationAvailability(available=True)
+    if sys.platform != "win32":
+        return IntegrationAvailability(
+            available=False,
+            reason="Spout is Windows-only",
+            install_hint="Run Scope on Windows to use Spout sources and sinks.",
+        )
+    return IntegrationAvailability(
+        available=False,
+        reason="Spout runtime not detected",
+        install_hint="Install Spout2 from https://spout.zeal.co and restart Scope.",
+    )
+
+
+def get_ndi_availability() -> IntegrationAvailability:
+    if is_ndi_output_available():
+        return IntegrationAvailability(available=True)
+    return IntegrationAvailability(
+        available=False,
+        reason="NDI SDK not found",
+        install_hint="Install the NDI SDK from https://ndi.video/tools and restart Scope.",
+    )
+
+
+def get_syphon_availability() -> IntegrationAvailability:
+    if is_syphon_output_available():
+        return IntegrationAvailability(available=True)
+    if sys.platform != "darwin":
+        return IntegrationAvailability(
+            available=False,
+            reason="Syphon is macOS-only",
+            install_hint="Run Scope on macOS to use Syphon sources and sinks.",
+        )
+    return IntegrationAvailability(
+        available=False,
+        reason="Syphon package not installed",
+        install_hint="Reinstall Scope dependencies with `uv sync` to enable Syphon.",
+    )
+
+
 _source_discovery_cache: dict[str, tuple[float, list]] = {}
 _SOURCE_DISCOVERY_TTL = 10  # seconds
 
@@ -2653,9 +2696,9 @@ async def get_hardware_info(
         if cloud_manager.is_connected:
             return await get_hardware_info_from_cloud(
                 cloud_manager,
-                is_spout_available(),
-                is_ndi_output_available(),
-                is_syphon_output_available(),
+                get_spout_availability(),
+                get_ndi_availability(),
+                get_syphon_availability(),
             )
 
         # Local mode: get local hardware info
@@ -2670,9 +2713,9 @@ async def get_hardware_info(
 
         return HardwareInfoResponse(
             vram_gb=vram_gb,
-            spout_available=is_spout_available(),
-            ndi_available=is_ndi_output_available(),
-            syphon_available=is_syphon_output_available(),
+            spout=get_spout_availability(),
+            ndi=get_ndi_availability(),
+            syphon=get_syphon_availability(),
         )
     except HTTPException:
         raise

--- a/src/scope/server/cloud_proxy.py
+++ b/src/scope/server/cloud_proxy.py
@@ -26,7 +26,7 @@ from fastapi import HTTPException, Request
 from fastapi.responses import Response
 
 from .models_config import get_assets_dir
-from .schema import AssetFileInfo, HardwareInfoResponse
+from .schema import AssetFileInfo, HardwareInfoResponse, IntegrationAvailability
 from .scope_cloud_types import ScopeCloudBackend
 
 logger = logging.getLogger(__name__)
@@ -154,9 +154,9 @@ async def proxy_with_body(
 
 async def get_hardware_info_from_cloud(
     cloud_manager: ScopeCloudBackend,
-    spout_available: bool,
-    ndi_available: bool = False,
-    syphon_available: bool = False,
+    spout: IntegrationAvailability,
+    ndi: IntegrationAvailability | None = None,
+    syphon: IntegrationAvailability | None = None,
 ) -> HardwareInfoResponse:
     """Fetch hardware info from cloud and return with local output availability.
 
@@ -187,9 +187,9 @@ async def get_hardware_info_from_cloud(
     data = response.get("data", {})
     return HardwareInfoResponse(
         vram_gb=data.get("vram_gb"),
-        spout_available=spout_available,
-        ndi_available=ndi_available,
-        syphon_available=syphon_available,
+        spout=spout,
+        ndi=ndi or IntegrationAvailability(),
+        syphon=syphon or IntegrationAvailability(),
     )
 
 

--- a/src/scope/server/schema.py
+++ b/src/scope/server/schema.py
@@ -250,23 +250,39 @@ class ErrorResponse(BaseModel):
     detail: str = Field(None, description="Additional error details")
 
 
+class IntegrationAvailability(BaseModel):
+    """Availability + install guidance for an optional integration (SDK/library)."""
+
+    available: bool = Field(
+        default=False, description="Whether the integration is ready to use"
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Short reason shown when unavailable (e.g. 'Spout is Windows-only')",
+    )
+    install_hint: str | None = Field(
+        default=None,
+        description="User-facing hint for how to make this integration available",
+    )
+
+
 class HardwareInfoResponse(BaseModel):
     """Hardware information response schema."""
 
     vram_gb: float | None = Field(
         default=None, description="Total VRAM in GB (None if CUDA not available)"
     )
-    spout_available: bool = Field(
-        default=False,
-        description="Whether Spout is available (Windows only, not WSL)",
+    spout: IntegrationAvailability = Field(
+        default_factory=IntegrationAvailability,
+        description="Spout video I/O (Windows only)",
     )
-    ndi_available: bool = Field(
-        default=False,
-        description="Whether NDI SDK is available for output",
+    ndi: IntegrationAvailability = Field(
+        default_factory=IntegrationAvailability,
+        description="NDI video I/O (all platforms, requires NDI SDK)",
     )
-    syphon_available: bool = Field(
-        default=False,
-        description="Whether Syphon is available for output (macOS only)",
+    syphon: IntegrationAvailability = Field(
+        default_factory=IntegrationAvailability,
+        description="Syphon video I/O (macOS only)",
     )
 
 


### PR DESCRIPTION
Split out from #990 per @leszko's review (rebase + smaller PRs).

## Summary

Source/Output node dropdowns previously filtered Spout/NDI/Syphon out of the type list whenever the backend reported them as unavailable. On macOS without the NDI SDK, NDI literally didn't appear in the dropdown — the silent failure that prompted the original \"where is NDI?\" report.

Now those options stay visible but render disabled, with:
- an **\"— unavailable\"** suffix on the option label
- a **hover tooltip** showing the install hint (e.g. \"Install the NDI SDK from https://ndi.video/tools and restart Scope\")
- an **inline amber note** below the dropdown when the currently-selected mode is disabled (handles stale graphs gracefully)

## Backend

`HardwareInfoResponse` switches from three plain booleans (`spout_available` / `ndi_available` / `syphon_available`) to three `IntegrationAvailability` objects, each carrying `available` + `reason` + `install_hint`. Mirrors the existing `tempo_sync` install_hint pattern. Platform gating (Spout=Windows-only, Syphon=macOS-only) and SDK-missing detection populate the hint string.

## Frontend

- `NodePillSelect` gains a per-option `disabled` flag and `reason` tooltip.
- `SourceNode` / `OutputNode` plumb the per-integration reason through the existing availability flow (`useStreamState` → `StreamPage` → `GraphEditor` → `useGraphState` → `nodeEnrichment` → `node.data`).
- Plays nicely with the dynamic `availableInputSources` system landed in #987 — backend-reported unavailable sources still show, just disabled with the reason from the hardware-info endpoint.

## Files changed

**Backend** — `src/scope/server/schema.py`, `app.py`, `cloud_proxy.py`
**Frontend** — `frontend/src/lib/api.ts`, `lib/graphUtils.ts`, `hooks/useStreamState.ts`, `pages/StreamPage.tsx`, `components/graph/GraphEditor.tsx`, `hooks/graph/useGraphState.ts`, `utils/nodeEnrichment.ts`, `ui/NodePillSelect.tsx`, `nodes/SourceNode.tsx`, `nodes/OutputNode.tsx`

## Testing

1. `uv run ruff check src/ && uv run ruff format --check src/` ✓
2. `cd frontend && npm run lint && npm run format:check && npm run build` ✓
3. **Backend smoke**: `curl http://localhost:8000/api/v1/hardware/info` returns the new `{available, reason, install_hint}` per integration.
4. **macOS without NDI SDK**: open the graph editor, add a Source node → NDI is visible but greyed with the install-link tooltip on hover. Same on the Output node.
5. **Windows behavior**: NDI/Syphon greyed with platform-specific reasons (\"Spout is Windows-only\" reverses for the appropriate OS).
6. **Backwards compat**: existing graphs with a saved sourceMode that's no longer available render as `<name> (unavailable)` rather than silently switching.

## Companion PR

The graph editor \"?\" cheat sheet button was the second feature in the original #990 — it's coming as a separate PR for cleaner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)