### PR TITLE
chore(docker): bump bundled scope-ltx-2 pin in Dockerfile.cloud

### DIFF
--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -47,8 +47,8 @@ COPY src/ /app/src/
 
 # Pre-install bundled plugins (cannot be removed by users)
 ENV DAYDREAM_SCOPE_BUNDLED_PLUGINS_FILE="/app/bundled-plugins.txt"
-RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git@69d2a1dfdfd810011ba4be084abcb28389826518" > /app/bundled-plugins.txt
-RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git@69d2a1dfdfd810011ba4be084abcb28389826518
+RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git@d13b5f9d94130b975989cd820eedbef5b3a8f165" > /app/bundled-plugins.txt
+RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git@d13b5f9d94130b975989cd820eedbef5b3a8f165
 
 # Expose port 8000 for RunPod HTTP proxy
 EXPOSE 8000


### PR DESCRIPTION
## Summary

Cloud builds (`Dockerfile.cloud`) ship a pinned `scope-ltx-2` install so RunPod images stay reproducible. This updates that pin from \`69d2a1df\` to current default-branch HEAD \`d13b5f9d\`, so bundled LTX matches the latest plugin without changing install mechanics.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Made with [Cursor](https://cursor.com)