### PR TITLE
fix(graph): give audio edges a distinct color

### DIFF
--- a/frontend/src/components/graph/nodeColors.ts
+++ b/frontend/src/components/graph/nodeColors.ts
@@ -14,7 +14,7 @@ export const COLOR_BOOLEAN = "#34d399"; // emerald-400
 export const COLOR_TRIGGER = "#f97316"; // orange-500
 export const COLOR_VACE = "#a78bfa"; // violet-400
 export const COLOR_LORA = "#f472b6"; // pink-400
-export const COLOR_AUDIO = "#34d399"; // emerald-400
+export const COLOR_AUDIO = "#06b6d4"; // cyan-500
 export const COLOR_IMAGE = COLOR_STRING; // images are string-typed paths
 export const COLOR_DOT = "#fafafa";
 export const COLOR_DEFAULT = "#9ca3af"; // gray-400
@@ -37,6 +37,7 @@ export const PARAM_TYPE_COLORS: Record<string, string> = {
 export const HANDLE_COLORS: Record<string, string> = {
   video: COLOR_STREAM,
   video2: COLOR_STREAM,
+  audio: COLOR_AUDIO,
   vace_input_frames: "#ffffff",
   vace_input_masks: COLOR_LORA, // pink-400
   source: "#4ade80",


### PR DESCRIPTION
## Summary

- `COLOR_AUDIO` was set to `#34d399` — identical to `COLOR_BOOLEAN`. Audio param edges and boolean edges were visually indistinguishable.
- Stream-port handles had no entry for \`audio\`, so audio stream edges fell through to the video gray (\`#eeeeee\`).
- Switch \`COLOR_AUDIO\` to cyan-500 (\`#06b6d4\`), and add \`audio: COLOR_AUDIO\` to \`HANDLE_COLORS\` so the audio stream handle and audio param edge share one consistent color.

Addresses the "Color coding of noodles needs to make sense" item in the bug tracker.

## Test plan

- [ ] Open a graph with an audio source connected to a pipeline — edge should now be cyan, not gray.
- [ ] Open a graph with a bool node connected to a pipeline param — edge should still be emerald (unchanged).
- [ ] Confirm no other emerald/cyan edges look out of place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)