### PR TITLE
fix(workflow-import): accept utility-only graph workflows

### DIFF
--- a/frontend/src/components/WorkflowImportDialog.tsx
+++ b/frontend/src/components/WorkflowImportDialog.tsx
@@ -418,11 +418,22 @@ export function WorkflowImportDialog({
         if (
           !parsed.metadata ||
           typeof parsed.metadata.name !== "string" ||
-          !Array.isArray(parsed.pipelines) ||
-          parsed.pipelines.length === 0
+          !Array.isArray(parsed.pipelines)
         ) {
           toast.error("Malformed workflow file", {
             description: "Missing required fields: metadata or pipelines",
+          });
+          return;
+        }
+
+        // A graph workflow may legitimately have an empty pipelines array
+        // (utility-only graphs), as long as it carries an embedded graph.
+        const hasEmbeddedGraph = Boolean(
+          parsed.graph?.nodes && parsed.graph?.edges
+        );
+        if (parsed.pipelines.length === 0 && !hasEmbeddedGraph) {
+          toast.error("Malformed workflow file", {
+            description: "Workflow has no pipelines and no graph to import",
           });
           return;
         }


### PR DESCRIPTION
## Summary

**Status: draft — speculative fix without a confirmed repro.**

Investigating the "Exported workflow, but it cannot be imported by others" bug, the original sample JSON was not attached to the bug report, so I could not reproduce the exact failure mode. This PR addresses one plausible cause:

- The import validator in \`WorkflowImportDialog.handleFileSelect\` rejects any workflow with \`pipelines.length === 0\` as "Malformed."
- Graph-mode \`buildGraphWorkflow\` builds the \`pipelines\` array by filtering for nodes of \`type === "pipeline"\`. A graph that contains only utility, source, sink, or plugin nodes (no pipeline nodes) would export a valid file with \`pipelines: []\` and an embedded \`graph\` — but be rejected on import.

The fix relaxes the validator to require \`pipelines\` **or** an embedded \`graph\`, and improves the error message when neither is present.

## Test plan

- [ ] **Need:** the actual workflow JSON from the bug reporter, to confirm whether this is the failure mode.
- [ ] Manually export a graph that contains no pipeline nodes (only sources/sinks/utility) and verify it now imports.
- [ ] Verify that a malformed file (missing both pipelines and graph) still surfaces a clear error.
- [ ] Confirm normal pipeline-bearing workflows still import as before.

## Why draft

If the underlying bug is something else (LoRA path resolution, plugin source mismatch, schema-field drift), this PR will not fix it and risks masking the real issue. Please confirm with the original sample workflow before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)