### PR TITLE
fix(graph): avoid spurious pipeline-node re-renders on each keystroke

### DIFF
--- a/frontend/src/components/graph/hooks/node/usePipelineParams.ts
+++ b/frontend/src/components/graph/hooks/node/usePipelineParams.ts
@@ -12,6 +12,11 @@ import type {
 import { getDefaultPromptForMode } from "../../../../data/pipelines";
 import type { InputMode } from "../../../../types";
 
+// Stable reference for pipeline nodes that have no params yet. Without this,
+// `nodeParams[id] || {}` produces a fresh object every keystroke, causing
+// every pipeline node's data ref to flip and forcing spurious re-renders.
+const EMPTY_PARAMS: Record<string, unknown> = Object.freeze({});
+
 interface UsePipelineParamsArgs {
   setNodes: React.Dispatch<React.SetStateAction<Node<FlowNodeData>[]>>;
   setEdges: React.Dispatch<React.SetStateAction<Edge[]>>;
@@ -284,15 +289,21 @@ export function usePipelineParams({
       let changed = false;
       const result = nds.map(n => {
         if (n.data.nodeType === "pipeline") {
-          const vals = nodeParams[n.id] || {};
-          if (n.data.parameterValues === vals) return n;
+          const vals = nodeParams[n.id] || EMPTY_PARAMS;
+          const promptText = (vals.__prompt as string) || "";
+          if (
+            n.data.parameterValues === vals &&
+            n.data.promptText === promptText
+          ) {
+            return n;
+          }
           changed = true;
           return {
             ...n,
             data: {
               ...n.data,
               parameterValues: vals,
-              promptText: (vals.__prompt as string) || "",
+              promptText,
             },
           };
         }


### PR DESCRIPTION
## Summary

**Status: draft — speculative fix without a confirmed repro.**

While investigating "Can't enter prompt if two pipeline nodes present (worked around by using primitive)" from the bug tracker, I found a real perf bug in the `nodeParams -> node data` sync that could plausibly contribute to input/focus issues:

```ts
const vals = nodeParams[n.id] || {};
if (n.data.parameterValues === vals) return n;
```

The `{}` fallback creates a fresh empty object every time the effect runs, so the identity check always fails for pipeline nodes that have no params yet — every such node's `data` ref flips on every keystroke into any prompt textarea, forcing React Flow to re-render them all.

This PR:
- Uses a frozen `EMPTY_PARAMS` sentinel so paramless pipelines stay reference-stable.
- Adds an explicit `promptText` comparison so a recomputed-but-equal prompt doesn't trigger a re-render.

## Why draft

I couldn't reproduce the exact reported behavior (the prompt textarea refusing input with 2+ pipelines) — this fix addresses a real perf bug that *might* be a contributing factor, but the actual cause could be elsewhere in the focus/event chain. Should be smoke-tested by the reporter before merging.

## Test plan

- [ ] **Need:** confirmation from the bug reporter that this fixes the symptom.
- [ ] Add 2 pipeline nodes to a graph — verify prompts can be typed into both.
- [ ] Profile React renders before/after — paramless pipeline nodes should no longer re-render on each keystroke.
- [ ] Verify existing prompt-flow scenarios (single pipeline, prompt-from-primitive, prompt-from-prompt-list) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
