### PR TITLE
fix(lora): serialize manifest writes for concurrent downloads

### DIFF
--- a/src/scope/core/lora/manifest.py
+++ b/src/scope/core/lora/manifest.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
@@ -9,6 +10,13 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 MANIFEST_FILENAME = "lora_manifest.json"
+
+# Serialize manifest read-modify-write across concurrent download / tag
+# operations within a single process. Without this, two near-simultaneous
+# add_manifest_entry calls can overwrite each other (e.g. when downloads
+# triggered in quick succession finish around the same scheduler slice).
+# Cross-process safety still requires a file lock; that is out of scope here.
+_MANIFEST_LOCK = threading.Lock()
 
 
 class LoRAProvenance(BaseModel):
@@ -75,7 +83,8 @@ def add_manifest_entry(
         size_bytes=size_bytes,
         added_at=datetime.now(UTC),
     )
-    manifest = load_manifest(lora_dir)
-    manifest.entries[filename] = entry
-    save_manifest(lora_dir, manifest)
+    with _MANIFEST_LOCK:
+        manifest = load_manifest(lora_dir)
+        manifest.entries[filename] = entry
+        save_manifest(lora_dir, manifest)
     return entry

--- a/src/scope/server/lora_downloader.py
+++ b/src/scope/server/lora_downloader.py
@@ -204,7 +204,15 @@ async def download_lora(
         version_id=request.version_id,
         url=request.url,
     )
-    add_manifest_entry(lora_dir, relative_filename, provenance, sha256, size_bytes)
+    await loop.run_in_executor(
+        None,
+        add_manifest_entry,
+        lora_dir,
+        relative_filename,
+        provenance,
+        sha256,
+        size_bytes,
+    )
 
     return LoRADownloadResult(
         filename=relative_filename,


### PR DESCRIPTION
## Summary

**Status: draft — speculative fix without a confirmed repro.**

Investigating "Triggering multiple downloads does not work reliably" from the bug tracker, I found a real race condition in the LoRA manifest update path that's a plausible contributor:

`add_manifest_entry` did `load_manifest` → mutate → `save_manifest` with no locking. Concurrent downloads (or a download finishing alongside a provenance-tag call) that hit this path close together can each load the manifest before the other has written its entry, then both save — dropping one of the entries.

This PR:
- Wraps the manifest read-modify-write in a process-local `threading.Lock` inside `add_manifest_entry`, so all callers (sync `tag_lora_provenance` + async `download_lora`) are protected.
- Pushes the (synchronous) `add_manifest_entry` call off the event loop in `download_lora` via `run_in_executor` — file I/O was previously blocking the loop after each download completed.

Cross-process safety (uvicorn `--workers > 1`) would need a file lock; that is **out of scope** here.

## Why draft

The original bug report is brief ("Triggering multiple downloads does not work reliably") with a Discord link I couldn't access from the bug folder. The manifest race is one plausible cause, but other failure modes — frontend progress-tracking confusion, executor thread pool saturation, partial-file collisions when two downloads target the same filename — are not addressed here.

## Test plan

- [ ] **Need:** confirmation from the original reporter that this resolves the symptom they saw.
- [ ] Trigger 3–5 concurrent LoRA downloads (different repos) and verify all entries appear in `lora_manifest.json`.
- [ ] Trigger a download and a provenance-tag call concurrently — both entries should land.
- [ ] Verify single-download flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
