### PR TITLE
fix(workflows): preserve pipelines key when proxying resolve to cloud

### DIFF
--- a/src/scope/core/workflows/resolve.py
+++ b/src/scope/core/workflows/resolve.py
@@ -85,13 +85,21 @@ class WorkflowRequest(BaseModel, extra="ignore"):
         unification there is one canonical list (``nodes``); this
         validator merges both keys when present so the rest of the code
         only has to look at :attr:`nodes`.
+
+        Must not mutate ``data``. Starlette caches the parsed request
+        JSON on ``request._json`` and ``cloud_proxy`` reads it again to
+        forward the body to the cloud — popping ``pipelines`` here
+        would strip it from the proxied request and break older cloud
+        builds that still require that field.
         """
         if not isinstance(data, dict):
             return data
-        legacy = data.pop("pipelines", None)
+        legacy = data.get("pipelines")
         if legacy:
-            combined = list(legacy) + list(data.get("nodes") or [])
-            data["nodes"] = combined
+            return {
+                **data,
+                "nodes": list(legacy) + list(data.get("nodes") or []),
+            }
         return data
 
 

--- a/tests/test_workflow_resolve.py
+++ b/tests/test_workflow_resolve.py
@@ -512,6 +512,24 @@ class TestExtraFieldsIgnored:
         assert wf.nodes[0].node_type_id == "p"
         assert not hasattr(wf, "future_field")
 
+    def test_validation_does_not_mutate_input_dict(self):
+        """Starlette caches the parsed request body on ``request._json`` and
+        ``cloud_proxy`` reads it again to forward the body upstream. If
+        validation pops/replaces keys on the input dict, the proxied request
+        loses ``pipelines`` — which breaks older cloud builds that still
+        require that field. Guard against that regression here.
+        """
+        data = {
+            "format": "scope-workflow",
+            "pipelines": [{"pipeline_id": "longlive", "source": {"type": "builtin"}}],
+        }
+        snapshot = {"keys": sorted(data.keys()), "pipelines": list(data["pipelines"])}
+        wf = WorkflowRequest.model_validate(data)
+        assert wf.nodes[0].node_type_id == "longlive"
+        assert sorted(data.keys()) == snapshot["keys"]
+        assert "pipelines" in data
+        assert data["pipelines"] == snapshot["pipelines"]
+
 
 # ---------------------------------------------------------------------------
 # min_scope_version tests


### PR DESCRIPTION
## Summary

Selecting any featured workflow while connected to cloud failed with `Cloud proxy request failed: status: 422 ... loc: ['body', 'pipelines'], msg: 'Field required'` — affecting every workflow, including the bundled starters.

## Root cause

`_merge_legacy_pipelines` was popping `pipelines` out of the request dict during Pydantic validation:

```python
legacy = data.pop("pipelines", None)   # mutates the cached body
data["nodes"] = combined
```

Starlette caches the parsed request JSON on `request._json` and returns the same dict reference on every `await request.json()` call. FastAPI handed that cached dict to Pydantic for validation, then `cloud_proxy._proxy_to_cloud` read it again to forward the body upstream — by which point `pipelines` had been stripped and only `nodes` remained. Older cloud builds still require `pipelines` and rejected the resulting `nodes`-only payload, so every proxied workflow blew up.

Reproduced before the fix:
```
BEFORE validation: ['format', 'pipelines']
AFTER validation:  ['format', 'nodes']
```

## Fix

Return a new dict from the validator instead of mutating the input. The original `request._json` is left alone, so whatever the frontend sent (legacy `pipelines`, new `nodes`, or both) reaches the cloud verbatim. Internal model semantics are unchanged: `wf.nodes` still combines both keys for in-process consumers.

## Compatibility matrix after this fix

| Client                                      | Behavior                                                                 |
|---------------------------------------------|--------------------------------------------------------------------------|
| New Electron (post-fix)                     | Body forwarded as-is — works with any cloud                              |
| Recent preview Electron (post-#980, pre-fix)| Local validator still mutates locally, but new cloud accepts `nodes` ✅  |
| Pre-#980 stable (v0.2.3)                    | Works when frontend sends `pipelines`; out of our reach for `nodes`-only |

## Test plan

- [x] `uv run pytest tests/test_workflow_resolve.py` — 54 passed (includes new `test_validation_does_not_mutate_input_dict` regression).
- [x] `uv run ruff check src/scope/core/workflows/resolve.py tests/test_workflow_resolve.py` — clean.
- [x] `uv run ruff format --check` — clean.
- [ ] Manually verify: select a featured workflow in the Electron preview while connected to cloud — no longer 422s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)