### PR TITLE
fix(tests): unblock AudioProcessingTrack recv() silence tests

### DIFF
--- a/tests/test_audio_processing_track.py
+++ b/tests/test_audio_processing_track.py
@@ -200,7 +200,7 @@ class TestResampling:
 
 class TestRecv:
     def test_no_audio_returns_silence(self):
-        track = _make_track(started=False)
+        track = _make_track()
         frame = _run(track.recv())
         raw = np.frombuffer(bytes(frame.planes[0]), dtype=np.int16)
         assert np.all(raw == 0)
@@ -247,7 +247,7 @@ class TestRecv:
         assert isinstance(frame, AudioFrame)
 
     def test_paused_returns_silence(self):
-        track = _make_track(started=False)
+        track = _make_track()
         track.frame_processor.paused = True
         audio = torch.randn(2, SAMPLES_PER_FRAME + 100)
         track.frame_processor.get_audio_packet = MagicMock(
@@ -259,7 +259,7 @@ class TestRecv:
         assert np.all(raw == 0)
 
     def test_undersized_chunk_returns_silence(self):
-        track = _make_track(started=False)
+        track = _make_track()
         audio = torch.randn(2, 100)  # too small for a 960-sample frame
         track.frame_processor.get_audio_packet = MagicMock(
             side_effect=_once(audio, 48000)


### PR DESCRIPTION
## Summary

- CI test runs were timing out at ~2h (recent runs cancelled at 1h43m / 1h56m / 2h0m). Root cause: PR #1001 ("Delay A/V in WebRTC until both tracks have been seen.") changed `AudioProcessingTrack.recv()` so the first call now blocks in `_wait_for_initial_audio()` until enough audio has been buffered, but three tests in `tests/test_audio_processing_track.py` still constructed tracks with `started=False` and fed no / insufficient / paused audio — so `recv()` looped forever.
- Drop `started=False` from the silence-fallback tests (`test_no_audio_returns_silence`, `test_paused_returns_silence`, `test_undersized_chunk_returns_silence`) so they exercise the post-anchor `recv()` path, which is the path these silence-fallback assertions actually care about.
- Local `pytest` now completes in ~70s instead of hanging.

## Test plan

- [x] `uv run pytest tests/test_audio_processing_track.py -v` — 30/30 pass in ~1.2s
- [x] `uv run pytest` — full suite completes in ~70s (vs. previously hanging on `test_no_audio_returns_silence`)
- [x] `uv run ruff check tests/test_audio_processing_track.py` clean
- [x] `uv run ruff format --check tests/test_audio_processing_track.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
