### PR TITLE
feat(pipeline): one-shot 'step' trigger while paused

### DIFF
--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -500,8 +500,15 @@ class PipelineProcessor:
             self._last_batch_time = None
             self.paused = paused
         if self.paused:
-            self.shutdown_event.wait(SLEEP_TIME)
-            return
+            # While paused, a one-shot `step: true` trigger advances the
+            # pipeline by exactly one chunk before falling back to paused.
+            # Used by frame-by-frame render drivers that clock the pipeline
+            # off-line — engines stay loaded, no separate session needed.
+            if self.parameters.pop("step", False):
+                pass  # fall through to process_chunk
+            else:
+                self.shutdown_event.wait(SLEEP_TIME)
+                return
 
         # Prepare pipeline
         reset_cache = self.parameters.pop("reset_cache", None)


### PR DESCRIPTION
## Summary

Adds a one-shot `step: true` parameter that, while the pipeline worker is paused, advances the pipeline by exactly one chunk before re-entering the paused state. Same trigger-param shape as the existing `next_video` / `restart_video` (consumed by `pop`, auto-resets each pause cycle).

## Why

Unlocks off-line frame-by-frame render drivers — pause every node, send `step: true` per frame, capture the sink's output between steps. Engines stay loaded; no second session, no double VRAM, no model reloading.

Today the only deterministic-render option is to spawn a separate Python process that re-instantiates plugin pipelines. That contends for the GPU with the live session and pays a re-load tax. With this gate, a moth-side or external render driver can clock the live session itself.

## Scope

- 9 added / 2 removed in `src/scope/server/pipeline_processor.py`. Single block inside the existing `paused` branch in `process_chunk`.
- Continuous-mode behavior is unchanged: the new branch only fires while `self.paused == True`. When `paused` is False the old code path runs as-is.
- A separate follow-up PR will add `format=png` on `GET /api/v1/session/frame` for lossless capture (needed because JPEG q=100 is still chroma-subsampled).

## Test plan

- [ ] Pause a running session via `update_parameters({paused: true})`; verify worker stops producing frames.
- [ ] Send `update_parameters({step: true})`; verify exactly one chunk advances (frame counter increments by one).
- [ ] Repeat 30 times; verify pipeline produces 30 stepped frames identical to a continuous run with the same seed.
- [ ] Resume with `update_parameters({paused: false})`; verify continuous-mode resumes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)