### PR TITLE
feat(errors): surface pipeline failures in the UI

### DIFF
--- a/.agents/skills/testing-livepeer/SKILL.md
+++ b/.agents/skills/testing-livepeer/SKILL.md
@@ -79,18 +79,22 @@ The `url` points to the local `livepeer-runner` websocket endpoint, not the Scop
 
 ## Start The Local Stack
 
-Kill old processes on the relevant ports first:
+**Port selection — check first, do not blind-kill.** Cursor (and other IDEs) commonly hold ports `8935` and `8022` on macOS via remote-tunnel/extension hosts. Never kill processes you didn't start; pick free ports instead. The doc's defaults below assume the canonical ports — if any are taken, pick the next free one and adjust `LIVEPEER_ORCH_URL` and Scope's `--port` accordingly. Before starting, run:
 
 ```bash
-lsof -ti:8001 -ti:8022 -ti:8935 | xargs kill -9 2>/dev/null
-lsof -tiUDP:9001 | xargs kill -9 2>/dev/null
+lsof -i :8001 -i :8022 -i :8935 2>/dev/null
+lsof -iUDP:9001 2>/dev/null
 ```
+
+A common alternate set when 8022/8935 are taken: orchestrator `8936`, Scope `8023`, runner `8001` (rarely conflicts), OSC UDP `9001`.
 
 **Orchestrator:**
 
 ```bash
 ./livepeer -orchestrator -aiWorker -aiServerless -aiModels serverless.json -serviceAddr localhost:8935
 ```
+
+If `flag provided but not defined: -aiServerless`, the local binary predates the `ja/serverless` PR. Download the artifact (see "Artifact Discovery"), save it as `livepeer-serverless` next to the existing one, and use that. Do not overwrite the user's existing `livepeer` binary.
 
 **Runner** (`SCOPE_PORT=9001` prevents OSC port collision with the main Scope server; `LIVEPEER_DEV_MODE=1` skips auth for local testing):
 
@@ -115,6 +119,15 @@ uv run daydream-scope --no-browser --port 8022
 ```
 
 Wait for health: `curl -s http://localhost:8022/health`
+
+**Connect to cloud (Livepeer mode).** As of 2026-05, `POST /api/v1/cloud/connect` requires a non-empty `app_id` ending in `/ws` even in Livepeer dev mode (the value is parsed into a `wss://fal.run/<app_id>` URL but auth is skipped). Empty body returns 400. Use:
+
+```bash
+curl -s -X POST http://localhost:<scope-port>/api/v1/cloud/connect \
+  -H 'Content-Type: application/json' -d '{"app_id": "livepeer/dev/ws"}'
+# poll status (connecting → connected: true within ~5s)
+curl -s http://localhost:<scope-port>/api/v1/cloud/status
+```
 
 For MCP-driven testing after Scope is healthy, follow the `testing-scope-mcp` skill to start the MCP server and connect to port `8022`.
 
@@ -159,7 +172,7 @@ HTTP API fallbacks useful during Livepeer testing (when MCP is unavailable):
 
 | Operation | Endpoint |
 |-----------|----------|
-| Cloud connect | `POST /api/v1/cloud/connect` body: `{}` |
+| Cloud connect | `POST /api/v1/cloud/connect` body: `{"app_id": "livepeer/dev/ws"}` (must end in `/ws`) |
 | Cloud disconnect | `POST /api/v1/cloud/disconnect` |
 | Cloud status | `GET /api/v1/cloud/status` |
 | Load pipeline | `POST /api/v1/pipeline/load` body: `{"pipeline_ids": ["name"]}` |

--- a/frontend/src/components/VideoOutput.tsx
+++ b/frontend/src/components/VideoOutput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import { Volume2, VolumeX } from "lucide-react";
+import { AlertTriangle, Volume2, VolumeX } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import type { StreamError } from "../hooks/useUnifiedWebRTC";
 import { Spinner } from "./ui/spinner";
 import { PlayOverlay } from "./ui/play-overlay";
 import { useCloudStatus } from "../hooks/useCloudStatus";
@@ -13,6 +14,8 @@ interface VideoOutputProps {
   isCloudConnecting?: boolean;
   isConnecting?: boolean;
   pipelineError?: string | null;
+  /** Active runtime stream error from the backend (overlay + replaces video) */
+  streamError?: StreamError | null;
   cloudConnectStage?: string | null;
   pipelineLoadingStage?: string | null;
   isPlaying?: boolean;
@@ -37,6 +40,7 @@ export function VideoOutput({
   isCloudConnecting = false,
   isConnecting = false,
   pipelineError: _pipelineError = null,
+  streamError = null,
   cloudConnectStage = null,
   pipelineLoadingStage = null,
   isPlaying = true,
@@ -203,7 +207,36 @@ export function VideoOutput({
         <CardTitle className="text-base font-medium">Video Output</CardTitle>
       </CardHeader>
       <CardContent className="flex-1 flex items-center justify-center min-h-0 p-4">
-        {remoteStream ? (
+        {streamError ? (
+          (() => {
+            const label = streamError.nodeId ?? streamError.pipelineId;
+            return (
+              <div className="flex flex-col items-center justify-center gap-3 text-center max-w-[480px] px-4">
+                <div className="rounded-full bg-red-500/15 p-3 ring-1 ring-red-500/40">
+                  <AlertTriangle className="w-8 h-8 text-red-400" />
+                </div>
+                <p className="text-base font-medium text-red-300">
+                  {label ? `Pipeline error (${label})` : "Pipeline error"}
+                </p>
+                <p className="text-sm text-red-200/80 break-words leading-relaxed">
+                  {streamError.message}
+                </p>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Stream stopped. Check the logs and try again.
+                </p>
+                {onStartStream && (
+                  <button
+                    type="button"
+                    onClick={onStartStream}
+                    className="mt-2 px-3 py-1.5 text-xs rounded-md bg-red-500/20 hover:bg-red-500/30 text-red-100 ring-1 ring-red-500/40 transition-colors"
+                  >
+                    Retry
+                  </button>
+                )}
+              </div>
+            );
+          })()
+        ) : remoteStream ? (
           <div
             ref={containerRef}
             className="relative w-full h-full cursor-pointer flex items-center justify-center"

--- a/frontend/src/components/graph/GraphEditor.tsx
+++ b/frontend/src/components/graph/GraphEditor.tsx
@@ -236,6 +236,7 @@ interface GraphEditorProps {
   remoteStream?: MediaStream | null;
   remoteStreams?: Record<string, MediaStream>;
   sinkStats?: Record<string, { fps: number; bitrate: number }>;
+  streamError?: import("../../hooks/useUnifiedWebRTC").StreamError | null;
   onVideoFileUpload?: (file: File, nodeId?: string) => Promise<boolean>;
   onCycleSampleVideo?: (nodeId?: string) => void;
   onInitSampleVideo?: (nodeId?: string) => void;
@@ -290,6 +291,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
       remoteStream,
       remoteStreams,
       sinkStats,
+      streamError = null,
       onVideoFileUpload,
       onCycleSampleVideo,
       onInitSampleVideo,
@@ -396,6 +398,7 @@ export const GraphEditor = forwardRef<GraphEditorHandle, GraphEditorProps>(
         remoteStream,
         remoteStreams,
         sinkStats,
+        streamError,
         isStreaming,
         isPlaying,
         onPlayPauseToggle,

--- a/frontend/src/components/graph/hooks/graph/useGraphState.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphState.ts
@@ -91,6 +91,7 @@ export interface GraphEditorStreams {
   remoteStream?: MediaStream | null;
   remoteStreams?: Record<string, MediaStream>;
   sinkStats?: Record<string, { fps: number; bitrate: number }>;
+  streamError?: import("../../../../hooks/useUnifiedWebRTC").StreamError | null;
   isStreaming: boolean;
   isLoading?: boolean;
   loadingStage?: string | null;
@@ -281,6 +282,7 @@ export function useGraphState(
     remoteStream: streams.remoteStream,
     remoteStreams: streams.remoteStreams,
     sinkStats: streams.sinkStats,
+    streamError: streams.streamError ?? null,
     onVideoFileUploadRef,
     onSourceModeChangeRef,
     onSpoutSourceChangeRef,
@@ -337,6 +339,7 @@ export function useGraphState(
     streams.remoteStream,
     streams.remoteStreams,
     streams.sinkStats,
+    streams.streamError,
     streams.isStreaming,
     streams.isLoading,
     streams.loadingStage,

--- a/frontend/src/components/graph/nodes/SinkNode.tsx
+++ b/frontend/src/components/graph/nodes/SinkNode.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { Handle, Position } from "@xyflow/react";
 import type { NodeProps, Node } from "@xyflow/react";
 import {
+  AlertTriangle,
   Maximize2,
   Minimize2,
   Pause,
@@ -11,6 +12,7 @@ import {
   VolumeX,
 } from "lucide-react";
 import type { FlowNodeData } from "../../../lib/graphUtils";
+import type { StreamError } from "../../../hooks/useUnifiedWebRTC";
 import { useNodeData } from "../hooks/node/useNodeData";
 import { useNodeCollapse } from "../hooks/node/useNodeCollapse";
 import { NodeCard, NodeHeader, collapsedHandleStyle } from "../ui";
@@ -28,6 +30,8 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
   const sinkStats = data.sinkStats as
     | { fps: number; bitrate: number }
     | undefined;
+  const streamError =
+    (data.streamError as StreamError | null | undefined) ?? null;
   const isPlaying = (data.isPlaying as boolean | undefined) ?? true;
   const onPlayPauseToggle = data.onPlayPauseToggle as (() => void) | undefined;
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -104,17 +108,34 @@ export function SinkNode({ id, data, selected }: NodeProps<SinkNodeType>) {
 
   const handleY = HEADER_H + BODY_PAD + PREVIEW_H / 2;
 
+  // Show the error on every sink (the toast already attributes it to a
+  // specific node) — sinks are where the user notices the blank screen.
   const videoContainer = (
     <div
       className={
         isFullscreen
           ? "fixed inset-0 z-[9999] bg-black"
-          : "relative rounded-md overflow-hidden bg-black/50 flex-1 min-h-[60px]"
+          : `relative rounded-md overflow-hidden bg-black/50 flex-1 min-h-[60px] ${
+              streamError ? "ring-2 ring-red-500/80" : ""
+            }`
       }
       onPointerDown={e => e.stopPropagation()}
       onWheel={isFullscreen ? e => e.stopPropagation() : undefined}
     >
-      {remoteStream ? (
+      {streamError ? (
+        <div className="flex flex-col items-center justify-center h-full gap-1.5 px-2 text-center">
+          <AlertTriangle className="h-5 w-5 text-red-400" />
+          <span className="text-[10px] font-medium text-red-300">
+            Pipeline error
+          </span>
+          <span
+            className="text-[9px] text-red-200/80 break-words leading-snug max-w-full"
+            title={streamError.message}
+          >
+            {streamError.message}
+          </span>
+        </div>
+      ) : remoteStream ? (
         <>
           <video
             ref={videoRef}

--- a/frontend/src/components/graph/utils/nodeEnrichment.ts
+++ b/frontend/src/components/graph/utils/nodeEnrichment.ts
@@ -25,6 +25,8 @@ export interface EnrichNodesDeps {
   remoteStreams?: Record<string, MediaStream>;
   /** Per-sink-node WebRTC stats */
   sinkStats?: Record<string, { fps: number; bitrate: number }>;
+  /** Active stream error to surface inline on sink nodes */
+  streamError?: import("../../../hooks/useUnifiedWebRTC").StreamError | null;
   onVideoFileUploadRef: React.RefObject<
     ((file: File, nodeId?: string) => Promise<boolean>) | undefined
   >;
@@ -201,6 +203,7 @@ export function enrichNodes(
           ...n.data,
           remoteStream: nodeRemoteStream,
           sinkStats: nodeStats,
+          streamError: deps.streamError ?? null,
           isPlaying: deps.isPlaying,
           isLoading: deps.isLoading,
           loadingStage: deps.loadingStage,

--- a/frontend/src/hooks/useUnifiedWebRTC.ts
+++ b/frontend/src/hooks/useUnifiedWebRTC.ts
@@ -41,6 +41,14 @@ interface InitialParameters {
   graph?: GraphConfig;
 }
 
+export interface StreamError {
+  message: string;
+  pipelineId?: string;
+  nodeId?: string;
+  exceptionType?: string;
+  fatal: boolean;
+}
+
 interface UseUnifiedWebRTCOptions {
   /** Callback function called when the stream stops on the backend */
   onStreamStop?: () => void;
@@ -75,6 +83,8 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
     useState<RTCPeerConnectionState>("new");
   const [isConnecting, setIsConnecting] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [streamError, setStreamError] = useState<StreamError | null>(null);
+  const streamErrorShownRef = useRef(false);
 
   const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
   const dataChannelRef = useRef<RTCDataChannel | null>(null);
@@ -104,6 +114,11 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
     setRemoteStreams({});
     setConnectionState("new");
     setIsStreaming(false);
+  }, []);
+
+  const clearStreamError = useCallback(() => {
+    setStreamError(null);
+    streamErrorShownRef.current = false;
   }, []);
 
   // Helper to get ICE servers
@@ -158,6 +173,8 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
     ) => {
       if (isConnecting || peerConnectionRef.current) return;
 
+      setStreamError(null);
+      streamErrorShownRef.current = false;
       setIsConnecting(true);
 
       try {
@@ -194,7 +211,30 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
           try {
             const data = JSON.parse(event.data);
 
-            // Handle stream stop notification from backend
+            // Sent before stream_stopped so we can attribute the failure to
+            // a specific pipeline / sink instead of just blanking the video.
+            if (data.type === "pipeline_error") {
+              const message: string =
+                typeof data.message === "string" && data.message.length > 0
+                  ? data.message
+                  : "Pipeline error";
+              const label = data.node_id ?? data.pipeline_id;
+              setStreamError({
+                message,
+                pipelineId: data.pipeline_id,
+                nodeId: data.node_id,
+                exceptionType: data.exception_type,
+                fatal: data.fatal !== false,
+              });
+              if (!streamErrorShownRef.current) {
+                streamErrorShownRef.current = true;
+                toast.error(
+                  label ? `Pipeline Error (${label})` : "Pipeline Error",
+                  { description: message, duration: 8000 }
+                );
+              }
+            }
+
             if (data.type === "stream_stopped") {
               console.log("[UnifiedWebRTC] Stream stopped by backend");
               setIsStreaming(false);
@@ -202,10 +242,15 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
               setRemoteStream(null);
               setRemoteStreams({});
 
-              if (data.error_message) {
-                toast.error("Stream Error", {
+              if (data.error_message && !streamErrorShownRef.current) {
+                streamErrorShownRef.current = true;
+                setStreamError({
+                  message: data.error_message,
+                  fatal: true,
+                });
+                toast.error("Pipeline Error", {
                   description: data.error_message,
-                  duration: 5000,
+                  duration: 8000,
                 });
               }
 
@@ -732,6 +777,8 @@ export function useUnifiedWebRTC(options?: UseUnifiedWebRTCOptions) {
     connectionState,
     isConnecting,
     isStreaming,
+    streamError,
+    clearStreamError,
     peerConnectionRef,
     sinkNodeIdsRef,
     sinkMidMapRef,

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -276,6 +276,8 @@ export interface FlowNodeData {
   remoteStream?: MediaStream | null;
   /** For sink nodes: per-sink WebRTC stats (FPS, bitrate) */
   sinkStats?: { fps: number; bitrate: number };
+  /** For sink nodes: active backend stream error to show as an inline overlay */
+  streamError?: import("../hooks/useUnifiedWebRTC").StreamError | null;
   /** For pipeline nodes: whether the selected pipeline supports prompts */
   supportsPrompts?: boolean;
   /** For pipeline nodes: whether the selected pipeline supports cache management (shows Reset Cache button) */
@@ -1172,6 +1174,7 @@ const NON_SERIALIZABLE_KEYS = new Set<string>([
   "localStream",
   "remoteStream",
   "sinkStats",
+  "streamError",
   "onVideoFileUpload",
   "onSourceModeChange",
   "onSpoutSourceChange",

--- a/frontend/src/pages/StreamPage.tsx
+++ b/frontend/src/pages/StreamPage.tsx
@@ -654,6 +654,7 @@ export function StreamPage() {
     remoteStreams,
     isStreaming,
     isConnecting,
+    streamError,
     peerConnectionRef,
     sinkNodeIdsRef,
     sinkMidMapRef,
@@ -3550,6 +3551,7 @@ export function StreamPage() {
             remoteStream={remoteStream}
             remoteStreams={remoteStreams}
             sinkStats={perSinkStats}
+            streamError={streamError}
             onVideoFileUpload={handlePerNodeVideoFileUpload}
             onCycleSampleVideo={handlePerNodeCycleSampleVideo}
             onInitSampleVideo={handlePerNodeInitSampleVideo}
@@ -3776,6 +3778,7 @@ export function StreamPage() {
                   isCloudConnecting={isCloudConnecting}
                   isConnecting={isConnecting}
                   pipelineError={pipelineError}
+                  streamError={streamError}
                   pipelineLoadingStage={pipelineLoadingStage}
                   cloudConnectStage={cloudConnectStage}
                   isPlaying={!settings.paused}

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -316,7 +316,32 @@ class FrameProcessor:
             connection_info=self.connection_info,
         )
 
-    def stop(self, error_message: str = None):
+    def _handle_pipeline_fatal_error(
+        self, pipeline_id: str, node_id: str | None, message: str
+    ) -> None:
+        """Stop the stream after a pipeline reports a fatal error.
+
+        Dispatched on a fresh daemon thread so we don't try to join the
+        worker thread that's calling us — that would deadlock pipeline
+        shutdown.
+        """
+        if not self.running:
+            return
+        label = node_id or pipeline_id or "pipeline"
+        error_message = f"{label}: {message}"
+        logger.error(
+            "[FRAME-PROCESSOR] Fatal pipeline error from %s — stopping stream: %s",
+            label,
+            message,
+        )
+        threading.Thread(
+            target=self.stop,
+            kwargs={"error_message": error_message},
+            name=f"frame-processor-stop-{label}",
+            daemon=True,
+        ).start()
+
+    def stop(self, error_message: str | None = None):
         if not self.running:
             return
 
@@ -366,9 +391,10 @@ class FrameProcessor:
         # Notify callback that frame processor has stopped
         if self.notification_callback:
             try:
-                message = {"type": "stream_stopped"}
+                message: dict[str, Any] = {"type": "stream_stopped"}
                 if error_message:
                     message["error_message"] = error_message
+                    message["fatal"] = True
                 self.notification_callback(message)
             except Exception as e:
                 logger.error(f"Error in frame processor stop callback: {e}")
@@ -1004,6 +1030,7 @@ class FrameProcessor:
             tempo_sync=self.tempo_sync,
             modulation_engine=self.modulation_engine,
             notification_callback=self.notification_callback,
+            on_fatal_error=self._handle_pipeline_fatal_error,
         )
 
         self._sink_processor = graph_run.sink_processor

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -69,6 +69,7 @@ def build_graph(
     tempo_sync: Any | None = None,
     modulation_engine: Any | None = None,
     notification_callback: Callable[[dict], None] | None = None,
+    on_fatal_error: Callable[[str, str, str], None] | None = None,
 ) -> GraphRun:
     """Build executable graph: create queues and processors, wire edges.
 
@@ -144,6 +145,7 @@ def build_graph(
                 modulation_engine=modulation_engine if node_gets_tempo else None,
                 node_id=node.id,
                 notification_callback=notification_callback,
+                on_fatal_error=on_fatal_error,
             )
             node_processors[node.id] = processor
             pipeline_ids.append(node.pipeline_id)

--- a/src/scope/server/graph_executor.py
+++ b/src/scope/server/graph_executor.py
@@ -69,7 +69,7 @@ def build_graph(
     tempo_sync: Any | None = None,
     modulation_engine: Any | None = None,
     notification_callback: Callable[[dict], None] | None = None,
-    on_fatal_error: Callable[[str, str, str], None] | None = None,
+    on_fatal_error: Callable[[str, str | None, str], None] | None = None,
 ) -> GraphRun:
     """Build executable graph: create queues and processors, wire edges.
 

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -62,7 +62,7 @@ class PipelineProcessor:
         modulation_engine: Any | None = None,
         node_id: str | None = None,
         notification_callback: Callable[[dict], None] | None = None,
-        on_fatal_error: Callable[[str, str, str], None] | None = None,
+        on_fatal_error: Callable[[str, str | None, str], None] | None = None,
     ):
         """Initialize a pipeline processor.
 

--- a/src/scope/server/pipeline_processor.py
+++ b/src/scope/server/pipeline_processor.py
@@ -40,6 +40,11 @@ MIN_FPS = 1.0  # Minimum FPS to prevent division by zero
 MAX_FPS = 60.0  # Maximum FPS cap
 BATCH_FPS_SAMPLE_SIZE = 10  # Number of batch-level samples for windowed averaging
 
+# A pipeline that throws every chunk would otherwise loop silently forever
+# and leave the user staring at a blank screen — escalate to a fatal error
+# after this many consecutive failures so the UI surfaces it.
+MAX_CONSECUTIVE_RECOVERABLE_ERRORS = 10
+
 
 class PipelineProcessor:
     """Processes frames through a single pipeline in a dedicated thread."""
@@ -57,6 +62,7 @@ class PipelineProcessor:
         modulation_engine: Any | None = None,
         node_id: str | None = None,
         notification_callback: Callable[[dict], None] | None = None,
+        on_fatal_error: Callable[[str, str, str], None] | None = None,
     ):
         """Initialize a pipeline processor.
 
@@ -72,6 +78,8 @@ class PipelineProcessor:
             modulation_engine: ModulationEngine for beat-synced param modulation
             node_id: Graph node ID (used for per-node parameter routing in graph mode)
             notification_callback: Lets consumers know of parameter updates etc
+            on_fatal_error: Invoked with (pipeline_id, node_id, error_message)
+                when this pipeline hits a fatal error and should stop the stream.
         """
         self.pipeline = pipeline
         self.pipeline_id = pipeline_id
@@ -83,6 +91,9 @@ class PipelineProcessor:
         self.tempo_sync = tempo_sync
         self.modulation_engine = modulation_engine
         self.notification_callback = notification_callback
+        self.on_fatal_error = on_fatal_error
+        self._consecutive_errors = 0
+        self._last_recoverable_error: tuple[str, str] | None = None
 
         # Port-based queues wired by graph_executor.build_graph()
         self.input_queues: dict[str, queue.Queue] = {}
@@ -338,6 +349,49 @@ class PipelineProcessor:
             )
             return False
 
+    def _trigger_fatal(self, message: str, exception_type: str) -> None:
+        """Notify frontend of a fatal pipeline error and request a stream stop."""
+        if self.notification_callback is not None:
+            try:
+                self.notification_callback(
+                    {
+                        "type": "pipeline_error",
+                        "pipeline_id": self.pipeline_id,
+                        "node_id": self.node_id,
+                        "message": message,
+                        "exception_type": exception_type,
+                        "fatal": True,
+                        "recoverable": False,
+                    }
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to emit pipeline_error notification for %s",
+                    self.pipeline_id,
+                    exc_info=True,
+                )
+        publish_event(
+            event_type="error",
+            session_id=self.session_id,
+            connection_id=self.connection_id,
+            pipeline_ids=[self.pipeline_id],
+            user_id=self.user_id,
+            error={
+                "error_type": "pipeline_processing_failed",
+                "message": message,
+                "exception_type": exception_type,
+                "recoverable": False,
+            },
+            connection_info=self.connection_info,
+        )
+        if self.on_fatal_error is not None:
+            try:
+                self.on_fatal_error(self.pipeline_id, self.node_id, message)
+            except Exception:
+                logger.exception(
+                    "Error in on_fatal_error callback for %s", self.pipeline_id
+                )
+
     def worker_loop(self):
         """Main worker loop that processes frames."""
         logger.info(f"Worker thread started for pipeline: {self.pipeline_id}")
@@ -345,41 +399,34 @@ class PipelineProcessor:
         while self.running and not self.shutdown_event.is_set():
             try:
                 self.process_chunk()
-
             except PipelineNotAvailableException as e:
                 logger.debug(
                     f"Pipeline {self.pipeline_id} temporarily unavailable: {e}"
                 )
-                # Sleep briefly and continue
                 self.shutdown_event.wait(SLEEP_TIME)
                 continue
             except Exception as e:
-                if self._is_recoverable(e):
-                    logger.error(
-                        f"Error in worker loop for {self.pipeline_id}: {e}",
-                        exc_info=True,
-                    )
-                    continue
-                else:
-                    logger.error(
-                        f"Non-recoverable error in worker loop for {self.pipeline_id}: {e}, stopping"
-                    )
-                    # Publish error event for pipeline processing failure
-                    publish_event(
-                        event_type="error",
-                        session_id=self.session_id,
-                        connection_id=self.connection_id,
-                        pipeline_ids=[self.pipeline_id],
-                        user_id=self.user_id,
-                        error={
-                            "error_type": "pipeline_processing_failed",
-                            "message": str(e),
-                            "exception_type": type(e).__name__,
-                            "recoverable": False,
-                        },
-                        connection_info=self.connection_info,
-                    )
-                    break
+                logger.error(
+                    f"Non-recoverable error in worker loop for {self.pipeline_id}: {e}, stopping"
+                )
+                self._trigger_fatal(
+                    message=f"{type(e).__name__}: {e}",
+                    exception_type=type(e).__name__,
+                )
+                break
+
+            if self._consecutive_errors >= MAX_CONSECUTIVE_RECOVERABLE_ERRORS:
+                msg, exc_type = self._last_recoverable_error or (
+                    "Pipeline produced no output",
+                    "PipelineStallError",
+                )
+                logger.error(
+                    f"Pipeline {self.pipeline_id} hit "
+                    f"{self._consecutive_errors} consecutive errors with no "
+                    "output, escalating to fatal"
+                )
+                self._trigger_fatal(message=msg, exception_type=exc_type)
+                break
 
         logger.info(f"Worker thread stopped for pipeline: {self.pipeline_id}")
 
@@ -605,6 +652,8 @@ class PipelineProcessor:
             processing_start = time.time()
             output_dict = self.pipeline(**call_params)
             processing_time = time.time() - processing_start
+            self._consecutive_errors = 0
+            self._last_recoverable_error = None
 
             if not output_dict:
                 # 1) Some pipelines return {} when idle
@@ -761,8 +810,15 @@ class PipelineProcessor:
 
         except Exception as e:
             if self._is_recoverable(e):
+                self._consecutive_errors += 1
+                self._last_recoverable_error = (
+                    f"{type(e).__name__}: {e}",
+                    type(e).__name__,
+                )
                 logger.error(
-                    f"Error processing chunk for {self.pipeline_id}: {e}", exc_info=True
+                    f"Error processing chunk for {self.pipeline_id} "
+                    f"(consecutive={self._consecutive_errors}): {e}",
+                    exc_info=True,
                 )
             else:
                 raise e

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import threading
 import uuid
 
 # Type checking imports
@@ -1334,14 +1335,29 @@ class WebRTCManager:
         Safe to call from worker threads: sends are marshalled onto the
         aiortc event loop through each session's :class:`NotificationSender`,
         which also buffers messages until the data channel is open.
+
+        When the message is fatal, also tear down the local relay session as
+        a safety net so it doesn't linger if the browser doesn't react.  We
+        deliberately don't pass ``error_message`` to ``FrameProcessor.stop``
+        — the upstream ``stream_stopped`` was already forwarded above and
+        would otherwise duplicate the toast.
         """
+        is_fatal = message.get("fatal") is True
+
         for session in self.sessions.values():
             if session.pc.connectionState in ("closed", "failed"):
                 continue
             sender = session.notification_sender
-            if sender is None:
-                continue
-            sender.call(message)
+            if sender is not None:
+                sender.call(message)
+            if is_fatal:
+                fp = getattr(session, "frame_processor", None)
+                if fp is not None and getattr(fp, "running", False):
+                    threading.Thread(
+                        target=fp.stop,
+                        name=f"webrtc-fatal-stop-{session.id}",
+                        daemon=True,
+                    ).start()
 
     async def stop(self):
         """Close and cleanup all sessions (WebRTC and headless)."""

--- a/tests/test_cloud_pipeline_error_forwarding.py
+++ b/tests/test_cloud_pipeline_error_forwarding.py
@@ -1,0 +1,208 @@
+"""Tests for cloud-side pipeline_error forwarding.
+
+Cloud architecture in scope:
+- Cloud-side scope's PipelineProcessor emits a pipeline_error notification
+  via its notification_callback (wired to _enqueue_notification on the
+  cloud).
+- Cloud's _forward_notifications_to_events writes
+  {"type": "notification", "payload": <pipeline_error>} to the events
+  channel.
+- Local relay's livepeer_client._forward_runner_notification receives that
+  payload and calls webrtc_manager.broadcast_notification(payload).
+- broadcast_notification fans the payload out to every active browser
+  session and, on a fatal error, schedules a defensive local-side
+  FrameProcessor stop so the relay doesn't linger if the browser is slow
+  to react.
+
+These tests cover the local-relay side of that chain — the cloud side is
+already covered by test_pipeline_error_notification.py.
+"""
+
+import time
+import types
+from unittest.mock import patch
+
+import pytest
+
+from scope.server.livepeer_client import _forward_runner_notification
+from scope.server.webrtc import WebRTCManager
+
+
+class _FakeSender:
+    def __init__(self):
+        self.messages: list[dict] = []
+
+    def call(self, message: dict) -> None:
+        self.messages.append(message)
+
+
+class _FakeFrameProcessor:
+    def __init__(self):
+        self.running = True
+        self.stop_calls = 0
+
+    def stop(self, error_message: str | None = None) -> None:
+        # Mimic FrameProcessor.stop early-exit guard.
+        if not self.running:
+            return
+        self.running = False
+        self.stop_calls += 1
+
+
+class _FakePeerConnection:
+    def __init__(self, state: str = "connected"):
+        self.connectionState = state
+
+
+class _FakeSession:
+    def __init__(self, sid: str):
+        self.id = sid
+        self.pc = _FakePeerConnection("connected")
+        self.notification_sender = _FakeSender()
+        self.frame_processor = _FakeFrameProcessor()
+
+
+@pytest.fixture
+def manager_with_session():
+    manager = WebRTCManager()
+    session = _FakeSession("session-1")
+    manager.sessions[session.id] = session
+    return manager, session
+
+
+def test_pipeline_error_is_broadcast_to_all_sessions(manager_with_session):
+    """A non-fatal pipeline_error from cloud reaches every active session."""
+    manager, session = manager_with_session
+
+    payload = {
+        "type": "pipeline_error",
+        "pipeline_id": "longlive",
+        "node_id": "longlive",
+        "message": "RuntimeError: boom",
+        "exception_type": "RuntimeError",
+        "fatal": False,
+        "recoverable": True,
+    }
+
+    manager.broadcast_notification(payload)
+
+    assert session.notification_sender.messages == [payload]
+    # Non-fatal: do NOT stop the relay's frame processor.
+    assert session.frame_processor.running is True
+    assert session.frame_processor.stop_calls == 0
+
+
+def test_fatal_pipeline_error_also_stops_local_frame_processor(manager_with_session):
+    """A fatal pipeline_error tears down the local relay too."""
+    manager, session = manager_with_session
+
+    payload = {
+        "type": "pipeline_error",
+        "pipeline_id": "longlive",
+        "node_id": "longlive",
+        "message": "CUDA OOM",
+        "exception_type": "OutOfMemoryError",
+        "fatal": True,
+        "recoverable": False,
+    }
+
+    manager.broadcast_notification(payload)
+
+    # Browser still gets the message.
+    assert session.notification_sender.messages == [payload]
+
+    # Defensive stop runs on a daemon thread; wait briefly.
+    deadline = time.time() + 2.0
+    while time.time() < deadline and session.frame_processor.running:
+        time.sleep(0.02)
+
+    assert session.frame_processor.running is False
+    assert session.frame_processor.stop_calls == 1
+
+
+def test_stream_stopped_with_error_also_tears_down(manager_with_session):
+    """stream_stopped carrying fatal=True tears down the local relay too."""
+    manager, session = manager_with_session
+
+    payload = {
+        "type": "stream_stopped",
+        "error_message": "Pipeline died",
+        "fatal": True,
+    }
+
+    manager.broadcast_notification(payload)
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and session.frame_processor.running:
+        time.sleep(0.02)
+
+    assert session.frame_processor.running is False
+
+
+def test_stream_stopped_without_error_does_not_tear_down(manager_with_session):
+    """A normal stream_stopped (e.g. user clicked Stop) does NOT tear down."""
+    manager, session = manager_with_session
+
+    manager.broadcast_notification({"type": "stream_stopped"})
+
+    # Give any (incorrect) thread a chance to run.
+    time.sleep(0.1)
+    assert session.frame_processor.running is True
+    assert session.frame_processor.stop_calls == 0
+
+
+def test_closed_session_is_skipped(manager_with_session):
+    """Closed/failed sessions don't receive notifications."""
+    manager, session = manager_with_session
+    session.pc.connectionState = "closed"
+
+    manager.broadcast_notification(
+        {"type": "pipeline_error", "fatal": True, "message": "x"}
+    )
+
+    assert session.notification_sender.messages == []
+    assert session.frame_processor.running is True
+
+
+def test_forward_runner_notification_routes_to_broadcast():
+    """_forward_runner_notification looks up webrtc_manager and forwards."""
+    fake_manager = types.SimpleNamespace(received=[])
+    fake_manager.broadcast_notification = lambda payload: fake_manager.received.append(
+        payload
+    )
+    fake_app = types.SimpleNamespace(webrtc_manager=fake_manager)
+
+    payload = {"type": "pipeline_error", "fatal": True, "message": "x"}
+    with patch.dict(
+        "sys.modules",
+        {
+            "scope.server.app": fake_app,
+            "scope.server": types.ModuleType("scope.server"),
+        },
+    ):
+        # The function uses `from . import app as _app`; patch that lookup.
+        with patch("scope.server.livepeer_client._forward_runner_notification") as _:
+            pass
+
+    # Easier: directly substitute scope.server.app.webrtc_manager.
+    import scope.server.app as real_app
+
+    saved = getattr(real_app, "webrtc_manager", None)
+    try:
+        real_app.webrtc_manager = fake_manager
+        _forward_runner_notification(payload)
+    finally:
+        if saved is None:
+            delattr(real_app, "webrtc_manager")
+        else:
+            real_app.webrtc_manager = saved
+
+    assert fake_manager.received == [payload]
+
+
+def test_forward_runner_notification_ignores_non_dict():
+    """Garbage payloads from the events channel are dropped silently."""
+    # Should not raise even if webrtc_manager is missing.
+    _forward_runner_notification("not a dict")
+    _forward_runner_notification(None)
+    _forward_runner_notification(42)

--- a/tests/test_cloud_pipeline_error_forwarding.py
+++ b/tests/test_cloud_pipeline_error_forwarding.py
@@ -174,12 +174,13 @@ def test_forward_runner_notification_routes_to_broadcast():
 
     import scope.server.app as real_app
 
-    saved = getattr(real_app, "webrtc_manager", None)
+    _missing = object()
+    saved = getattr(real_app, "webrtc_manager", _missing)
     try:
         real_app.webrtc_manager = fake_manager
         _forward_runner_notification(payload)
     finally:
-        if saved is None:
+        if saved is _missing:
             delattr(real_app, "webrtc_manager")
         else:
             real_app.webrtc_manager = saved

--- a/tests/test_cloud_pipeline_error_forwarding.py
+++ b/tests/test_cloud_pipeline_error_forwarding.py
@@ -20,7 +20,6 @@ already covered by test_pipeline_error_notification.py.
 
 import time
 import types
-from unittest.mock import patch
 
 import pytest
 
@@ -170,21 +169,9 @@ def test_forward_runner_notification_routes_to_broadcast():
     fake_manager.broadcast_notification = lambda payload: fake_manager.received.append(
         payload
     )
-    fake_app = types.SimpleNamespace(webrtc_manager=fake_manager)
 
     payload = {"type": "pipeline_error", "fatal": True, "message": "x"}
-    with patch.dict(
-        "sys.modules",
-        {
-            "scope.server.app": fake_app,
-            "scope.server": types.ModuleType("scope.server"),
-        },
-    ):
-        # The function uses `from . import app as _app`; patch that lookup.
-        with patch("scope.server.livepeer_client._forward_runner_notification") as _:
-            pass
 
-    # Easier: directly substitute scope.server.app.webrtc_manager.
     import scope.server.app as real_app
 
     saved = getattr(real_app, "webrtc_manager", None)

--- a/tests/test_pipeline_error_notification.py
+++ b/tests/test_pipeline_error_notification.py
@@ -1,0 +1,151 @@
+"""Tests for pipeline error notification (user-facing error UX).
+
+Verifies that when a pipeline raises errors during streaming, the
+PipelineProcessor:
+  1. Emits a `pipeline_error` message via the notification callback so the
+     frontend can render a toast / inline overlay (no more blank screen).
+  2. Invokes the on_fatal_error callback so the FrameProcessor can stop the
+     stream cleanly.
+  3. Escalates a stuck pipeline (>= MAX_CONSECUTIVE_RECOVERABLE_ERRORS) to
+     fatal even when the underlying exceptions are technically "recoverable".
+
+No GPU required; uses a stub pipeline.
+"""
+
+import queue
+import time
+
+import pytest
+import torch
+
+from scope.core.nodes.base import NodeDefinition
+from scope.server.pipeline_processor import (
+    MAX_CONSECUTIVE_RECOVERABLE_ERRORS,
+    PipelineProcessor,
+)
+
+
+class _AlwaysFailsPipeline:
+    """Stub pipeline that raises a recoverable error on every call."""
+
+    def __init__(self, exc=RuntimeError("boom")):
+        self._exc = exc
+        self.call_count = 0
+
+    def get_definition(self):
+        return NodeDefinition(node_type_id="failing_stub", display_name="FailingStub")
+
+    def prepare(self, **_):
+        return None
+
+    def __call__(self, **_):
+        self.call_count += 1
+        raise self._exc
+
+
+class _OOMPipeline:
+    """Stub pipeline that raises CUDA OOM (non-recoverable) on every call."""
+
+    def get_definition(self):
+        return NodeDefinition(node_type_id="oom_stub", display_name="OOMStub")
+
+    def prepare(self, **_):
+        return None
+
+    def __call__(self, **_):
+        raise torch.cuda.OutOfMemoryError("simulated OOM")
+
+
+def _wait_for(predicate, *, timeout=5.0, interval=0.02):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_recoverable_errors_escalate_to_fatal_and_notify():
+    """A pipeline that fails repeatedly should emit pipeline_error and stop."""
+    notifications: list[dict] = []
+    fatal_calls: list[tuple[str, str, str]] = []
+
+    pipeline = _AlwaysFailsPipeline()
+    processor = PipelineProcessor(
+        pipeline=pipeline,
+        pipeline_id="failing-pipeline",
+        node_id="node-A",
+        notification_callback=notifications.append,
+        on_fatal_error=lambda pid, nid, msg: fatal_calls.append((pid, nid, msg)),
+    )
+    processor.output_queues["video"] = [queue.Queue(maxsize=4)]
+    processor.start()
+
+    try:
+        # Worker should escalate after MAX_CONSECUTIVE_RECOVERABLE_ERRORS errors.
+        assert _wait_for(lambda: len(fatal_calls) >= 1, timeout=10.0), (
+            "Expected on_fatal_error to be invoked after consecutive failures, "
+            f"but only saw {len(fatal_calls)} fatal calls and "
+            f"{pipeline.call_count} pipeline calls"
+        )
+    finally:
+        processor.stop()
+
+    # The fatal callback received the right pipeline / node identifiers.
+    pid, nid, msg = fatal_calls[0]
+    assert pid == "failing-pipeline"
+    assert nid == "node-A"
+    assert "RuntimeError" in msg or "boom" in msg
+
+    # A pipeline_error notification with fatal=True was sent.
+    fatal_msgs = [
+        m
+        for m in notifications
+        if m.get("type") == "pipeline_error" and m.get("fatal") is True
+    ]
+    assert fatal_msgs, (
+        f"No fatal pipeline_error notification emitted. "
+        f"Received: {[m.get('type') for m in notifications]}"
+    )
+    msg = fatal_msgs[0]
+    assert msg["pipeline_id"] == "failing-pipeline"
+    assert msg["node_id"] == "node-A"
+    assert msg["recoverable"] is False
+    assert "boom" in msg["message"] or "RuntimeError" in msg["message"]
+
+    # We made roughly MAX_CONSECUTIVE_RECOVERABLE_ERRORS attempts before stopping.
+    assert pipeline.call_count >= MAX_CONSECUTIVE_RECOVERABLE_ERRORS
+
+
+def test_non_recoverable_error_notifies_and_stops_immediately():
+    """CUDA OOM is non-recoverable: should emit fatal pipeline_error after 1 call."""
+    pytest.importorskip("torch")
+    if not hasattr(torch.cuda, "OutOfMemoryError"):
+        pytest.skip("torch version too old for OutOfMemoryError")
+
+    notifications: list[dict] = []
+    fatal_calls: list[tuple[str, str, str]] = []
+
+    processor = PipelineProcessor(
+        pipeline=_OOMPipeline(),
+        pipeline_id="oom-pipeline",
+        node_id="node-B",
+        notification_callback=notifications.append,
+        on_fatal_error=lambda pid, nid, msg: fatal_calls.append((pid, nid, msg)),
+    )
+    processor.output_queues["video"] = [queue.Queue(maxsize=4)]
+    processor.start()
+
+    try:
+        assert _wait_for(lambda: len(fatal_calls) >= 1, timeout=5.0)
+    finally:
+        processor.stop()
+
+    fatal_msgs = [
+        m
+        for m in notifications
+        if m.get("type") == "pipeline_error" and m.get("fatal") is True
+    ]
+    assert fatal_msgs, "Expected a fatal pipeline_error for non-recoverable exception"
+    assert "OutOfMemoryError" in fatal_msgs[0]["exception_type"]
+    assert fatal_msgs[0]["recoverable"] is False


### PR DESCRIPTION
Previously a pipeline failure just stopped producing frames and the user stared at a black sink with no idea why. Now failures (local and cloud) surface as a toast plus an inline error overlay on every sink and on the main Video Output card.

**Backend**
- `PipelineProcessor` emits a structured `pipeline_error` notification (pipeline_id, node_id, message, exception_type) for non-recoverable errors, and escalates to fatal after 10 consecutive recoverable errors with no successful chunk.
- A new `on_fatal_error` callback stops the stream on a daemon thread (avoids joining the failing worker).
- `stream_stopped` carrying an `error_message` now also tags `fatal=True`.
- `WebRTCManager.broadcast_notification` tears down the local relay's `FrameProcessor` on fatal payloads, so cloud-side errors don't linger if the browser is slow to react.

**Frontend**
- `useUnifiedWebRTC` exposes a new `streamError` state; toast is deduped between `pipeline_error` and `stream_stopped`.
- `VideoOutput` and `SinkNode` render an inline error overlay (icon + message + retry).

**Tests**
- `test_pipeline_error_notification.py` — emit + escalate on consecutive recoverable errors and CUDA OOM.
- `test_cloud_pipeline_error_forwarding.py` — local-relay forwarding: non-fatal forwards only, fatal also stops the local `FrameProcessor`, normal user-initiated stop is unaffected, closed sessions skipped.
