### PR TITLE
feat(workflows): bundle media files inside exported workflow JSON

### DIFF
--- a/frontend/src/components/WorkflowExportDialog.tsx
+++ b/frontend/src/components/WorkflowExportDialog.tsx
@@ -62,13 +62,17 @@ export function WorkflowExportDialog({
         scopeVersion: scopeVersion ?? "unknown",
       });
 
-      // Ask the backend to embed referenced media files. If embedding fails
-      // (e.g. during testing without a backend), fall back to the un-embedded
-      // workflow so export still works.
+      // Ask the backend to embed referenced media files. If embedding fails,
+      // fall back to the un-embedded workflow and warn the user — without
+      // embeds, anyone who imports the file on another machine will see
+      // missing assets where the author had reference images, audio, or
+      // video files.
       let workflow = baseWorkflow;
+      let embedFailed = false;
       try {
         workflow = await embedWorkflowAssets(baseWorkflow);
       } catch (err) {
+        embedFailed = true;
         console.warn("Workflow embed failed; exporting without embeds:", err);
       }
 
@@ -90,9 +94,16 @@ export function WorkflowExportDialog({
         node_count: workflow.graph?.nodes?.length ?? workflow.pipelines.length,
         surface: "app_chrome",
       });
-      toast.success("Workflow exported", {
-        description: `"${name}" saved as .scope-workflow.json`,
-      });
+      if (embedFailed) {
+        toast.warning("Workflow exported without embedded media", {
+          description:
+            "Referenced images, audio, and video could not be bundled. Sharing this file may show missing assets on another machine.",
+        });
+      } else {
+        toast.success("Workflow exported", {
+          description: `"${name}" saved as .scope-workflow.json`,
+        });
+      }
       onClose();
     } catch (err) {
       console.error("Workflow export failed:", err);

--- a/frontend/src/components/WorkflowExportDialog.tsx
+++ b/frontend/src/components/WorkflowExportDialog.tsx
@@ -15,7 +15,7 @@ import type { SettingsState } from "../types";
 import type { TimelinePrompt } from "./PromptTimeline";
 import type { WorkflowPromptState } from "../lib/workflowSettings";
 import { buildScopeWorkflow } from "../lib/workflowSettings";
-import type { PluginInfo } from "../lib/api";
+import { embedWorkflowAssets, type PluginInfo } from "../lib/api";
 import { usePipelinesContext } from "../contexts/PipelinesContext";
 import { useLoRAsContext } from "../contexts/LoRAsContext";
 import { usePluginsContext } from "../contexts/PluginsContext";
@@ -44,14 +44,14 @@ export function WorkflowExportDialog({
   const { plugins } = usePluginsContext();
   const { version: scopeVersion } = useServerInfoContext();
 
-  const handleExport = () => {
+  const handleExport = async () => {
     setExporting(true);
     try {
       const pluginInfoMap = new Map<string, PluginInfo>(
         plugins.map(p => [p.name, p])
       );
 
-      const workflow = buildScopeWorkflow({
+      const baseWorkflow = buildScopeWorkflow({
         name,
         settings,
         timelinePrompts,
@@ -61,6 +61,16 @@ export function WorkflowExportDialog({
         pluginInfoMap,
         scopeVersion: scopeVersion ?? "unknown",
       });
+
+      // Ask the backend to embed referenced media files. If embedding fails
+      // (e.g. during testing without a backend), fall back to the un-embedded
+      // workflow so export still works.
+      let workflow = baseWorkflow;
+      try {
+        workflow = await embedWorkflowAssets(baseWorkflow);
+      } catch (err) {
+        console.warn("Workflow embed failed; exporting without embeds:", err);
+      }
 
       // Download as JSON file
       const blob = new Blob([JSON.stringify(workflow, null, 2)], {

--- a/frontend/src/components/WorkflowImportDialog.tsx
+++ b/frontend/src/components/WorkflowImportDialog.tsx
@@ -252,6 +252,41 @@ export function WorkflowImportDialog({
   }, [onClose, resetLoras, resetPlugins]);
 
   // -----------------------------------------------------------------------
+  // Materialize embedded assets (shared by both file-pick and deeplink paths)
+  // -----------------------------------------------------------------------
+
+  /**
+   * If *wf* carries an ``embedded_assets`` array, ask the backend to write
+   * each entry to the local assets directory and rewrite path references.
+   * Returns the rewritten workflow, or ``null`` if extraction failed (a toast
+   * is shown in that case).
+   */
+  const materializeEmbeddedAssets = useCallback(
+    async (wf: ScopeWorkflow): Promise<ScopeWorkflow | null> => {
+      const hasEmbeds = Array.isArray(
+        (wf as unknown as { embedded_assets?: unknown[] }).embedded_assets
+      );
+      if (!hasEmbeds) return wf;
+      try {
+        const result = await extractWorkflowAssets(wf);
+        if (result.warning) {
+          toast.warning("Embedded media partially restored", {
+            description: result.warning,
+          });
+        }
+        return result.workflow;
+      } catch (err) {
+        console.error("Failed to extract embedded assets:", err);
+        toast.error("Failed to restore embedded media", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      }
+    },
+    []
+  );
+
+  // -----------------------------------------------------------------------
   // Auto-resolve when opened with a preloaded workflow (e.g. from deeplink)
   // -----------------------------------------------------------------------
 
@@ -262,23 +297,10 @@ export function WorkflowImportDialog({
     (async () => {
       try {
         setValidating(true);
-        let materialized: ScopeWorkflow = initialWorkflow;
-        if (
-          Array.isArray(
-            (initialWorkflow as unknown as { embedded_assets?: unknown[] })
-              .embedded_assets
-          )
-        ) {
-          try {
-            materialized = await extractWorkflowAssets(initialWorkflow);
-          } catch (err) {
-            console.error("Failed to extract embedded assets:", err);
-            toast.error("Failed to restore embedded media", {
-              description: err instanceof Error ? err.message : String(err),
-            });
-            handleClose();
-            return;
-          }
+        const materialized = await materializeEmbeddedAssets(initialWorkflow);
+        if (materialized === null) {
+          handleClose();
+          return;
         }
         if (cancelled) return;
         setWorkflow(materialized);
@@ -454,22 +476,9 @@ export function WorkflowImportDialog({
         // If the workflow embeds media files, materialize them into the
         // local assets directory and rewrite path references first. The
         // backend strips ``embedded_assets`` from the returned workflow.
-        if (
-          Array.isArray(
-            (parsed as unknown as { embedded_assets?: unknown[] })
-              .embedded_assets
-          )
-        ) {
-          try {
-            parsed = await extractWorkflowAssets(parsed);
-          } catch (err) {
-            console.error("Failed to extract embedded assets:", err);
-            toast.error("Failed to restore embedded media", {
-              description: err instanceof Error ? err.message : String(err),
-            });
-            return;
-          }
-        }
+        const materialized = await materializeEmbeddedAssets(parsed);
+        if (materialized === null) return;
+        parsed = materialized;
 
         setWorkflow(parsed);
 
@@ -513,7 +522,12 @@ export function WorkflowImportDialog({
         setValidating(false);
       }
     },
-    [initializeLoras, initializePlugins, loadWorkflowDirect]
+    [
+      initializeLoras,
+      initializePlugins,
+      loadWorkflowDirect,
+      materializeEmbeddedAssets,
+    ]
   );
 
   const handleDrop = useCallback(

--- a/frontend/src/components/WorkflowImportDialog.tsx
+++ b/frontend/src/components/WorkflowImportDialog.tsx
@@ -30,7 +30,12 @@ import {
 } from "./ui/alert-dialog";
 import { toast } from "sonner";
 import type { ScopeWorkflow, WorkflowResolutionPlan } from "../lib/workflowApi";
-import { resolveWorkflow, getApiKeys, setApiKey } from "../lib/api";
+import {
+  resolveWorkflow,
+  extractWorkflowAssets,
+  getApiKeys,
+  setApiKey,
+} from "../lib/api";
 import type { ApiKeyInfo } from "../lib/api";
 import {
   statusIcon,
@@ -257,9 +262,28 @@ export function WorkflowImportDialog({
     (async () => {
       try {
         setValidating(true);
-        setWorkflow(initialWorkflow);
+        let materialized: ScopeWorkflow = initialWorkflow;
+        if (
+          Array.isArray(
+            (initialWorkflow as unknown as { embedded_assets?: unknown[] })
+              .embedded_assets
+          )
+        ) {
+          try {
+            materialized = await extractWorkflowAssets(initialWorkflow);
+          } catch (err) {
+            console.error("Failed to extract embedded assets:", err);
+            toast.error("Failed to restore embedded media", {
+              description: err instanceof Error ? err.message : String(err),
+            });
+            handleClose();
+            return;
+          }
+        }
+        if (cancelled) return;
+        setWorkflow(materialized);
 
-        const resolution = await resolveWorkflow(initialWorkflow);
+        const resolution = await resolveWorkflow(materialized);
         if (cancelled) return;
 
         // If all dependencies are already resolved, skip the review dialog
@@ -267,7 +291,7 @@ export function WorkflowImportDialog({
           resolution.items.every(i => i.status === "ok") &&
           resolution.warnings.length === 0
         ) {
-          await loadWorkflowDirect(initialWorkflow);
+          await loadWorkflowDirect(materialized);
           return;
         }
 
@@ -425,6 +449,26 @@ export function WorkflowImportDialog({
             description: "Missing required fields: metadata or pipelines",
           });
           return;
+        }
+
+        // If the workflow embeds media files, materialize them into the
+        // local assets directory and rewrite path references first. The
+        // backend strips ``embedded_assets`` from the returned workflow.
+        if (
+          Array.isArray(
+            (parsed as unknown as { embedded_assets?: unknown[] })
+              .embedded_assets
+          )
+        ) {
+          try {
+            parsed = await extractWorkflowAssets(parsed);
+          } catch (err) {
+            console.error("Failed to extract embedded assets:", err);
+            toast.error("Failed to restore embedded media", {
+              description: err instanceof Error ? err.message : String(err),
+            });
+            return;
+          }
         }
 
         setWorkflow(parsed);

--- a/frontend/src/components/graph/GraphWorkflowExportDialog.tsx
+++ b/frontend/src/components/graph/GraphWorkflowExportDialog.tsx
@@ -34,9 +34,11 @@ export function GraphWorkflowExportDialog({
       const baseWorkflow = buildWorkflow(name);
 
       let workflow = baseWorkflow;
+      let embedFailed = false;
       try {
         workflow = await embedWorkflowAssets(baseWorkflow);
       } catch (err) {
+        embedFailed = true;
         console.warn("Workflow embed failed; exporting without embeds:", err);
       }
 
@@ -53,9 +55,16 @@ export function GraphWorkflowExportDialog({
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
 
-      toast.success("Workflow exported", {
-        description: `"${name}" saved as .scope-workflow.json`,
-      });
+      if (embedFailed) {
+        toast.warning("Workflow exported without embedded media", {
+          description:
+            "Referenced images, audio, and video could not be bundled. Sharing this file may show missing assets on another machine.",
+        });
+      } else {
+        toast.success("Workflow exported", {
+          description: `"${name}" saved as .scope-workflow.json`,
+        });
+      }
       onClose();
     } catch (err) {
       console.error("Workflow export failed:", err);

--- a/frontend/src/components/graph/GraphWorkflowExportDialog.tsx
+++ b/frontend/src/components/graph/GraphWorkflowExportDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "../ui/dialog";
 import { toast } from "sonner";
 import type { ScopeWorkflow } from "../../lib/workflowApi";
+import { embedWorkflowAssets } from "../../lib/api";
 
 interface GraphWorkflowExportDialogProps {
   open: boolean;
@@ -27,10 +28,17 @@ export function GraphWorkflowExportDialog({
   const [name, setName] = useState("Untitled Workflow");
   const [exporting, setExporting] = useState(false);
 
-  const handleExport = () => {
+  const handleExport = async () => {
     setExporting(true);
     try {
-      const workflow = buildWorkflow(name);
+      const baseWorkflow = buildWorkflow(name);
+
+      let workflow = baseWorkflow;
+      try {
+        workflow = await embedWorkflowAssets(baseWorkflow);
+      } catch (err) {
+        console.warn("Workflow embed failed; exporting without embeds:", err);
+      }
 
       const blob = new Blob([JSON.stringify(workflow, null, 2)], {
         type: "application/json",

--- a/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
@@ -19,6 +19,7 @@ import type {
   WorkflowResolutionPlan,
 } from "../../../../lib/workflowApi";
 import { buildGraphWorkflow } from "../../../../lib/workflowSettings";
+import { toast } from "sonner";
 import { usePipelinesContext } from "../../../../contexts/PipelinesContext";
 import { usePluginsContext } from "../../../../contexts/PluginsContext";
 import { useLoRAsContext } from "../../../../contexts/LoRAsContext";
@@ -518,7 +519,13 @@ export function useGraphPersistence({
               )
             ) {
               try {
-                workflow = await extractWorkflowAssets(workflow);
+                const result = await extractWorkflowAssets(workflow);
+                workflow = result.workflow;
+                if (result.warning) {
+                  toast.warning("Embedded media partially restored", {
+                    description: result.warning,
+                  });
+                }
               } catch (err) {
                 console.error("Failed to extract embedded assets:", err);
                 setStatus("Import failed: could not restore embedded media");
@@ -635,9 +642,11 @@ export function useGraphPersistence({
     const baseWorkflow = buildCurrentWorkflow();
 
     let workflow = baseWorkflow;
+    let embedFailed = false;
     try {
       workflow = await embedWorkflowAssets(baseWorkflow);
     } catch (err) {
+      embedFailed = true;
       console.warn("Workflow embed failed; exporting without embeds:", err);
     }
 
@@ -654,7 +663,15 @@ export function useGraphPersistence({
     link.click();
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
-    setStatus("Graph exported");
+    if (embedFailed) {
+      setStatus("Graph exported without embedded media");
+      toast.warning("Graph exported without embedded media", {
+        description:
+          "Referenced images, audio, and video could not be bundled. Sharing this file may show missing assets on another machine.",
+      });
+    } else {
+      setStatus("Graph exported");
+    }
   }, [buildCurrentWorkflow]);
 
   const getCurrentGraphConfig = useCallback(() => {

--- a/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
+++ b/frontend/src/components/graph/hooks/graph/useGraphPersistence.ts
@@ -8,7 +8,12 @@ import {
 } from "../../../../lib/graphUtils";
 import type { FlowNodeData } from "../../../../lib/graphUtils";
 import type { PluginInfo, NodeDefinitionDto } from "../../../../lib/api";
-import { resolveWorkflow, fetchNodeDefinitions } from "../../../../lib/api";
+import {
+  resolveWorkflow,
+  fetchNodeDefinitions,
+  embedWorkflowAssets,
+  extractWorkflowAssets,
+} from "../../../../lib/api";
 import type {
   ScopeWorkflow,
   WorkflowResolutionPlan,
@@ -505,7 +510,21 @@ export function useGraphPersistence({
             parsed.format === "scope-workflow" &&
             Array.isArray(parsed.pipelines)
           ) {
-            const workflow = parsed as ScopeWorkflow;
+            let workflow = parsed as ScopeWorkflow;
+            if (
+              Array.isArray(
+                (workflow as unknown as { embedded_assets?: unknown[] })
+                  .embedded_assets
+              )
+            ) {
+              try {
+                workflow = await extractWorkflowAssets(workflow);
+              } catch (err) {
+                console.error("Failed to extract embedded assets:", err);
+                setStatus("Import failed: could not restore embedded media");
+                return;
+              }
+            }
             setPendingImportWorkflow(workflow);
             setPendingImportResolving(true);
             try {
@@ -612,8 +631,15 @@ export function useGraphPersistence({
     ]
   );
 
-  const handleExport = useCallback(() => {
-    const workflow = buildCurrentWorkflow();
+  const handleExport = useCallback(async () => {
+    const baseWorkflow = buildCurrentWorkflow();
+
+    let workflow = baseWorkflow;
+    try {
+      workflow = await embedWorkflowAssets(baseWorkflow);
+    } catch (err) {
+      console.warn("Workflow embed failed; exporting without embeds:", err);
+    }
 
     const dataStr = JSON.stringify(workflow, null, 2);
     const blob = new Blob([dataStr], { type: "application/json" });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1130,10 +1130,19 @@ export const embedWorkflowAssets = async (
 /**
  * Ask the backend to write each ``embedded_assets`` entry to the local
  * assets directory and rewrite path references in the workflow.
+ *
+ * Returns both the rewritten workflow and any non-fatal warning the backend
+ * surfaced (e.g. cloud mode where the local-copy step failed but the cloud
+ * extract succeeded — previews will be missing until the user re-uploads).
  */
+export interface ExtractWorkflowResult {
+  workflow: ScopeWorkflow;
+  warning: string | null;
+}
+
 export const extractWorkflowAssets = async (
   workflow: ScopeWorkflow
-): Promise<ScopeWorkflow> => {
+): Promise<ExtractWorkflowResult> => {
   const response = await fetch("/api/v1/workflow/extract", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -1143,7 +1152,9 @@ export const extractWorkflowAssets = async (
     const detail = await extractErrorDetail(response);
     throw new Error(detail);
   }
-  return response.json();
+  const warning = response.headers.get("X-Scope-Warning");
+  const rewritten = (await response.json()) as ScopeWorkflow;
+  return { workflow: rewritten, warning };
 };
 
 export const downloadLoRA = async (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1107,6 +1107,45 @@ export const resolveWorkflow = async (
   return response.json();
 };
 
+/**
+ * Ask the backend to embed every referenced media file into the workflow as
+ * a top-level ``embedded_assets`` array. Returns the workflow unchanged if
+ * no referenced files exist on disk.
+ */
+export const embedWorkflowAssets = async (
+  workflow: ScopeWorkflow
+): Promise<ScopeWorkflow> => {
+  const response = await fetch("/api/v1/workflow/embed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(workflow),
+  });
+  if (!response.ok) {
+    const detail = await extractErrorDetail(response);
+    throw new Error(detail);
+  }
+  return response.json();
+};
+
+/**
+ * Ask the backend to write each ``embedded_assets`` entry to the local
+ * assets directory and rewrite path references in the workflow.
+ */
+export const extractWorkflowAssets = async (
+  workflow: ScopeWorkflow
+): Promise<ScopeWorkflow> => {
+  const response = await fetch("/api/v1/workflow/extract", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(workflow),
+  });
+  if (!response.ok) {
+    const detail = await extractErrorDetail(response);
+    throw new Error(detail);
+  }
+  return response.json();
+};
+
 export const downloadLoRA = async (
   request: LoRADownloadRequest
 ): Promise<LoRADownloadResult> => {

--- a/src/scope/core/workflows/__init__.py
+++ b/src/scope/core/workflows/__init__.py
@@ -1,5 +1,6 @@
 """Shareable workflow resolution helpers."""
 
+from .embed import embed_workflow_assets, extract_workflow_assets
 from .resolve import (
     ResolutionItem,
     WorkflowRequest,
@@ -11,5 +12,7 @@ __all__ = [
     "ResolutionItem",
     "WorkflowRequest",
     "WorkflowResolutionPlan",
+    "embed_workflow_assets",
+    "extract_workflow_assets",
     "resolve_workflow",
 ]

--- a/src/scope/core/workflows/embed.py
+++ b/src/scope/core/workflows/embed.py
@@ -33,6 +33,12 @@ VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
 AUDIO_EXTENSIONS = {".wav", ".mp3", ".flac", ".ogg"}
 MEDIA_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS | AUDIO_EXTENSIONS
 
+CURRENT_FORMAT_VERSION = "1.1"
+
+# Cap on basename-collision rename attempts before we give up. Hitting more
+# than a handful means something is structurally wrong with the assets dir.
+_MAX_RENAME_ATTEMPTS = 1000
+
 _MIME_BY_EXT: dict[str, str] = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
@@ -51,18 +57,43 @@ _MIME_BY_EXT: dict[str, str] = {
 }
 
 
-def _is_media_path(value: Any) -> bool:
-    """Heuristic: a string is a media path if it has a known media extension
-    AND looks pathy (contains a slash/backslash, or is a bare filename — but
-    only if the bare filename actually existed in the assets dir we'll
-    confirm at the call-site). We err on the permissive side here and let
-    file existence be the final filter on export.
+def _normalize_separators(value: str) -> str:
+    """Map Windows-style backslash separators to forward slashes so a single
+    POSIX-style ``Path`` can extract a basename regardless of the OS that
+    wrote the workflow. Only converts ``\\`` between path-like segments; leaves
+    free-form strings alone since the caller filters those out first."""
+    return value.replace("\\", "/")
+
+
+def _basename(value: str) -> str:
+    """Cross-OS basename: split on either separator and return the trailing
+    component. ``Path(value).name`` on POSIX would treat backslashes as
+    regular characters, which breaks Windows-exported workflows."""
+    return Path(_normalize_separators(value)).name
+
+
+def _looks_path_shaped(value: str, known_filenames: set[str]) -> bool:
+    """Stricter than ``_has_media_extension``: require the string to actually
+    look like a path. Either it contains a path separator (so it's clearly
+    addressing a file location), or its full content exactly equals a known
+    embedded filename (so a bare ``ref.png`` reference still gets rewritten).
+
+    This guards against rewriting prompt strings or other free-form text that
+    happens to end with a media extension (``"… see attached cat.png"``).
     """
+    if "/" in value or "\\" in value:
+        return True
+    return value in known_filenames
+
+
+def _has_media_extension(value: Any) -> bool:
+    """A string carries a media extension if its last path component ends in
+    one of our known media suffixes and it isn't a URL/data scheme."""
     if not isinstance(value, str) or not value:
         return False
     if value.startswith(("http://", "https://", "blob:", "data:")):
         return False
-    suffix = Path(value).suffix.lower()
+    suffix = Path(_normalize_separators(value)).suffix.lower()
     return suffix in MEDIA_EXTENSIONS
 
 
@@ -84,32 +115,46 @@ def _resolve_media_path(value: str, assets_dir: Path) -> Path | None:
 
     Tries the literal path first, then falls back to looking up the basename
     in ``assets_dir`` (handles workflows whose absolute paths point at a
-    different machine).
+    different machine, including Windows-style paths viewed from POSIX).
     """
     candidate = Path(value)
-    if candidate.is_absolute():
-        if candidate.is_file():
-            return candidate
-        # Absolute path from another machine — try basename in assets_dir.
-        basename_match = assets_dir / candidate.name
-        if basename_match.is_file():
-            return basename_match
-        return None
+    if candidate.is_absolute() and candidate.is_file():
+        return candidate
 
-    # Relative path: try assets_dir / value, then assets_dir / basename.
-    rel_match = assets_dir / value
-    if rel_match.is_file():
-        return rel_match
-    base_match = assets_dir / candidate.name
-    if base_match.is_file():
-        return base_match
+    # Either the absolute path doesn't exist locally, or the value is
+    # relative / Windows-style. Fall back to basename lookup in assets_dir.
+    base = _basename(value)
+    if base:
+        base_match = assets_dir / base
+        if base_match.is_file():
+            return base_match
+
+    if not candidate.is_absolute():
+        rel_match = assets_dir / value
+        if rel_match.is_file():
+            return rel_match
+
     return None
+
+
+def _next_higher_version(current: Any, minimum: str) -> str:
+    """Return the higher of *current* and *minimum* using a tuple-of-ints
+    compare. Falls back to *minimum* when *current* is missing or unparseable
+    so we don't silently downgrade unparseable values."""
+    if not isinstance(current, str):
+        return minimum
+    try:
+        cur_parts = tuple(int(p) for p in current.split("."))
+        min_parts = tuple(int(p) for p in minimum.split("."))
+    except ValueError:
+        return minimum
+    return current if cur_parts >= min_parts else minimum
 
 
 def embed_workflow_assets(workflow: dict[str, Any], assets_dir: Path) -> dict[str, Any]:
     """Walk *workflow*, base64-encode every referenced media file that exists
     on disk into a new top-level ``embedded_assets`` list, and bump
-    ``format_version`` to ``"1.1"``.
+    ``format_version`` to ``"1.1"`` (preserving any higher value already set).
 
     Returns a new dict; *workflow* is not mutated.
 
@@ -130,7 +175,7 @@ def embed_workflow_assets(workflow: dict[str, Any], assets_dir: Path) -> dict[st
     embedded: dict[str, dict[str, Any]] = {}
 
     def visit(value: str) -> str:
-        if not _is_media_path(value):
+        if not _has_media_extension(value):
             return value
         resolved = _resolve_media_path(value, assets_dir)
         if resolved is None:
@@ -168,7 +213,9 @@ def embed_workflow_assets(workflow: dict[str, Any], assets_dir: Path) -> dict[st
             if isinstance(entry, dict) and isinstance(entry.get("filename"), str):
                 embedded.setdefault(entry["filename"], entry)
     result["embedded_assets"] = list(embedded.values())
-    result["format_version"] = "1.1"
+    result["format_version"] = _next_higher_version(
+        result.get("format_version"), CURRENT_FORMAT_VERSION
+    )
     return result
 
 
@@ -176,9 +223,14 @@ def extract_workflow_assets(
     workflow: dict[str, Any], assets_dir: Path
 ) -> dict[str, Any]:
     """Write each ``embedded_assets`` entry to *assets_dir*, then rewrite
-    every path reference in *workflow* whose basename matches an embedded
-    filename to point at the resulting on-disk path. Strips
+    every path-shaped reference in *workflow* whose basename matches an
+    embedded filename to point at the resulting on-disk path. Strips
     ``embedded_assets`` from the returned workflow.
+
+    Path rewriting only fires for strings that look path-shaped (contain a
+    separator, or exactly match an embedded filename). Free-form strings that
+    happen to end with a media extension — e.g. a prompt mentioning
+    ``cat.png`` — are left alone.
 
     Idempotent: if an existing file with matching SHA-256 is already present
     we reuse it. If a different file with the same basename exists we save
@@ -192,6 +244,15 @@ def extract_workflow_assets(
         return workflow
 
     assets_dir.mkdir(parents=True, exist_ok=True)
+    assets_dir_resolved = assets_dir.resolve()
+
+    def _confine(target: Path, label: str) -> Path | None:
+        """Reject paths that escape assets_dir after symlink resolution."""
+        resolved = target.resolve()
+        if not resolved.is_relative_to(assets_dir_resolved):
+            logger.warning("extract: refusing to write outside assets dir: %s", label)
+            return None
+        return resolved
 
     written: dict[str, str] = {}  # original filename -> resolved path
     for entry in embedded:
@@ -209,12 +270,8 @@ def extract_workflow_assets(
             logger.warning("extract: invalid base64 for %s: %s", filename, exc)
             continue
 
-        target = (assets_dir / filename).resolve()
-        # Confine writes to the assets directory.
-        if not target.is_relative_to(assets_dir.resolve()):
-            logger.warning(
-                "extract: refusing to write outside assets dir: %s", filename
-            )
+        target = _confine(assets_dir / filename, filename)
+        if target is None:
             continue
 
         if target.exists():
@@ -225,16 +282,29 @@ def extract_workflow_assets(
             if existing_sha and existing_sha == expected_sha:
                 written[filename] = str(target)
                 continue
-            # Same name, different content — pick a non-conflicting name.
+            # Same name, different content — pick a non-conflicting name and
+            # re-validate confinement on every attempt so the safety check is
+            # local to each write.
             stem, suffix = target.stem, target.suffix
             counter = 1
-            while target.exists():
-                target = (assets_dir / f"{stem}_imported{counter}{suffix}").resolve()
+            while True:
+                candidate = _confine(
+                    assets_dir / f"{stem}_imported{counter}{suffix}",
+                    f"{filename} (rename #{counter})",
+                )
+                if candidate is None:
+                    target = None
+                    break
+                if not candidate.exists():
+                    target = candidate
+                    break
                 counter += 1
-                if counter > 10_000:
+                if counter > _MAX_RENAME_ATTEMPTS:
                     raise RuntimeError(
                         f"Could not find non-conflicting name for {filename}"
                     )
+            if target is None:
+                continue
 
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(data)
@@ -245,10 +315,14 @@ def extract_workflow_assets(
         result.pop("embedded_assets", None)
         return result
 
+    known_filenames = set(written.keys())
+
     def visit(value: str) -> str:
-        if not _is_media_path(value):
+        if not _has_media_extension(value):
             return value
-        basename = Path(value).name
+        if not _looks_path_shaped(value, known_filenames):
+            return value
+        basename = _basename(value)
         if basename in written:
             return written[basename]
         return value

--- a/src/scope/core/workflows/embed.py
+++ b/src/scope/core/workflows/embed.py
@@ -1,0 +1,257 @@
+"""Embed referenced media files into a workflow JSON and extract them back.
+
+A shareable workflow file references media (reference images, audio, video) by
+filesystem path. Those paths only resolve on the machine that exported the
+workflow, so an importer ends up missing the assets the workflow author saw.
+
+These helpers walk the workflow JSON, base64-encode every existing media file
+they find into a top-level ``embedded_assets`` list, and on import write each
+embedded asset to the local assets directory and rewrite path references by
+basename so they resolve again.
+
+The functions operate on plain ``dict``/``list`` JSON values to avoid coupling
+to either the client-side schema or :mod:`scope.core.workflows.resolve`'s
+strictly-typed models. ``WorkflowRequest`` already uses ``extra="ignore"``,
+so a workflow with ``embedded_assets`` resolves fine without further changes.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Mirrors scope.server.file_utils to avoid importing server-side modules from
+# core. Keeping the lists in sync is a documented invariant — both files name
+# the same set of extensions and ship together.
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
+AUDIO_EXTENSIONS = {".wav", ".mp3", ".flac", ".ogg"}
+MEDIA_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS | AUDIO_EXTENSIONS
+
+_MIME_BY_EXT: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".mp4": "video/mp4",
+    ".avi": "video/x-msvideo",
+    ".mov": "video/quicktime",
+    ".mkv": "video/x-matroska",
+    ".webm": "video/webm",
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+}
+
+
+def _is_media_path(value: Any) -> bool:
+    """Heuristic: a string is a media path if it has a known media extension
+    AND looks pathy (contains a slash/backslash, or is a bare filename — but
+    only if the bare filename actually existed in the assets dir we'll
+    confirm at the call-site). We err on the permissive side here and let
+    file existence be the final filter on export.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    if value.startswith(("http://", "https://", "blob:", "data:")):
+        return False
+    suffix = Path(value).suffix.lower()
+    return suffix in MEDIA_EXTENSIONS
+
+
+def _walk_strings(obj: Any, visit: Any) -> Any:
+    """Recursively walk a JSON-like value, replacing each string with
+    ``visit(string)`` (must return a string). Mutates a copy, leaves input
+    alone."""
+    if isinstance(obj, str):
+        return visit(obj)
+    if isinstance(obj, list):
+        return [_walk_strings(x, visit) for x in obj]
+    if isinstance(obj, dict):
+        return {k: _walk_strings(v, visit) for k, v in obj.items()}
+    return obj
+
+
+def _resolve_media_path(value: str, assets_dir: Path) -> Path | None:
+    """Map a workflow path string to an existing file on disk.
+
+    Tries the literal path first, then falls back to looking up the basename
+    in ``assets_dir`` (handles workflows whose absolute paths point at a
+    different machine).
+    """
+    candidate = Path(value)
+    if candidate.is_absolute():
+        if candidate.is_file():
+            return candidate
+        # Absolute path from another machine — try basename in assets_dir.
+        basename_match = assets_dir / candidate.name
+        if basename_match.is_file():
+            return basename_match
+        return None
+
+    # Relative path: try assets_dir / value, then assets_dir / basename.
+    rel_match = assets_dir / value
+    if rel_match.is_file():
+        return rel_match
+    base_match = assets_dir / candidate.name
+    if base_match.is_file():
+        return base_match
+    return None
+
+
+def embed_workflow_assets(workflow: dict[str, Any], assets_dir: Path) -> dict[str, Any]:
+    """Walk *workflow*, base64-encode every referenced media file that exists
+    on disk into a new top-level ``embedded_assets`` list, and bump
+    ``format_version`` to ``"1.1"``.
+
+    Returns a new dict; *workflow* is not mutated.
+
+    Embedded entry shape::
+
+        {
+          "filename": "ref.png",
+          "mime_type": "image/png",
+          "size_bytes": 1234,
+          "sha256": "<hex>",
+          "data": "<base64>"
+        }
+
+    Multiple references to the same file (by basename) collapse to one entry.
+    Paths whose target file we can't locate are left as-is — the importer
+    will see them and report a missing-asset condition like before.
+    """
+    embedded: dict[str, dict[str, Any]] = {}
+
+    def visit(value: str) -> str:
+        if not _is_media_path(value):
+            return value
+        resolved = _resolve_media_path(value, assets_dir)
+        if resolved is None:
+            return value
+        filename = resolved.name
+        if filename in embedded:
+            return value
+        try:
+            data = resolved.read_bytes()
+        except OSError as exc:
+            logger.warning("embed: cannot read %s: %s", resolved, exc)
+            return value
+        embedded[filename] = {
+            "filename": filename,
+            "mime_type": _MIME_BY_EXT.get(
+                resolved.suffix.lower(), "application/octet-stream"
+            ),
+            "size_bytes": len(data),
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "data": base64.b64encode(data).decode("ascii"),
+        }
+        return value
+
+    rewritten = _walk_strings(workflow, visit)
+
+    if not embedded:
+        return rewritten
+
+    result = dict(rewritten)
+    # Preserve any pre-existing embedded_assets a caller already attached
+    # (e.g. partial embeds), keyed by filename so we don't double up.
+    existing = result.get("embedded_assets")
+    if isinstance(existing, list):
+        for entry in existing:
+            if isinstance(entry, dict) and isinstance(entry.get("filename"), str):
+                embedded.setdefault(entry["filename"], entry)
+    result["embedded_assets"] = list(embedded.values())
+    result["format_version"] = "1.1"
+    return result
+
+
+def extract_workflow_assets(
+    workflow: dict[str, Any], assets_dir: Path
+) -> dict[str, Any]:
+    """Write each ``embedded_assets`` entry to *assets_dir*, then rewrite
+    every path reference in *workflow* whose basename matches an embedded
+    filename to point at the resulting on-disk path. Strips
+    ``embedded_assets`` from the returned workflow.
+
+    Idempotent: if an existing file with matching SHA-256 is already present
+    we reuse it. If a different file with the same basename exists we save
+    under a deduplicated name (``foo_imported1.png``) and rewrite paths to
+    that new name.
+
+    Returns a new dict; *workflow* is not mutated.
+    """
+    embedded = workflow.get("embedded_assets")
+    if not isinstance(embedded, list) or not embedded:
+        return workflow
+
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    written: dict[str, str] = {}  # original filename -> resolved path
+    for entry in embedded:
+        if not isinstance(entry, dict):
+            continue
+        filename = entry.get("filename")
+        data_b64 = entry.get("data")
+        expected_sha = entry.get("sha256")
+        if not isinstance(filename, str) or not isinstance(data_b64, str):
+            logger.warning("extract: skipping malformed embedded asset entry")
+            continue
+        try:
+            data = base64.b64decode(data_b64)
+        except (ValueError, TypeError) as exc:
+            logger.warning("extract: invalid base64 for %s: %s", filename, exc)
+            continue
+
+        target = (assets_dir / filename).resolve()
+        # Confine writes to the assets directory.
+        if not target.is_relative_to(assets_dir.resolve()):
+            logger.warning(
+                "extract: refusing to write outside assets dir: %s", filename
+            )
+            continue
+
+        if target.exists():
+            try:
+                existing_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+            except OSError:
+                existing_sha = None
+            if existing_sha and existing_sha == expected_sha:
+                written[filename] = str(target)
+                continue
+            # Same name, different content — pick a non-conflicting name.
+            stem, suffix = target.stem, target.suffix
+            counter = 1
+            while target.exists():
+                target = (assets_dir / f"{stem}_imported{counter}{suffix}").resolve()
+                counter += 1
+                if counter > 10_000:
+                    raise RuntimeError(
+                        f"Could not find non-conflicting name for {filename}"
+                    )
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        written[filename] = str(target)
+
+    if not written:
+        result = dict(workflow)
+        result.pop("embedded_assets", None)
+        return result
+
+    def visit(value: str) -> str:
+        if not _is_media_path(value):
+            return value
+        basename = Path(value).name
+        if basename in written:
+            return written[basename]
+        return value
+
+    stripped = {k: v for k, v in workflow.items() if k != "embedded_assets"}
+    return _walk_strings(stripped, visit)

--- a/src/scope/core/workflows/embed.py
+++ b/src/scope/core/workflows/embed.py
@@ -139,8 +139,8 @@ def _resolve_media_path(value: str, assets_dir: Path) -> Path | None:
 
 def _next_higher_version(current: Any, minimum: str) -> str:
     """Return the higher of *current* and *minimum* using a tuple-of-ints
-    compare. Falls back to *minimum* when *current* is missing or unparseable
-    so we don't silently downgrade unparseable values."""
+    compare. When *current* is missing or unparseable we substitute *minimum*
+    so embedded files always carry a version we recognize."""
     if not isinstance(current, str):
         return minimum
     try:

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -2150,7 +2150,6 @@ async def workflow_embed_endpoint(
 
 
 @app.post("/api/v1/workflow/extract")
-@cloud_proxy(timeout=_WORKFLOW_ASSET_PROXY_TIMEOUT)
 async def workflow_extract_endpoint(
     http_request: Request,
     cloud_manager: ScopeCloudBackend = Depends(get_scope_cloud),
@@ -2162,8 +2161,10 @@ async def workflow_extract_endpoint(
     the resulting on-disk paths, strips ``embedded_assets``, and returns
     the rewritten workflow.
 
-    In cloud mode this is proxied to the cloud server so the assets land
-    where the session that consumes them will run.
+    In cloud mode the assets are also materialized locally — sessions resolve
+    paths on the cloud server, but the local frontend serves preview thumbnails
+    from the local assets directory by basename, so a local copy is required
+    for ``<img>``/``<video>`` previews to render after import.
     """
     try:
         body = await http_request.json()
@@ -2173,6 +2174,29 @@ async def workflow_extract_endpoint(
         raise HTTPException(
             status_code=400, detail="Workflow body must be a JSON object"
         )
+
+    if cloud_manager.is_connected:
+        # Materialize a local copy of every embedded asset so the frontend
+        # can render previews (its thumbnail endpoint reads from the local
+        # assets dir by basename). The rewritten workflow we get back here
+        # is discarded; we use cloud's response so workflow paths resolve
+        # at session-run time on the cloud server.
+        try:
+            extract_workflow_assets(body, get_assets_dir())
+        except Exception as e:
+            logger.warning(
+                "extract: local asset materialization failed (cloud copy "
+                "still attempted): %s",
+                e,
+            )
+        return await proxy_with_body(
+            cloud_manager,
+            method="POST",
+            path="/api/v1/workflow/extract",
+            body=body,
+            timeout=_WORKFLOW_ASSET_PROXY_TIMEOUT,
+        )
+
     try:
         return extract_workflow_assets(body, get_assets_dir())
     except Exception as e:

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -41,6 +41,10 @@ from scope.core.lora.manifest import (
     load_manifest,
     save_manifest,
 )
+from scope.core.workflows import (
+    embed_workflow_assets,
+    extract_workflow_assets,
+)
 from scope.core.workflows.resolve import (
     WorkflowRequest,
     WorkflowResolutionPlan,
@@ -2102,6 +2106,80 @@ async def resolve_workflow_endpoint(
         raise HTTPException(
             status_code=500,
             detail="Internal error while resolving workflow dependencies",
+        ) from e
+
+
+# Embedding/extracting can ship multi-MB bodies (a workflow with embedded
+# video files quickly grows past plain JSON sizes). Bump the proxy timeout
+# from the 30s default so the cloud round-trip has time to read/write files.
+_WORKFLOW_ASSET_PROXY_TIMEOUT = 120.0
+
+
+@app.post("/api/v1/workflow/embed")
+@cloud_proxy(timeout=_WORKFLOW_ASSET_PROXY_TIMEOUT)
+async def workflow_embed_endpoint(
+    http_request: Request,
+    cloud_manager: ScopeCloudBackend = Depends(get_scope_cloud),
+):
+    """Embed referenced media files into a workflow JSON.
+
+    Accepts the full workflow JSON in the request body, walks string fields
+    for media paths, and base64-encodes every existing file into a top-level
+    ``embedded_assets`` list. Returns the resulting workflow.
+
+    In cloud mode this is proxied to the cloud server because the actual
+    asset files live on its disk; reading them locally would silently embed
+    nothing.
+    """
+    try:
+        body = await http_request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=400, detail="Workflow body must be a JSON object"
+        )
+    try:
+        return embed_workflow_assets(body, get_assets_dir())
+    except Exception as e:
+        logger.error("Error embedding workflow assets: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Internal error while embedding workflow assets",
+        ) from e
+
+
+@app.post("/api/v1/workflow/extract")
+@cloud_proxy(timeout=_WORKFLOW_ASSET_PROXY_TIMEOUT)
+async def workflow_extract_endpoint(
+    http_request: Request,
+    cloud_manager: ScopeCloudBackend = Depends(get_scope_cloud),
+):
+    """Extract embedded media from a workflow JSON.
+
+    Writes each ``embedded_assets`` entry to the local assets directory
+    (idempotent via SHA-256), rewrites path references in the workflow to
+    the resulting on-disk paths, strips ``embedded_assets``, and returns
+    the rewritten workflow.
+
+    In cloud mode this is proxied to the cloud server so the assets land
+    where the session that consumes them will run.
+    """
+    try:
+        body = await http_request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=400, detail="Workflow body must be a JSON object"
+        )
+    try:
+        return extract_workflow_assets(body, get_assets_dir())
+    except Exception as e:
+        logger.error("Error extracting workflow assets: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Internal error while extracting workflow assets",
         ) from e
 
 

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -22,7 +22,12 @@ import click
 import uvicorn
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, Response, StreamingResponse
+from fastapi.responses import (
+    FileResponse,
+    JSONResponse,
+    Response,
+    StreamingResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
@@ -2181,6 +2186,7 @@ async def workflow_extract_endpoint(
         # assets dir by basename). The rewritten workflow we get back here
         # is discarded; we use cloud's response so workflow paths resolve
         # at session-run time on the cloud server.
+        local_materialization_warning: str | None = None
         try:
             extract_workflow_assets(body, get_assets_dir())
         except Exception as e:
@@ -2189,13 +2195,26 @@ async def workflow_extract_endpoint(
                 "still attempted): %s",
                 e,
             )
-        return await proxy_with_body(
+            local_materialization_warning = (
+                "Local asset materialization failed; embedded media previews "
+                "may not render until the assets are uploaded again."
+            )
+        cloud_response = await proxy_with_body(
             cloud_manager,
             method="POST",
             path="/api/v1/workflow/extract",
             body=body,
             timeout=_WORKFLOW_ASSET_PROXY_TIMEOUT,
         )
+        # Surface the warning to the client via a response header so the
+        # frontend can toast a user-visible notice. The body is the cloud's
+        # rewritten workflow (paths point at cloud's filesystem).
+        headers = (
+            {"X-Scope-Warning": local_materialization_warning}
+            if local_materialization_warning
+            else None
+        )
+        return JSONResponse(content=cloud_response, headers=headers)
 
     try:
         return extract_workflow_assets(body, get_assets_dir())

--- a/tests/test_workflow_embed.py
+++ b/tests/test_workflow_embed.py
@@ -279,6 +279,120 @@ def test_round_trip_via_graph_ui_state(tmp_path: Path) -> None:
     assert Path(new_source_name).is_relative_to(target.resolve())
 
 
+def test_extract_does_not_rewrite_freeform_text_ending_in_extension(
+    tmp_path: Path,
+) -> None:
+    """A prompt or label that happens to end in ``cat.png`` (no path separator)
+    must not be rewritten to a local filesystem path on import. Only strings
+    that look path-shaped — contain ``/``/``\\`` or exactly equal an embedded
+    filename — are eligible for substitution.
+    """
+    png = _png_bytes()
+    target_assets = tmp_path / "target_assets"
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [
+            {
+                "params": {
+                    "prompt": "an image of cat.png on a couch",
+                    "vace_ref_images": ["/old/cat.png"],
+                }
+            }
+        ],
+        "embedded_assets": [
+            {
+                "filename": "cat.png",
+                "mime_type": "image/png",
+                "size_bytes": len(png),
+                "sha256": hashlib.sha256(png).hexdigest(),
+                "data": base64.b64encode(png).decode("ascii"),
+            }
+        ],
+    }
+
+    result = extract_workflow_assets(workflow, target_assets)
+    # Path-shaped reference is rewritten to the new on-disk location.
+    new_ref = result["pipelines"][0]["params"]["vace_ref_images"][0]
+    assert Path(new_ref).name == "cat.png"
+    assert Path(new_ref).is_relative_to(target_assets.resolve())
+    # Free-form prompt is left alone.
+    assert (
+        result["pipelines"][0]["params"]["prompt"] == "an image of cat.png on a couch"
+    )
+
+
+def test_extract_rewrites_bare_basename_reference(tmp_path: Path) -> None:
+    """A workflow that references a file by bare basename (no separator) is a
+    known shape and must still be rewritten to the on-disk path so it
+    resolves at session-run time."""
+    png = _png_bytes()
+    target_assets = tmp_path / "target_assets"
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [{"params": {"vace_ref_images": ["ref.png"]}}],
+        "embedded_assets": [
+            {
+                "filename": "ref.png",
+                "mime_type": "image/png",
+                "size_bytes": len(png),
+                "sha256": hashlib.sha256(png).hexdigest(),
+                "data": base64.b64encode(png).decode("ascii"),
+            }
+        ],
+    }
+
+    result = extract_workflow_assets(workflow, target_assets)
+    new_ref = result["pipelines"][0]["params"]["vace_ref_images"][0]
+    assert Path(new_ref).name == "ref.png"
+    assert Path(new_ref).exists()
+
+
+def test_extract_handles_windows_style_backslash_paths(tmp_path: Path) -> None:
+    """Workflows exported on Windows reference assets with ``\\`` separators.
+    On POSIX, ``Path(value).name`` would treat the whole string as a single
+    component. The basename extractor must normalize separators so the
+    rewrite still fires."""
+    png = _png_bytes()
+    target_assets = tmp_path / "target_assets"
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [
+            {"params": {"vace_ref_images": ["C:\\Users\\Alice\\assets\\ref.png"]}}
+        ],
+        "embedded_assets": [
+            {
+                "filename": "ref.png",
+                "mime_type": "image/png",
+                "size_bytes": len(png),
+                "sha256": hashlib.sha256(png).hexdigest(),
+                "data": base64.b64encode(png).decode("ascii"),
+            }
+        ],
+    }
+
+    result = extract_workflow_assets(workflow, target_assets)
+    new_ref = result["pipelines"][0]["params"]["vace_ref_images"][0]
+    assert Path(new_ref).name == "ref.png"
+    assert Path(new_ref).exists()
+
+
+def test_embed_preserves_higher_format_version(tmp_path: Path) -> None:
+    """If a future workflow exports with a higher format_version, embedding
+    additional media must not silently downgrade the version."""
+    png = _png_bytes()
+    assets = _make_assets_dir(tmp_path, {"ref.png": png})
+    workflow = {
+        "format_version": "1.5",
+        "metadata": {"name": "t"},
+        "pipelines": [{"params": {"vace_ref_images": [str(assets / "ref.png")]}}],
+    }
+    result = embed_workflow_assets(workflow, assets)
+    assert result["format_version"] == "1.5"
+
+
 def test_extract_endpoint_in_cloud_mode_writes_local_copy_for_previews(
     tmp_path: Path, cloud_mock: MagicMock
 ) -> None:
@@ -339,3 +453,56 @@ def test_extract_endpoint_in_cloud_mode_writes_local_copy_for_previews(
         "local copy missing — frontend previews will show broken image"
     )
     assert local_copy.read_bytes() == png
+    # Happy path: no warning header when local materialization succeeds.
+    assert response.headers.get("X-Scope-Warning") is None
+
+
+def test_extract_endpoint_cloud_mode_surfaces_local_failure_via_header(
+    tmp_path: Path, cloud_mock: MagicMock
+) -> None:
+    """When the local materialization step in cloud mode fails (e.g. the
+    assets dir is unwritable), the frontend won't be able to render previews.
+    The endpoint must still proxy to cloud so workflow paths resolve at
+    session-run time, but it must surface the local failure via the
+    ``X-Scope-Warning`` response header so the import dialog can toast a
+    user-visible notice."""
+    png = _png_bytes()
+    local_assets = tmp_path / "local_assets"  # intentionally not created
+
+    workflow_with_embedded = {
+        "format": "scope-workflow",
+        "format_version": "1.1",
+        "metadata": {"name": "t"},
+        "pipelines": [
+            {"params": {"vace_ref_images": ["/some/origin/machine/ref.png"]}}
+        ],
+        "embedded_assets": [
+            {
+                "filename": "ref.png",
+                "mime_type": "image/png",
+                "size_bytes": len(png),
+                "sha256": hashlib.sha256(png).hexdigest(),
+                "data": base64.b64encode(png).decode("ascii"),
+            }
+        ],
+    }
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk on fire")
+
+    with (
+        patch("scope.server.app.get_assets_dir", return_value=local_assets),
+        patch("scope.server.app.livepeer", cloud_mock),
+        patch("scope.server.app.extract_workflow_assets", side_effect=_raise),
+    ):
+        from scope.server.app import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/api/v1/workflow/extract", json=workflow_with_embedded)
+
+    assert response.status_code == 200, response.text
+    # Cloud was still called so the workflow's session-run paths resolve.
+    cloud_mock.api_request.assert_awaited_once()
+    # Frontend can read this header and toast the warning.
+    assert response.headers.get("X-Scope-Warning") is not None
+    assert "previews" in response.headers["X-Scope-Warning"].lower()

--- a/tests/test_workflow_embed.py
+++ b/tests/test_workflow_embed.py
@@ -1,0 +1,250 @@
+"""Tests for embedding/extracting media assets in workflow JSON."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+
+from scope.core.workflows.embed import (
+    embed_workflow_assets,
+    extract_workflow_assets,
+)
+
+
+def _png_bytes() -> bytes:
+    # 1x1 transparent PNG (smallest valid)
+    return base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+
+
+def _make_assets_dir(tmp_path: Path, files: dict[str, bytes]) -> Path:
+    d = tmp_path / "assets"
+    d.mkdir()
+    for name, data in files.items():
+        (d / name).write_bytes(data)
+    return d
+
+
+def test_embed_collects_referenced_files(tmp_path: Path) -> None:
+    png = _png_bytes()
+    assets = _make_assets_dir(tmp_path, {"ref.png": png})
+
+    workflow = {
+        "format": "scope-workflow",
+        "format_version": "1.0",
+        "metadata": {"name": "test"},
+        "pipelines": [
+            {
+                "pipeline_id": "longlive",
+                "params": {
+                    "vace_ref_images": [str(assets / "ref.png")],
+                    "noise_scale": 0.3,
+                },
+            }
+        ],
+    }
+
+    result = embed_workflow_assets(workflow, assets)
+    assert result["format_version"] == "1.1"
+    assert "embedded_assets" in result
+    assert len(result["embedded_assets"]) == 1
+    entry = result["embedded_assets"][0]
+    assert entry["filename"] == "ref.png"
+    assert entry["mime_type"] == "image/png"
+    assert entry["size_bytes"] == len(png)
+    assert entry["sha256"] == hashlib.sha256(png).hexdigest()
+    assert base64.b64decode(entry["data"]) == png
+    # Path references unchanged in the source workflow.
+    assert result["pipelines"][0]["params"]["vace_ref_images"][0] == str(
+        assets / "ref.png"
+    )
+
+
+def test_embed_skips_missing_files(tmp_path: Path) -> None:
+    assets = _make_assets_dir(tmp_path, {})
+    workflow = {
+        "metadata": {"name": "test"},
+        "pipelines": [{"params": {"vace_ref_images": ["/nonexistent/foo.png"]}}],
+    }
+    result = embed_workflow_assets(workflow, assets)
+    assert "embedded_assets" not in result
+
+
+def test_embed_resolves_basename_when_absolute_path_missing(tmp_path: Path) -> None:
+    """Workflow exported on machine A points at /home/alice/.daydream-scope/
+    assets/x.png; on machine B that path doesn't exist but x.png lives in the
+    local assets dir."""
+    png = _png_bytes()
+    assets = _make_assets_dir(tmp_path, {"x.png": png})
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [
+            {
+                "params": {
+                    "vace_ref_images": ["/home/alice/.daydream-scope/assets/x.png"]
+                }
+            }
+        ],
+    }
+    result = embed_workflow_assets(workflow, assets)
+    assert len(result["embedded_assets"]) == 1
+    assert result["embedded_assets"][0]["filename"] == "x.png"
+
+
+def test_embed_dedups_same_basename(tmp_path: Path) -> None:
+    png = _png_bytes()
+    assets = _make_assets_dir(tmp_path, {"shared.png": png})
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [
+            {"params": {"vace_ref_images": [str(assets / "shared.png")]}},
+            {
+                "params": {
+                    "first_frame_image": str(assets / "shared.png"),
+                    "last_frame_image": str(assets / "shared.png"),
+                }
+            },
+        ],
+    }
+    result = embed_workflow_assets(workflow, assets)
+    assert len(result["embedded_assets"]) == 1
+
+
+def test_extract_writes_assets_and_rewrites_paths(tmp_path: Path) -> None:
+    png = _png_bytes()
+    target_assets = tmp_path / "target_assets"  # importer's local dir, empty
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "format_version": "1.1",
+        "pipelines": [
+            {
+                "params": {
+                    "vace_ref_images": ["/old/machine/ref.png"],
+                }
+            }
+        ],
+        "embedded_assets": [
+            {
+                "filename": "ref.png",
+                "mime_type": "image/png",
+                "size_bytes": len(png),
+                "sha256": hashlib.sha256(png).hexdigest(),
+                "data": base64.b64encode(png).decode("ascii"),
+            }
+        ],
+    }
+
+    result = extract_workflow_assets(workflow, target_assets)
+
+    assert "embedded_assets" not in result
+    new_path = result["pipelines"][0]["params"]["vace_ref_images"][0]
+    assert Path(new_path).name == "ref.png"
+    assert Path(new_path).exists()
+    assert Path(new_path).read_bytes() == png
+    # Confirm written into target_assets
+    assert Path(new_path).is_relative_to(target_assets.resolve())
+
+
+def test_extract_idempotent_when_sha_matches(tmp_path: Path) -> None:
+    png = _png_bytes()
+    sha = hashlib.sha256(png).hexdigest()
+    target_assets = tmp_path / "target_assets"
+    target_assets.mkdir()
+    (target_assets / "ref.png").write_bytes(png)
+    mtime_before = (target_assets / "ref.png").stat().st_mtime_ns
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [{"params": {"vace_ref_images": ["/old/ref.png"]}}],
+        "embedded_assets": [
+            {
+                "filename": "ref.png",
+                "mime_type": "image/png",
+                "size_bytes": len(png),
+                "sha256": sha,
+                "data": base64.b64encode(png).decode("ascii"),
+            }
+        ],
+    }
+    extract_workflow_assets(workflow, target_assets)
+    mtime_after = (target_assets / "ref.png").stat().st_mtime_ns
+    # Existing identical file is not rewritten
+    assert mtime_before == mtime_after
+
+
+def test_extract_dedups_basename_collision_with_different_content(
+    tmp_path: Path,
+) -> None:
+    other_png = _png_bytes() + b"x"  # different content, same name
+    embedded_png = _png_bytes()
+    target_assets = tmp_path / "target"
+    target_assets.mkdir()
+    (target_assets / "ref.png").write_bytes(other_png)
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [{"params": {"vace_ref_images": ["/old/ref.png"]}}],
+        "embedded_assets": [
+            {
+                "filename": "ref.png",
+                "mime_type": "image/png",
+                "size_bytes": len(embedded_png),
+                "sha256": hashlib.sha256(embedded_png).hexdigest(),
+                "data": base64.b64encode(embedded_png).decode("ascii"),
+            }
+        ],
+    }
+    result = extract_workflow_assets(workflow, target_assets)
+    new_path = result["pipelines"][0]["params"]["vace_ref_images"][0]
+    # Should be a renamed file like ref_imported1.png
+    assert Path(new_path).name != "ref.png"
+    assert Path(new_path).read_bytes() == embedded_png
+    # Original untouched
+    assert (target_assets / "ref.png").read_bytes() == other_png
+
+
+def test_round_trip_via_graph_ui_state(tmp_path: Path) -> None:
+    """Embedding should reach into graph.ui_state.nodes[].data.imagePath."""
+    png = _png_bytes()
+    src_assets = _make_assets_dir(tmp_path, {"hero.png": png})
+
+    workflow = {
+        "metadata": {"name": "t"},
+        "pipelines": [],
+        "graph": {
+            "nodes": [
+                {
+                    "id": "media1",
+                    "type": "source",
+                    "source_mode": "video_file",
+                    "source_name": str(src_assets / "hero.png"),
+                }
+            ],
+            "edges": [],
+            "ui_state": {
+                "nodes": [
+                    {
+                        "id": "img1",
+                        "type": "image",
+                        "data": {"imagePath": str(src_assets / "hero.png")},
+                    }
+                ]
+            },
+        },
+    }
+
+    embedded = embed_workflow_assets(workflow, src_assets)
+    assert len(embedded["embedded_assets"]) == 1
+
+    # Now extract on a fresh dir
+    target = tmp_path / "fresh"
+    extracted = extract_workflow_assets(embedded, target)
+    new_source_name = extracted["graph"]["nodes"][0]["source_name"]
+    new_image_path = extracted["graph"]["ui_state"]["nodes"][0]["data"]["imagePath"]
+    assert Path(new_source_name).read_bytes() == png
+    assert Path(new_image_path).read_bytes() == png
+    assert Path(new_source_name).is_relative_to(target.resolve())

--- a/tests/test_workflow_embed.py
+++ b/tests/test_workflow_embed.py
@@ -5,11 +5,40 @@ from __future__ import annotations
 import base64
 import hashlib
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
 
 from scope.core.workflows.embed import (
     embed_workflow_assets,
     extract_workflow_assets,
 )
+
+
+@pytest.fixture
+def cloud_mock():
+    """Mock cloud backend that reports connected and records api_request calls."""
+    mock = MagicMock()
+    mock.is_connected = True
+    # Mirror the real cloud's response shape: cloud-side path is returned in
+    # the workflow it sends back. Tests can override via .api_request.return_value.
+    mock.api_request = AsyncMock(
+        return_value={
+            "status": 200,
+            "data": {
+                "metadata": {"name": "t"},
+                "pipelines": [
+                    {
+                        "params": {
+                            "vace_ref_images": ["/root/.daydream-scope/assets/ref.png"]
+                        }
+                    }
+                ],
+            },
+        }
+    )
+    return mock
 
 
 def _png_bytes() -> bytes:
@@ -248,3 +277,65 @@ def test_round_trip_via_graph_ui_state(tmp_path: Path) -> None:
     assert Path(new_source_name).read_bytes() == png
     assert Path(new_image_path).read_bytes() == png
     assert Path(new_source_name).is_relative_to(target.resolve())
+
+
+def test_extract_endpoint_in_cloud_mode_writes_local_copy_for_previews(
+    tmp_path: Path, cloud_mock: MagicMock
+) -> None:
+    """In cloud mode the extract endpoint must still materialize embedded
+    assets locally, otherwise the frontend's ``<img>``/``<video>`` previews
+    (which load from ``/api/v1/assets/{basename}``, a local-only endpoint)
+    show as broken images after import.
+
+    Regression test for the case where importing a workflow with
+    ``embedded_assets`` while connected to the cloud left the local assets
+    dir untouched, so previews 404'd.
+    """
+    png = _png_bytes()
+    local_assets = tmp_path / "local_assets"
+    local_assets.mkdir()
+
+    workflow_with_embedded = {
+        "format": "scope-workflow",
+        "format_version": "1.1",
+        "metadata": {"name": "t"},
+        "pipelines": [
+            {"params": {"vace_ref_images": ["/some/origin/machine/ref.png"]}}
+        ],
+        "embedded_assets": [
+            {
+                "filename": "ref.png",
+                "mime_type": "image/png",
+                "size_bytes": len(png),
+                "sha256": hashlib.sha256(png).hexdigest(),
+                "data": base64.b64encode(png).decode("ascii"),
+            }
+        ],
+    }
+
+    with (
+        patch("scope.server.app.get_assets_dir", return_value=local_assets),
+        patch("scope.server.app.livepeer", cloud_mock),
+    ):
+        from scope.server.app import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/api/v1/workflow/extract", json=workflow_with_embedded)
+
+    assert response.status_code == 200, response.text
+    # Cloud's response is what the client sees — paths point at the cloud's
+    # filesystem so sessions resolve them on the cloud worker.
+    body = response.json()
+    assert (
+        body["pipelines"][0]["params"]["vace_ref_images"][0]
+        == "/root/.daydream-scope/assets/ref.png"
+    )
+    # And the cloud was actually called.
+    cloud_mock.api_request.assert_awaited_once()
+    # The fix: a local copy must exist so the preview thumbnail endpoint
+    # (which strips the path to its basename) can serve it.
+    local_copy = local_assets / "ref.png"
+    assert local_copy.exists(), (
+        "local copy missing — frontend previews will show broken image"
+    )
+    assert local_copy.read_bytes() == png


### PR DESCRIPTION


https://github.com/user-attachments/assets/dfd93ed2-c9d0-446f-94fe-2287da584b24



Workflows reference media (images, audio, video) by filesystem path, which only resolves on the author's machine. This change base64-encodes every referenced file into a top-level `embedded_assets` array on export, and on import writes them back to the local assets directory and rewrites the path references.

New endpoints `POST /api/v1/workflow/embed` and `POST /api/v1/workflow/extract` handle the round trip; both `@cloud_proxy()` to the cloud server in cloud mode (assets live on cloud disk). Extract is idempotent via SHA-256 and dedupes basename collisions. `format_version` bumps to `"1.1"` only when `embedded_assets` is present; older files stay compatible.

## Test plan
- [x] Unit tests cover round trip, idempotency, basename collisions, graph ui_state walking, free-form-prompt protection, Windows-style paths, and cloud-mode warning header
- [x] HTTP smoke test: embed → delete file → extract restores byte-identical, prompt unmangled, paths rewritten
- [x] Local Livepeer relay: embed/extract proxied to runner, frame after extract matched the seeded source
