### PR TITLE
fix(lora): fail fast on incompatible LoRAs and warn in UI on missing files

### DIFF
--- a/frontend/src/components/LoRAManager.tsx
+++ b/frontend/src/components/LoRAManager.tsx
@@ -33,7 +33,8 @@ export function LoRAManager({
   loraMergeStrategy = "permanent_merge",
   onOpenLoRAsSettings,
 }: LoRAManagerProps) {
-  const { loraFiles: availableLoRAs } = useLoRAsContext();
+  const { loraFiles: availableLoRAs, isLoading: isLoadingLoRAs } =
+    useLoRAsContext();
   const { isConnected: isCloudConnected } = useCloudStatus();
   const [localScales, setLocalScales] = useState<Record<string, number>>({});
 
@@ -166,6 +167,12 @@ export function LoRAManager({
                   disabled={disabled || isStreaming}
                   placeholder="Select LoRA file"
                   emptyMessage="No LoRA files found"
+                  isLoading={isLoadingLoRAs}
+                  missingTooltip={
+                    isCloudConnected
+                      ? "This LoRA isn't available on the cloud runner. Upload it to your library or pick another file — the pipeline will fail to load otherwise."
+                      : "This LoRA isn't in your local library. Install it or pick another file — the pipeline will fail to load otherwise."
+                  }
                 />
               </div>
               <Button

--- a/frontend/src/components/ui/file-picker.tsx
+++ b/frontend/src/components/ui/file-picker.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { ChevronRight, ChevronDown } from "lucide-react";
+import { ChevronRight, ChevronDown, AlertTriangle } from "lucide-react";
 import { cn } from "../../lib/utils";
 
 export interface FileInfo {
@@ -16,6 +16,10 @@ interface FilePickerProps {
   disabled?: boolean;
   placeholder?: string;
   emptyMessage?: string;
+  /** When true, don't flag a non-matching value as missing — files are still loading. */
+  isLoading?: boolean;
+  /** Hover text shown when the configured value isn't in `files`. */
+  missingTooltip?: string;
 }
 
 export function FilePicker({
@@ -25,6 +29,8 @@ export function FilePicker({
   disabled,
   placeholder = "Select file",
   emptyMessage = "No files found",
+  isLoading = false,
+  missingTooltip = "This file isn't available on the active backend. Install or upload it before starting the pipeline.",
 }: FilePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
@@ -51,6 +57,13 @@ export function FilePicker({
   }, [files]);
 
   const selectedFile = files.find(f => f.path === value);
+  const isMissing = !!value && !selectedFile && !isLoading;
+  const missingLabel = useMemo(() => {
+    if (!isMissing) return "";
+    // Handle both Windows ("C:\Users\...") and Unix ("/Users/...") paths.
+    const parts = value.split(/[\\/]/).filter(Boolean);
+    return parts[parts.length - 1] || value;
+  }, [isMissing, value]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -92,14 +105,25 @@ export function FilePicker({
         type="button"
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
+        title={isMissing ? `${missingTooltip} (${value})` : undefined}
         className={cn(
           "flex h-7 w-full items-center justify-between rounded-md border border-input bg-background px-2 text-xs",
           "hover:bg-accent hover:text-accent-foreground",
-          "disabled:cursor-not-allowed disabled:opacity-50"
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          isMissing && "border-amber-500/60 text-amber-500"
         )}
       >
-        <span className="truncate">
-          {selectedFile ? selectedFile.name : placeholder}
+        <span className="flex min-w-0 items-center gap-1">
+          {isMissing && (
+            <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden="true" />
+          )}
+          <span className="truncate">
+            {selectedFile
+              ? selectedFile.name
+              : isMissing
+                ? missingLabel
+                : placeholder}
+          </span>
         </span>
         <ChevronDown className="h-3 w-3 ml-1 shrink-0" />
       </button>

--- a/src/scope/core/pipelines/wan2_1/lora/strategies/peft_lora.py
+++ b/src/scope/core/pipelines/wan2_1/lora/strategies/peft_lora.py
@@ -17,6 +17,7 @@ import torch
 import torch.nn as nn
 
 from ..utils import (
+    LoRAIncompatibleError,
     find_lora_pair,
     load_lora_weights,
     normalize_lora_key,
@@ -427,7 +428,7 @@ class PeftLoRAStrategy:
 
         # Parse and map LoRA weights to model parameters
         # Returns keys matching model_state (PEFT keys if model is PEFT-wrapped)
-        lora_mapping = parse_lora_weights(lora_state, model_state)
+        lora_mapping = parse_lora_weights(lora_state, model_state, lora_path=lora_path)
         logger.info(
             f"load_adapter: Mapped {len(lora_mapping)} LoRA layers to model parameters"
         )
@@ -521,6 +522,9 @@ class PeftLoRAStrategy:
                 raise RuntimeError(
                     f"{logger_prefix}LoRA loading failed. File not found: {lora_path}"
                 ) from e
+            except LoRAIncompatibleError:
+                # Preserve the typed exception so the UI gets a specific error.
+                raise
             except Exception as e:
                 logger.error(f"{logger_prefix}Failed to load LoRA: {e}", exc_info=True)
                 raise RuntimeError(f"{logger_prefix}LoRA loading failed: {e}") from e

--- a/src/scope/core/pipelines/wan2_1/lora/strategies/permanent_merge_lora.py
+++ b/src/scope/core/pipelines/wan2_1/lora/strategies/permanent_merge_lora.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import torch
 
-from ..utils import standardize_lora_for_peft
+from ..utils import LoRAIncompatibleError, standardize_lora_for_peft
 from .peft_lora import PeftLoRAStrategy
 
 __all__ = ["PermanentMergeLoRAStrategy"]
@@ -63,7 +63,9 @@ class PermanentMergeLoRAStrategy:
         # Parse the converted state dict through PeftLoRAStrategy
         # to inject LoRA layers (this handles the PEFT wrapping)
         model_state = model.state_dict()
-        lora_mapping = parse_lora_weights(converted_state, model_state)
+        lora_mapping = parse_lora_weights(
+            converted_state, model_state, lora_path=lora_path
+        )
 
         # Inject PEFT LoRA layers
         PeftLoRAStrategy._inject_lora_layers(
@@ -197,6 +199,9 @@ class PermanentMergeLoRAStrategy:
                     f"{logger_prefix}LoRA loading failed. File not found: {lora_path}. "
                     f"Ensure the file exists in the models/lora/ directory."
                 ) from e
+            except LoRAIncompatibleError:
+                # Preserve the typed exception so the UI gets a specific error.
+                raise
             except Exception as e:
                 raise RuntimeError(
                     f"{logger_prefix}LoRA loading failed. Pipeline cannot start without all configured LoRAs. "

--- a/src/scope/core/pipelines/wan2_1/lora/utils.py
+++ b/src/scope/core/pipelines/wan2_1/lora/utils.py
@@ -15,6 +15,15 @@ from safetensors.torch import load_file
 logger = logging.getLogger(__name__)
 
 
+class LoRAIncompatibleError(RuntimeError):
+    """Raised when a LoRA's tensor shapes do not match the target model.
+
+    The most common cause is loading a LoRA trained on one base model
+    (e.g. Wan 14B, hidden_dim=5120) into a pipeline using a different
+    base model (e.g. Wan 1.3B, hidden_dim=1536).
+    """
+
+
 def sanitize_adapter_name(adapter_name: str) -> str:
     """
     Sanitize adapter name to be valid for PyTorch module names.
@@ -318,10 +327,21 @@ def build_key_map(model_state_dict: dict[str, torch.Tensor]) -> dict[str, str]:
 
 
 def parse_lora_weights(
-    lora_state: dict[str, torch.Tensor], model_state: dict[str, torch.Tensor]
+    lora_state: dict[str, torch.Tensor],
+    model_state: dict[str, torch.Tensor],
+    lora_path: str | None = None,
 ) -> dict[str, dict[str, Any]]:
     """
     Parse LoRA weights and match them to model parameters.
+
+    Args:
+        lora_state: LoRA state dictionary
+        model_state: Target model state dictionary
+        lora_path: Optional source path, used only to enrich error messages
+
+    Raises:
+        LoRAIncompatibleError: If a matched LoRA tensor's shape does not match
+            the target model parameter (e.g. wrong base model dimension).
 
     Returns:
         Dict mapping model parameter names to LoRA info:
@@ -409,6 +429,27 @@ def parse_lora_weights(
             logger.debug(
                 f"parse_lora_weights: Matched base_key='{base_key}' -> model_key='{model_key}'"
             )
+
+        # Validate dimensions against the target weight before injection.
+        # PEFT's later .data assignment will silently accept mismatched shapes
+        # and only crash at the first forward pass with an opaque message; we
+        # prefer to fail fast here with a hint about base-model mismatch.
+        target_shape = tuple(model_state[model_key].shape)
+        if len(target_shape) >= 2 and lora_A.dim() >= 2 and lora_B.dim() >= 2:
+            target_out_dim, target_in_dim = target_shape[0], target_shape[1]
+            lora_in_dim = lora_A.shape[1]
+            lora_out_dim = lora_B.shape[0]
+            if lora_in_dim != target_in_dim or lora_out_dim != target_out_dim:
+                lora_label = f" '{lora_path}'" if lora_path else ""
+                raise LoRAIncompatibleError(
+                    f"LoRA{lora_label} is incompatible with this pipeline's base model: "
+                    f"layer '{model_key}' expects shape "
+                    f"({target_out_dim}, {target_in_dim}) but the LoRA provides "
+                    f"({lora_out_dim}, {lora_in_dim}). "
+                    f"This usually means the LoRA was trained on a different base model "
+                    f"(e.g. Wan 14B / 5120-dim vs. Wan 1.3B / 1536-dim). "
+                    f"Use a LoRA trained on a compatible base model."
+                )
 
         # Extract alpha and rank
         alpha = None

--- a/src/scope/core/pipelines/wan2_1/lora/utils.py
+++ b/src/scope/core/pipelines/wan2_1/lora/utils.py
@@ -434,20 +434,22 @@ def parse_lora_weights(
         # PEFT's later .data assignment will silently accept mismatched shapes
         # and only crash at the first forward pass with an opaque message; we
         # prefer to fail fast here with a hint about base-model mismatch.
+        # Restricted to 2D weights (Linear) to avoid false positives on Conv
+        # LoRAs whose A matrix may be flattened across kernel dims.
         target_shape = tuple(model_state[model_key].shape)
-        if len(target_shape) >= 2 and lora_A.dim() >= 2 and lora_B.dim() >= 2:
-            target_out_dim, target_in_dim = target_shape[0], target_shape[1]
+        if len(target_shape) == 2 and lora_A.dim() == 2 and lora_B.dim() == 2:
+            target_out_dim, target_in_dim = target_shape
             lora_in_dim = lora_A.shape[1]
             lora_out_dim = lora_B.shape[0]
             if lora_in_dim != target_in_dim or lora_out_dim != target_out_dim:
-                lora_label = f" '{lora_path}'" if lora_path else ""
+                lora_label = f" '{os.path.basename(lora_path)}'" if lora_path else ""
                 raise LoRAIncompatibleError(
                     f"LoRA{lora_label} is incompatible with this pipeline's base model: "
                     f"layer '{model_key}' expects shape "
                     f"({target_out_dim}, {target_in_dim}) but the LoRA provides "
                     f"({lora_out_dim}, {lora_in_dim}). "
                     f"This usually means the LoRA was trained on a different base model "
-                    f"(e.g. Wan 14B / 5120-dim vs. Wan 1.3B / 1536-dim). "
+                    f"(e.g. Wan 14B vs. Wan 1.3B have different hidden dims). "
                     f"Use a LoRA trained on a compatible base model."
                 )
 

--- a/src/scope/server/pipeline_manager.py
+++ b/src/scope/server/pipeline_manager.py
@@ -53,6 +53,9 @@ class PipelineManager:
         self._pipeline_statuses: dict[
             str, PipelineStatus
         ] = {}  # instance_key -> status
+        self._pipeline_errors: dict[
+            str, str
+        ] = {}  # instance_key -> last error message (only populated on ERROR)
         self._pipeline_load_params: dict[str, dict] = {}  # instance_key -> load_params
         self._pipeline_registry_ids: dict[
             str, str
@@ -315,6 +318,7 @@ class PipelineManager:
                 self._pipeline_load_params[key] = load_params or {}
                 self._pipeline_registry_ids[key] = pipeline_id
                 self._pipeline_statuses[key] = PipelineStatus.LOADED
+                self._pipeline_errors.pop(key, None)
                 # Signal waiters that load is complete
                 if key in self._load_events:
                     self._load_events[key].set()
@@ -353,6 +357,7 @@ class PipelineManager:
             # Hold lock while updating state with error
             with self._lock:
                 self._pipeline_statuses[key] = PipelineStatus.ERROR
+                self._pipeline_errors[key] = str(e)
                 if key in self._pipelines:
                     del self._pipelines[key]
                 if key in self._pipeline_load_params:
@@ -448,17 +453,24 @@ class PipelineManager:
                 if all_adapters:
                     loaded_lora_adapters = all_adapters
 
-            # If there's an error, clear error statuses after capturing them
-            # This ensures errors don't persist across page reloads
+            # If there's an error, capture the per-pipeline messages, then
+            # clear both the ERROR statuses and stored messages so they don't
+            # persist across page reloads.
+            combined_error = None
             if overall_status == PipelineStatus.ERROR:
-                # Clear error statuses from tracked pipelines
+                error_messages = [
+                    self._pipeline_errors[pid]
+                    for pid in self._pipeline_statuses
+                    if self._pipeline_statuses[pid] == PipelineStatus.ERROR
+                    and pid in self._pipeline_errors
+                ]
+                if error_messages:
+                    combined_error = "\n".join(error_messages)
+
                 for pid in list(self._pipeline_statuses.keys()):
                     if self._pipeline_statuses[pid] == PipelineStatus.ERROR:
                         self._pipeline_statuses[pid] = PipelineStatus.NOT_LOADED
-
-            # Error messages are logged but not tracked per-pipeline
-            # The ERROR status is sufficient for the frontend
-            combined_error = None
+                        self._pipeline_errors.pop(pid, None)
 
             # Determine media modalities from the loaded node chain.
             # Use registry IDs (not instance keys) so the lookup works in
@@ -655,6 +667,7 @@ class PipelineManager:
             for key in list(self._pipeline_statuses.keys()):
                 if key not in new_key_set:
                     del self._pipeline_statuses[key]
+                    self._pipeline_errors.pop(key, None)
 
         # Phase 3: Load new entries.
         # First, unload any stale instances that sit at keys scheduled for
@@ -832,6 +845,7 @@ class PipelineManager:
             del self._pipelines[pipeline_id]
         if pipeline_id in self._pipeline_statuses:
             del self._pipeline_statuses[pipeline_id]
+        self._pipeline_errors.pop(pipeline_id, None)
         if pipeline_id in self._pipeline_load_params:
             del self._pipeline_load_params[pipeline_id]
         if pipeline_id in self._pipeline_registry_ids:

--- a/tests/test_lora_dim_validation.py
+++ b/tests/test_lora_dim_validation.py
@@ -1,0 +1,54 @@
+"""Validation that LoRA tensors must match the target model's layer shapes.
+
+Mismatched dimensions (e.g. a Wan-14B-trained LoRA loaded against a Wan-1.3B
+model) used to crash deep inside the first forward pass with an opaque tensor
+error. parse_lora_weights now fails fast with a typed LoRAIncompatibleError
+naming the offending layer and dimensions.
+"""
+
+import pytest
+import torch
+
+from scope.core.pipelines.wan2_1.lora.utils import (
+    LoRAIncompatibleError,
+    parse_lora_weights,
+)
+
+
+def _model_state(in_dim: int, out_dim: int) -> dict[str, torch.Tensor]:
+    return {"blocks.0.self_attn.q.weight": torch.zeros(out_dim, in_dim)}
+
+
+def _lora_state(in_dim: int, out_dim: int, rank: int = 8) -> dict[str, torch.Tensor]:
+    return {
+        "diffusion_model.blocks.0.self_attn.q.lora_A.weight": torch.zeros(rank, in_dim),
+        "diffusion_model.blocks.0.self_attn.q.lora_B.weight": torch.zeros(
+            out_dim, rank
+        ),
+    }
+
+
+def test_parse_lora_weights_accepts_matching_dims():
+    mapping = parse_lora_weights(_lora_state(1536, 1536), _model_state(1536, 1536))
+    assert "blocks.0.self_attn.q.weight" in mapping
+    assert mapping["blocks.0.self_attn.q.weight"]["rank"] == 8
+
+
+def test_parse_lora_weights_rejects_in_dim_mismatch():
+    # LoRA trained on Wan 14B (5120) loaded against Wan 1.3B (1536).
+    with pytest.raises(LoRAIncompatibleError) as excinfo:
+        parse_lora_weights(
+            _lora_state(5120, 5120),
+            _model_state(1536, 1536),
+            lora_path="/models/lora/wan14b_style.safetensors",
+        )
+    msg = str(excinfo.value)
+    assert "wan14b_style.safetensors" in msg
+    assert "1536" in msg and "5120" in msg
+    assert "blocks.0.self_attn.q.weight" in msg
+
+
+def test_parse_lora_weights_rejects_out_dim_mismatch():
+    # Same in_dim but different out_dim (e.g. partial dim mismatch).
+    with pytest.raises(LoRAIncompatibleError):
+        parse_lora_weights(_lora_state(1536, 5120), _model_state(1536, 1536))

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -341,3 +341,48 @@ class TestHelperMethods:
             "node_a", "longlive", {}, claimed_keys=set(), reserved_keys={"node_a"}
         )
         assert result == "node_a"
+
+
+class TestErrorPropagation:
+    """Load failures should surface their message via get_status_info exactly
+    once, then clear so the error doesn't stick across page reloads."""
+
+    def test_status_info_returns_load_error_message(self):
+        manager = _make_manager()
+        manager._pipeline_statuses["node_a"] = PipelineStatus.ERROR
+        manager._pipeline_errors["node_a"] = (
+            "LoRA 'foo.safetensors' is incompatible with this pipeline's base model"
+        )
+
+        info = manager.get_status_info()
+
+        assert info["status"] == "error"
+        assert info["error"] is not None
+        assert "incompatible" in info["error"]
+
+    def test_status_info_clears_error_after_capture(self):
+        manager = _make_manager()
+        manager._pipeline_statuses["node_a"] = PipelineStatus.ERROR
+        manager._pipeline_errors["node_a"] = "boom"
+
+        first = manager.get_status_info()
+        second = manager.get_status_info()
+
+        assert first["error"] == "boom"
+        # After the first capture, status reverts to NOT_LOADED and the
+        # message is dropped, so the next call doesn't re-surface it.
+        assert second["error"] is None
+        assert manager._pipeline_errors == {}
+
+    def test_status_info_joins_multiple_errors(self):
+        manager = _make_manager()
+        manager._pipeline_statuses["node_a"] = PipelineStatus.ERROR
+        manager._pipeline_statuses["node_b"] = PipelineStatus.ERROR
+        manager._pipeline_errors["node_a"] = "first"
+        manager._pipeline_errors["node_b"] = "second"
+
+        info = manager.get_status_info()
+
+        assert info["status"] == "error"
+        assert "first" in info["error"]
+        assert "second" in info["error"]


### PR DESCRIPTION


https://github.com/user-attachments/assets/f6f2fc50-3414-4a1c-a332-7165e120e500



## Summary
- Validate LoRA `lora_A`/`lora_B` shapes against target weights in `parse_lora_weights`. On mismatch (e.g. a Wan 14B LoRA on a Wan 1.3B pipeline) raise a typed `LoRAIncompatibleError` naming the layer and both shapes, instead of crashing deep in the first forward pass.
- Surface the message via `pipeline_load_failed` so the UI shows it.
- In the LoRA picker, flag a configured-but-missing path with an amber warning + tooltip (cloud vs. local copy) before the user starts the pipeline.

## Test plan
- [ ] `uv run pytest tests/test_lora_dim_validation.py tests/test_pipeline_manager.py`
- [ ] Load an incompatible LoRA in the UI and confirm the typed error message is shown.
- [ ] Configure a LoRA path that doesn't exist locally / on the cloud runner and confirm the picker shows the warning.
