### PR TITLE
fix(cloud): run Syphon/NDI/Spout sinks locally when connected to cloud

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -41,6 +41,7 @@ from livepeer_gateway.media_publish import (
 from pydantic import BaseModel
 
 import scope.server.app as scope_app_module
+from scope.core.outputs import HARDWARE_SINK_MODES
 from scope.server.app import app as scope_app
 from scope.server.app import lifespan as scope_lifespan
 from scope.server.frame_processor import FrameProcessor
@@ -210,7 +211,7 @@ def _parse_browser_graph_routes(
                 source_ids.append(node_id)
             elif node_type == "sink":
                 sink_mode = node.get("sink_mode")
-                if sink_mode not in ("spout", "ndi", "syphon"):
+                if sink_mode not in HARDWARE_SINK_MODES:
                     sink_ids.append(node_id)
             elif node_type == "record":
                 record_ids.append(node_id)

--- a/src/scope/core/outputs/__init__.py
+++ b/src/scope/core/outputs/__init__.py
@@ -5,7 +5,19 @@ Output sinks send processed video frames to external destinations like Spout, ND
 
 from .interface import OutputSink
 
-__all__ = ["OutputSink", "get_output_sink_classes", "get_available_output_sinks"]
+# Sink modes that publish frames to local OS-level IPC (Spout on Windows,
+# NDI on the LAN, Syphon on macOS) rather than the WebRTC peer connection.
+# These always run on the user's machine, even when the pipeline executes
+# on a cloud runner — so the cloud-relay code strips them from the graph
+# sent to the runner and re-creates the senders locally.
+HARDWARE_SINK_MODES: frozenset[str] = frozenset({"spout", "ndi", "syphon"})
+
+__all__ = [
+    "HARDWARE_SINK_MODES",
+    "OutputSink",
+    "get_available_output_sinks",
+    "get_output_sink_classes",
+]
 
 
 def get_output_sink_classes() -> dict[str, type[OutputSink]]:

--- a/src/scope/server/cloud_track.py
+++ b/src/scope/server/cloud_track.py
@@ -326,7 +326,7 @@ class CloudTrack(MediaStreamTrack):
             await handler.stop()
         self._extra_input_handlers.clear()
         self._extra_sink_tracks.clear()
-        self._record_callbacks.clear()
+        self._output_taps.clear()
         self._pending_extra_sources.clear()
 
         if self._input_task:

--- a/src/scope/server/cloud_track.py
+++ b/src/scope/server/cloud_track.py
@@ -95,13 +95,13 @@ class CloudTrack(MediaStreamTrack):
         self._pending_extra_sources: list[tuple[str, MediaStreamTrack]] = []
         self._extra_sink_tracks: list[CloudSinkOutputTrack] = []
         self._extra_input_handlers: list[CloudSourceInputHandler] = []
-        self._record_callbacks: list[tuple[str, Callable]] = []
-        # Hardware sink routes: (output_handler_index, hardware_sink_node_id).
-        # Each entry tees frames from the given cloud output handler into the
-        # named local hardware sink (Syphon/NDI/Spout) via the FrameProcessor's
-        # SinkManager.put_to_sink — same pattern as record_callbacks but the
-        # destination is a local hardware sender thread, not a recorder queue.
-        self._hardware_sink_routes: list[tuple[int, str]] = []
+        # Output taps: (output_handler_index, callback) pairs. Each entry
+        # registers an additional callback on the named cloud output handler
+        # so the same frame can be fanned out to record queues, local
+        # hardware sinks (Syphon/NDI/Spout), or any other consumer the
+        # offer-handler wires up. handle_offer_with_relay computes the
+        # handler indices from the graph structure.
+        self._output_taps: list[tuple[int, Callable]] = []
 
     def set_source_track(self, track: MediaStreamTrack) -> None:
         """Set the source track for input frames (from browser)."""
@@ -187,43 +187,16 @@ class CloudTrack(MediaStreamTrack):
                     )
                     logger.info(f"Wired extra sink track {i} to cloud output")
 
-            # Wire record node output callbacks (placed after sink tracks)
-            num_extra_sinks = len(self._extra_sink_tracks)
-            for i, (rec_id, callback) in enumerate(self._record_callbacks):
-                handler_index = num_extra_sinks + 1 + i
-                if handler_index < len(webrtc_client.output_handlers):
+            # Wire output taps: callbacks registered against specific cloud
+            # output handler indices. Used for record nodes and local
+            # hardware sinks (Syphon/NDI/Spout).
+            for handler_index, callback in self._output_taps:
+                if 0 <= handler_index < len(webrtc_client.output_handlers):
                     webrtc_client.output_handlers[handler_index].add_callback(callback)
-                    logger.info(f"Wired record node {rec_id} to cloud output")
-
-            # Wire hardware sinks (Syphon/NDI/Spout). Each route tees frames
-            # from an existing cloud output handler into a local hardware
-            # sender. The handler index is computed by handle_offer_with_relay
-            # based on which webrtc sink shares the same upstream pipeline.
-            if self.frame_processor is not None and self._hardware_sink_routes:
-                fp = self.frame_processor
-                for handler_index, hw_node_id in self._hardware_sink_routes:
-                    if handler_index < 0 or handler_index >= len(
-                        webrtc_client.output_handlers
-                    ):
-                        logger.warning(
-                            f"Cannot wire hardware sink {hw_node_id!r}: cloud "
-                            f"output handler index {handler_index} out of range "
-                            f"(have {len(webrtc_client.output_handlers)})"
-                        )
-                        continue
-
-                    def _make_hw_cb(node_id: str) -> Callable:
-                        def _cb(frame) -> None:
-                            fp.sink_manager.put_to_sink(node_id, frame)
-
-                        return _cb
-
-                    webrtc_client.output_handlers[handler_index].add_callback(
-                        _make_hw_cb(hw_node_id)
-                    )
-                    logger.info(
-                        f"Wired hardware sink {hw_node_id!r} to cloud output "
-                        f"handler {handler_index}"
+                else:
+                    logger.warning(
+                        f"Output tap on cloud handler {handler_index} skipped: "
+                        f"out of range (have {len(webrtc_client.output_handlers)})"
                     )
 
         logger.info("Relay started")
@@ -432,24 +405,17 @@ class CloudTrack(MediaStreamTrack):
         """Register extra sink output tracks that need cloud callbacks."""
         self._extra_sink_tracks = list(tracks)
 
-    def set_record_callbacks(self, callbacks: list[tuple[str, Callable]]) -> None:
-        """Register callbacks for record node outputs from cloud.
+    def set_output_taps(self, taps: list[tuple[int, Callable]]) -> None:
+        """Register fan-out callbacks on cloud output handlers.
 
-        Each entry is (record_node_id, callback) where callback receives a
-        VideoFrame and pushes it into the frame_processor's record queue.
+        Each entry is ``(handler_index, callback)``. Once the cloud relay
+        starts, every frame received on
+        ``webrtc_client.output_handlers[handler_index]`` is also delivered
+        to ``callback`` (in addition to whatever else is wired to that
+        handler). Used to feed record-node queues and local hardware sinks
+        from cloud-produced frames.
         """
-        self._record_callbacks = list(callbacks)
-
-    def set_hardware_sink_routes(self, routes: list[tuple[int, str]]) -> None:
-        """Register hardware sink routes from cloud output handlers.
-
-        Each entry is ``(handler_index, hardware_sink_node_id)``. After the
-        cloud relay starts, every frame received on
-        ``webrtc_client.output_handlers[handler_index]`` is teed into the
-        local SinkManager's queue for ``hardware_sink_node_id``, where a
-        per-node sender thread (Syphon/NDI/Spout) pushes it out.
-        """
-        self._hardware_sink_routes = list(routes)
+        self._output_taps = list(taps)
 
     def get_stats(self) -> dict:
         """Get relay statistics."""

--- a/src/scope/server/cloud_track.py
+++ b/src/scope/server/cloud_track.py
@@ -96,6 +96,12 @@ class CloudTrack(MediaStreamTrack):
         self._extra_sink_tracks: list[CloudSinkOutputTrack] = []
         self._extra_input_handlers: list[CloudSourceInputHandler] = []
         self._record_callbacks: list[tuple[str, Callable]] = []
+        # Hardware sink routes: (output_handler_index, hardware_sink_node_id).
+        # Each entry tees frames from the given cloud output handler into the
+        # named local hardware sink (Syphon/NDI/Spout) via the FrameProcessor's
+        # SinkManager.put_to_sink — same pattern as record_callbacks but the
+        # destination is a local hardware sender thread, not a recorder queue.
+        self._hardware_sink_routes: list[tuple[int, str]] = []
 
     def set_source_track(self, track: MediaStreamTrack) -> None:
         """Set the source track for input frames (from browser)."""
@@ -188,6 +194,37 @@ class CloudTrack(MediaStreamTrack):
                 if handler_index < len(webrtc_client.output_handlers):
                     webrtc_client.output_handlers[handler_index].add_callback(callback)
                     logger.info(f"Wired record node {rec_id} to cloud output")
+
+            # Wire hardware sinks (Syphon/NDI/Spout). Each route tees frames
+            # from an existing cloud output handler into a local hardware
+            # sender. The handler index is computed by handle_offer_with_relay
+            # based on which webrtc sink shares the same upstream pipeline.
+            if self.frame_processor is not None and self._hardware_sink_routes:
+                fp = self.frame_processor
+                for handler_index, hw_node_id in self._hardware_sink_routes:
+                    if handler_index < 0 or handler_index >= len(
+                        webrtc_client.output_handlers
+                    ):
+                        logger.warning(
+                            f"Cannot wire hardware sink {hw_node_id!r}: cloud "
+                            f"output handler index {handler_index} out of range "
+                            f"(have {len(webrtc_client.output_handlers)})"
+                        )
+                        continue
+
+                    def _make_hw_cb(node_id: str) -> Callable:
+                        def _cb(frame) -> None:
+                            fp.sink_manager.put_to_sink(node_id, frame)
+
+                        return _cb
+
+                    webrtc_client.output_handlers[handler_index].add_callback(
+                        _make_hw_cb(hw_node_id)
+                    )
+                    logger.info(
+                        f"Wired hardware sink {hw_node_id!r} to cloud output "
+                        f"handler {handler_index}"
+                    )
 
         logger.info("Relay started")
 
@@ -402,6 +439,17 @@ class CloudTrack(MediaStreamTrack):
         VideoFrame and pushes it into the frame_processor's record queue.
         """
         self._record_callbacks = list(callbacks)
+
+    def set_hardware_sink_routes(self, routes: list[tuple[int, str]]) -> None:
+        """Register hardware sink routes from cloud output handlers.
+
+        Each entry is ``(handler_index, hardware_sink_node_id)``. After the
+        cloud relay starts, every frame received on
+        ``webrtc_client.output_handlers[handler_index]`` is teed into the
+        local SinkManager's queue for ``hardware_sink_node_id``, where a
+        per-node sender thread (Syphon/NDI/Spout) pushes it out.
+        """
+        self._hardware_sink_routes = list(routes)
 
     def get_stats(self) -> dict:
         """Get relay statistics."""

--- a/src/scope/server/cloud_track.py
+++ b/src/scope/server/cloud_track.py
@@ -95,13 +95,13 @@ class CloudTrack(MediaStreamTrack):
         self._pending_extra_sources: list[tuple[str, MediaStreamTrack]] = []
         self._extra_sink_tracks: list[CloudSinkOutputTrack] = []
         self._extra_input_handlers: list[CloudSourceInputHandler] = []
-        # Output taps: (output_handler_index, callback) pairs. Each entry
-        # registers an additional callback on the named cloud output handler
-        # so the same frame can be fanned out to record queues, local
-        # hardware sinks (Syphon/NDI/Spout), or any other consumer the
-        # offer-handler wires up. handle_offer_with_relay computes the
-        # handler indices from the graph structure.
-        self._output_taps: list[tuple[int, Callable]] = []
+        self._record_callbacks: list[tuple[str, Callable]] = []
+        # Hardware sink routes: (output_handler_index, hardware_sink_node_id).
+        # Each entry tees frames from the given cloud output handler into the
+        # named local hardware sink (Syphon/NDI/Spout) via SinkManager —
+        # parallel to record_callbacks but the destination is a local sender
+        # thread, not a recorder queue.
+        self._hardware_sink_routes: list[tuple[int, str]] = []
 
     def set_source_track(self, track: MediaStreamTrack) -> None:
         """Set the source track for input frames (from browser)."""
@@ -187,17 +187,43 @@ class CloudTrack(MediaStreamTrack):
                     )
                     logger.info(f"Wired extra sink track {i} to cloud output")
 
-            # Wire output taps: callbacks registered against specific cloud
-            # output handler indices. Used for record nodes and local
-            # hardware sinks (Syphon/NDI/Spout).
-            for handler_index, callback in self._output_taps:
-                if 0 <= handler_index < len(webrtc_client.output_handlers):
+            # Wire record node output callbacks (placed after sink tracks)
+            num_extra_sinks = len(self._extra_sink_tracks)
+            for i, (rec_id, callback) in enumerate(self._record_callbacks):
+                handler_index = num_extra_sinks + 1 + i
+                if handler_index < len(webrtc_client.output_handlers):
                     webrtc_client.output_handlers[handler_index].add_callback(callback)
-                else:
-                    logger.warning(
-                        f"Output tap on cloud handler {handler_index} skipped: "
-                        f"out of range (have {len(webrtc_client.output_handlers)})"
-                    )
+                    logger.info(f"Wired record node {rec_id} to cloud output")
+
+            # Wire hardware sinks (Syphon/NDI/Spout). Each route tees frames
+            # from an existing cloud output handler into a local hardware
+            # sender via SinkManager.put_to_sink. handle_offer_with_relay
+            # computes the handler index from the graph structure (the buddy
+            # webrtc sink that shares the same upstream pipeline).
+            if self.frame_processor is not None and self._hardware_sink_routes:
+                fp = self.frame_processor
+                for handler_index, hw_node_id in self._hardware_sink_routes:
+                    if 0 <= handler_index < len(webrtc_client.output_handlers):
+
+                        def _make_hw_cb(node_id: str) -> Callable:
+                            def _cb(frame) -> None:
+                                fp.sink_manager.put_to_sink(node_id, frame)
+
+                            return _cb
+
+                        webrtc_client.output_handlers[handler_index].add_callback(
+                            _make_hw_cb(hw_node_id)
+                        )
+                        logger.info(
+                            f"Wired hardware sink {hw_node_id!r} to cloud output "
+                            f"handler {handler_index}"
+                        )
+                    else:
+                        logger.warning(
+                            f"Hardware sink {hw_node_id!r} on cloud handler "
+                            f"{handler_index} skipped: out of range "
+                            f"(have {len(webrtc_client.output_handlers)})"
+                        )
 
         logger.info("Relay started")
 
@@ -326,7 +352,8 @@ class CloudTrack(MediaStreamTrack):
             await handler.stop()
         self._extra_input_handlers.clear()
         self._extra_sink_tracks.clear()
-        self._output_taps.clear()
+        self._record_callbacks.clear()
+        self._hardware_sink_routes.clear()
         self._pending_extra_sources.clear()
 
         if self._input_task:
@@ -405,17 +432,24 @@ class CloudTrack(MediaStreamTrack):
         """Register extra sink output tracks that need cloud callbacks."""
         self._extra_sink_tracks = list(tracks)
 
-    def set_output_taps(self, taps: list[tuple[int, Callable]]) -> None:
-        """Register fan-out callbacks on cloud output handlers.
+    def set_record_callbacks(self, callbacks: list[tuple[str, Callable]]) -> None:
+        """Register callbacks for record node outputs from cloud.
 
-        Each entry is ``(handler_index, callback)``. Once the cloud relay
-        starts, every frame received on
-        ``webrtc_client.output_handlers[handler_index]`` is also delivered
-        to ``callback`` (in addition to whatever else is wired to that
-        handler). Used to feed record-node queues and local hardware sinks
-        from cloud-produced frames.
+        Each entry is (record_node_id, callback) where callback receives a
+        VideoFrame and pushes it into the frame_processor's record queue.
         """
-        self._output_taps = list(taps)
+        self._record_callbacks = list(callbacks)
+
+    def set_hardware_sink_routes(self, routes: list[tuple[int, str]]) -> None:
+        """Register hardware sink routes from cloud output handlers.
+
+        Each entry is ``(handler_index, hardware_sink_node_id)``. After the
+        cloud relay starts, every frame received on
+        ``webrtc_client.output_handlers[handler_index]`` is teed into the
+        local SinkManager's queue for ``hardware_sink_node_id``, where a
+        per-node sender thread (Syphon/NDI/Spout) pushes it out.
+        """
+        self._hardware_sink_routes = list(routes)
 
     def get_stats(self) -> dict:
         """Get relay statistics."""

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -228,12 +228,9 @@ class FrameProcessor:
                 # Hardware sinks (Syphon/NDI/Spout) always run on the local
                 # machine even when the pipeline executes on cloud. The cloud
                 # relay tees its received frames into these local senders.
-                # Use the pipeline-provided dimensions if available; the
-                # SyphonSender (and others) auto-resize on first frame so a
-                # placeholder is safe.
-                self.sink_manager.setup_cloud_hardware_sinks(
-                    graph, self._get_cloud_sink_dimensions()
-                )
+                # The dimensions are a placeholder — SyphonSender (and other
+                # hardware senders) auto-resize when the first frame arrives.
+                self.sink_manager.setup_cloud_hardware_sinks(graph, (512, 512))
 
             logger.info("[FRAME-PROCESSOR] Started in cloud mode")
 
@@ -895,22 +892,6 @@ class FrameProcessor:
             return width, height
         except Exception as e:
             logger.warning(f"Could not get pipeline dimensions: {e}")
-            return 512, 512
-
-    def _get_cloud_sink_dimensions(self) -> tuple[int, int]:
-        """Initial dimensions for hardware sinks created in cloud mode.
-
-        In cloud mode there is no local ``pipeline_manager`` so we fall back
-        to ``width``/``height`` from initial parameters if present, otherwise
-        a safe default. SyphonSender (and other hardware senders) auto-resize
-        on first frame, so the placeholder doesn't have to match cloud output.
-        """
-        params = self.parameters or {}
-        width = params.get("width") or 512
-        height = params.get("height") or 512
-        try:
-            return int(width), int(height)
-        except (TypeError, ValueError):
             return 512, 512
 
     def schedule_quantized_update(self, params: dict):

--- a/src/scope/server/frame_processor.py
+++ b/src/scope/server/frame_processor.py
@@ -225,6 +225,15 @@ class FrameProcessor:
                 graph = GraphConfig(**graph_data)
                 self._source_manager.setup_multi_sources(graph)
                 self.sink_manager.setup_cloud_graph(graph)
+                # Hardware sinks (Syphon/NDI/Spout) always run on the local
+                # machine even when the pipeline executes on cloud. The cloud
+                # relay tees its received frames into these local senders.
+                # Use the pipeline-provided dimensions if available; the
+                # SyphonSender (and others) auto-resize on first frame so a
+                # placeholder is safe.
+                self.sink_manager.setup_cloud_hardware_sinks(
+                    graph, self._get_cloud_sink_dimensions()
+                )
 
             logger.info("[FRAME-PROCESSOR] Started in cloud mode")
 
@@ -886,6 +895,22 @@ class FrameProcessor:
             return width, height
         except Exception as e:
             logger.warning(f"Could not get pipeline dimensions: {e}")
+            return 512, 512
+
+    def _get_cloud_sink_dimensions(self) -> tuple[int, int]:
+        """Initial dimensions for hardware sinks created in cloud mode.
+
+        In cloud mode there is no local ``pipeline_manager`` so we fall back
+        to ``width``/``height`` from initial parameters if present, otherwise
+        a safe default. SyphonSender (and other hardware senders) auto-resize
+        on first frame, so the placeholder doesn't have to match cloud output.
+        """
+        params = self.parameters or {}
+        width = params.get("width") or 512
+        height = params.get("height") or 512
+        try:
+            return int(width), int(height)
+        except (TypeError, ValueError):
             return 512, 512
 
     def schedule_quantized_update(self, params: dict):

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -421,22 +421,41 @@ class LivepeerClient:
         initial_parameters: dict[str, Any] | None,
         parsed: _BrowserGraphInfo,
     ) -> dict[str, Any]:
-        """Deep-copy params and drop sink-attached record nodes.
+        """Deep-copy params, drop sink-teed records and hardware sinks.
 
-        The runner creates a dedicated output for every record node it sees, so
-        removing sink-attached records avoids redundant remote outputs whose
-        frames are identical to the parent sink.
+        Two transformations are applied:
+        - Sink-attached record nodes are removed: the runner creates a
+          dedicated output for every record node, but sink-teed records are
+          mirrored locally from their parent sink so the remote duplicate
+          would be wasteful.
+        - Hardware sink nodes (Syphon/NDI/Spout) are removed: these always
+          run on the local machine, where the cloud relay tees frames into
+          them from the corresponding webrtc sink. Sending them to the
+          runner would only produce noisy "syphon-python not available"
+          errors on the Linux GPU host.
         """
         if not initial_parameters:
             return {}
-        if not parsed.sink_teed_records:
-            return copy.deepcopy(initial_parameters)
-        collapsed = {rid for rid, _ in parsed.sink_teed_records}
         params = copy.deepcopy(initial_parameters)
         graph = params.get("graph")
         if not isinstance(graph, dict):
             return params
+
+        collapsed = {rid for rid, _ in parsed.sink_teed_records}
         nodes = graph.get("nodes")
+        if isinstance(nodes, list):
+            for n in nodes:
+                if not isinstance(n, dict):
+                    continue
+                if n.get("type") == "sink" and n.get("sink_mode") in (
+                    "spout",
+                    "ndi",
+                    "syphon",
+                ):
+                    collapsed.add(n.get("id"))
+        if not collapsed:
+            return params
+
         if isinstance(nodes, list):
             graph["nodes"] = [
                 n for n in nodes if isinstance(n, dict) and n.get("id") not in collapsed
@@ -449,6 +468,7 @@ class LivepeerClient:
                 if isinstance(e, dict)
                 and e.get("to_node") not in collapsed
                 and e.get("from") not in collapsed
+                and e.get("from_node") not in collapsed
             ]
         return params
 

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -30,6 +30,7 @@ from livepeer_gateway.media_publish import (
 )
 from livepeer_gateway.scope import StartJobRequest, start_scope
 
+from scope.core.outputs import HARDWARE_SINK_MODES
 from scope.core.pacing import (
     MediaPacingDecision,
     MediaPacingState,
@@ -371,7 +372,7 @@ class LivepeerClient:
                 src_count += 1
             elif node_type == "sink":
                 sink_mode = node.get("sink_mode")
-                if sink_mode not in ("spout", "ndi", "syphon"):
+                if sink_mode not in HARDWARE_SINK_MODES:
                     sink_node_ids.append(node_id)
             elif node_type == "record":
                 record_node_ids.append(node_id)
@@ -447,10 +448,9 @@ class LivepeerClient:
             for n in nodes:
                 if not isinstance(n, dict):
                     continue
-                if n.get("type") == "sink" and n.get("sink_mode") in (
-                    "spout",
-                    "ndi",
-                    "syphon",
+                if (
+                    n.get("type") == "sink"
+                    and n.get("sink_mode") in HARDWARE_SINK_MODES
                 ):
                     collapsed.add(n.get("id"))
         if not collapsed:

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -403,21 +403,7 @@ class LivepeerClient:
                         (rec_id, sink_node_ids.index(inbound_from))
                     )
                 else:
-                    # Record reads from a hardware sink (Syphon/NDI/Spout).
-                    # In cloud mode the hardware sink is stripped from the
-                    # runner graph, so a remote output for this record would
-                    # never receive frames. Warn and still register it as a
-                    # remote record so handler-index alignment in
-                    # _build_cloud_output_taps stays correct — the user will
-                    # see the warning and re-wire the record from the
-                    # buddy webrtc sink or directly from the pipeline.
-                    logger.warning(
-                        f"Record node {rec_id!r} reads from hardware sink "
-                        f"{inbound_from!r}; in cloud mode the hardware sink "
-                        "is local-only, so this record will receive no "
-                        "frames. Rewire the record from a WebRTC sink or "
-                        "from the upstream pipeline."
-                    )
+                    # Hardware sink excluded from WebRTC sink list — needs remote output.
                     remote_record_node_ids.append(rec_id)
             else:
                 remote_record_node_ids.append(rec_id)

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -403,7 +403,21 @@ class LivepeerClient:
                         (rec_id, sink_node_ids.index(inbound_from))
                     )
                 else:
-                    # Hardware sink excluded from WebRTC sink list — needs remote output.
+                    # Record reads from a hardware sink (Syphon/NDI/Spout).
+                    # In cloud mode the hardware sink is stripped from the
+                    # runner graph, so a remote output for this record would
+                    # never receive frames. Warn and still register it as a
+                    # remote record so handler-index alignment in
+                    # _build_cloud_output_taps stays correct — the user will
+                    # see the warning and re-wire the record from the
+                    # buddy webrtc sink or directly from the pipeline.
+                    logger.warning(
+                        f"Record node {rec_id!r} reads from hardware sink "
+                        f"{inbound_from!r}; in cloud mode the hardware sink "
+                        "is local-only, so this record will receive no "
+                        "frames. Rewire the record from a WebRTC sink or "
+                        "from the upstream pipeline."
+                    )
                     remote_record_node_ids.append(rec_id)
             else:
                 remote_record_node_ids.append(rec_id)

--- a/src/scope/server/sink_manager.py
+++ b/src/scope/server/sink_manager.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import torch
 
+from scope.core.outputs import HARDWARE_SINK_MODES
+
 from .media_packets import MediaTimestamp, VideoPacket, ensure_video_packet
 from .recording_coordinator import RecordingCoordinator
 
@@ -340,7 +342,7 @@ class SinkManager:
         for node in graph.nodes:
             if node.type != "sink":
                 continue
-            if node.sink_mode not in ("spout", "ndi", "syphon"):
+            if node.sink_mode not in HARDWARE_SINK_MODES:
                 continue
             sink_name = node.sink_name or ""
             node_id = node.id
@@ -530,7 +532,7 @@ class SinkManager:
         for node in graph.nodes:
             if node.type != "sink":
                 continue
-            if node.sink_mode not in ("spout", "ndi", "syphon"):
+            if node.sink_mode not in HARDWARE_SINK_MODES:
                 continue
             if node.id in self._sink_hardware_queues_by_node:
                 continue

--- a/src/scope/server/sink_manager.py
+++ b/src/scope/server/sink_manager.py
@@ -345,7 +345,10 @@ class SinkManager:
             sink_name = node.sink_name or ""
             node_id = node.id
 
-            if node_id not in self._sink_queues_by_node:
+            if (
+                node_id not in self._sink_queues_by_node
+                and node_id not in self._sink_hardware_queues_by_node
+            ):
                 continue
 
             sink_class = sink_classes.get(node.sink_mode)
@@ -440,7 +443,22 @@ class SinkManager:
     def put_to_record(self, node_id: str, frame) -> None:
         """Convert a VideoFrame to tensor and put it into a record node's queue."""
         rec_q = self._recording._record_queues.get(node_id)
-        if rec_q is None:
+        self._enqueue_video_frame(rec_q, frame, node_id=node_id, kind="record")
+
+    @staticmethod
+    def _enqueue_video_frame(
+        target_queue: "queue.Queue | None",
+        frame,
+        *,
+        node_id: str,
+        kind: str,
+    ) -> None:
+        """Convert *frame* (VideoFrame) to a VideoPacket and enqueue it.
+
+        Drops the oldest packet if the queue is full. Used by both record
+        and hardware-sink fan-out paths.
+        """
+        if target_queue is None:
             return
         try:
             frame_np = frame.to_ndarray(format="rgb24")
@@ -456,15 +474,15 @@ class SinkManager:
                 )
             packet = VideoPacket(tensor=t, timestamp=timestamp)
             try:
-                rec_q.put_nowait(packet)
+                target_queue.put_nowait(packet)
             except queue.Full:
                 try:
-                    rec_q.get_nowait()
-                    rec_q.put_nowait(packet)
+                    target_queue.get_nowait()
+                    target_queue.put_nowait(packet)
                 except queue.Empty:
                     pass
         except Exception as e:
-            logger.error(f"Error in put_to_record for node {node_id}: {e}")
+            logger.error(f"Error enqueueing {kind} frame for node {node_id}: {e}")
 
     @property
     def recording(self) -> RecordingCoordinator:
@@ -513,11 +531,7 @@ class SinkManager:
                 continue
             if node.id in self._sink_hardware_queues_by_node:
                 continue
-            hw_queue: queue.Queue = queue.Queue(maxsize=30)
-            self._sink_hardware_queues_by_node[node.id] = hw_queue
-            # Populate sink_queues_by_node too so setup_multi_sinks' presence
-            # check passes (it gates sender creation on a queue being present).
-            self._sink_queues_by_node.setdefault(node.id, hw_queue)
+            self._sink_hardware_queues_by_node[node.id] = queue.Queue(maxsize=30)
 
         self.setup_multi_sinks(graph, dimensions)
 
@@ -529,31 +543,7 @@ class SinkManager:
         tees frames into record-node queues.
         """
         sink_q = self._sink_hardware_queues_by_node.get(node_id)
-        if sink_q is None:
-            return
-        try:
-            frame_np = frame.to_ndarray(format="rgb24")
-            t = torch.as_tensor(frame_np, dtype=torch.uint8).unsqueeze(0)
-            timestamp = MediaTimestamp()
-            if (
-                getattr(frame, "pts", None) is not None
-                and getattr(frame, "time_base", None) is not None
-            ):
-                timestamp = MediaTimestamp(
-                    pts=frame.pts,
-                    time_base=Fraction(frame.time_base),
-                )
-            packet = VideoPacket(tensor=t, timestamp=timestamp)
-            try:
-                sink_q.put_nowait(packet)
-            except queue.Full:
-                try:
-                    sink_q.get_nowait()
-                    sink_q.put_nowait(packet)
-                except queue.Empty:
-                    pass
-        except Exception as e:
-            logger.error(f"Error in put_to_sink for node {node_id}: {e}")
+        self._enqueue_video_frame(sink_q, frame, node_id=node_id, kind="hardware sink")
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/scope/server/sink_manager.py
+++ b/src/scope/server/sink_manager.py
@@ -351,6 +351,9 @@ class SinkManager:
             ):
                 continue
 
+            if node_id in self._sinks_by_node:
+                continue
+
             sink_class = sink_classes.get(node.sink_mode)
             if sink_class is None:
                 logger.warning(
@@ -572,6 +575,7 @@ class SinkManager:
             except Exception as e:
                 logger.error(f"Error closing output sink for node {node_id}: {e}")
         self._sinks_by_node.clear()
+        self._sink_hardware_queues_by_node.clear()
 
         # Recording
         self._recording.cleanup()

--- a/src/scope/server/sink_manager.py
+++ b/src/scope/server/sink_manager.py
@@ -487,6 +487,74 @@ class SinkManager:
         if record_node_ids:
             self._recording.setup_queues(record_node_ids)
 
+    def setup_cloud_hardware_sinks(
+        self, graph: Any, dimensions: tuple[int, int]
+    ) -> None:
+        """Set up local hardware output sinks (Syphon/NDI/Spout) in cloud mode.
+
+        Hardware sinks always run on the local machine (Syphon is macOS-only,
+        NDI/Spout require local network/hardware access) even when pipeline
+        execution is offloaded to the cloud. This method allocates the
+        per-node hardware queues and sender threads that ``put_to_sink``
+        feeds from frames received from the cloud relay.
+
+        In local mode the queues are wired by ``graph_executor`` via
+        ``setup_graph_queues``; this is the cloud-mode equivalent.
+        """
+        from .graph_schema import GraphConfig
+
+        if not isinstance(graph, GraphConfig):
+            return
+
+        for node in graph.nodes:
+            if node.type != "sink":
+                continue
+            if node.sink_mode not in ("spout", "ndi", "syphon"):
+                continue
+            if node.id in self._sink_hardware_queues_by_node:
+                continue
+            hw_queue: queue.Queue = queue.Queue(maxsize=30)
+            self._sink_hardware_queues_by_node[node.id] = hw_queue
+            # Populate sink_queues_by_node too so setup_multi_sinks' presence
+            # check passes (it gates sender creation on a queue being present).
+            self._sink_queues_by_node.setdefault(node.id, hw_queue)
+
+        self.setup_multi_sinks(graph, dimensions)
+
+    def put_to_sink(self, node_id: str, frame) -> None:
+        """Push a VideoFrame into a hardware sink's queue (cloud relay path).
+
+        Used by the cloud-relay wiring to tee cloud-produced frames into a
+        local Syphon/NDI/Spout sender, mirroring how ``put_to_record``
+        tees frames into record-node queues.
+        """
+        sink_q = self._sink_hardware_queues_by_node.get(node_id)
+        if sink_q is None:
+            return
+        try:
+            frame_np = frame.to_ndarray(format="rgb24")
+            t = torch.as_tensor(frame_np, dtype=torch.uint8).unsqueeze(0)
+            timestamp = MediaTimestamp()
+            if (
+                getattr(frame, "pts", None) is not None
+                and getattr(frame, "time_base", None) is not None
+            ):
+                timestamp = MediaTimestamp(
+                    pts=frame.pts,
+                    time_base=Fraction(frame.time_base),
+                )
+            packet = VideoPacket(tensor=t, timestamp=timestamp)
+            try:
+                sink_q.put_nowait(packet)
+            except queue.Full:
+                try:
+                    sink_q.get_nowait()
+                    sink_q.put_nowait(packet)
+                except queue.Empty:
+                    pass
+        except Exception as e:
+            logger.error(f"Error in put_to_sink for node {node_id}: {e}")
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -142,25 +142,32 @@ def _parse_graph_node_ids(
     )
 
 
-def _compute_hardware_sink_routes(
+def _build_cloud_output_taps(
+    *,
     initial_parameters: dict,
     all_sink_node_ids: list[str],
-) -> list[tuple[int, str]]:
-    """Map each hardware sink to the cloud output handler that should feed it.
+    record_node_ids: list[str],
+    frame_processor: "FrameProcessor | None",
+) -> list[tuple[int, Callable]]:
+    """Build the list of ``(handler_index, callback)`` taps for cloud relay.
 
-    Cloud-relay mode strips hardware sinks (Syphon/NDI/Spout) from the graph
-    before sending it to the cloud runner, so the runner produces output
-    tracks only for webrtc sinks. Each hardware sink is teed from the cloud
-    output handler of the webrtc sink that shares its upstream pipeline node,
-    so the local sender receives the same frames the browser sees.
+    Two consumers fan out off cloud output handlers:
 
-    Returns a list of ``(handler_index, hardware_sink_node_id)`` pairs.
-    ``handler_index`` is the index into ``webrtc_client.output_handlers``:
-    0 is the primary CloudTrack output, 1+ are extra-sink tracks.
+    1. Record nodes — handler indices come after the webrtc sinks
+       (primary + extras), so handler N = num_webrtc_sinks + record_pos.
+    2. Hardware sinks (Syphon/NDI/Spout) — handler N = the cloud output
+       handler of the webrtc sink that shares this sink's upstream
+       pipeline, so the local sender mirrors what the browser sees.
 
-    If a hardware sink has no buddy webrtc sink with the same upstream, falls
-    back to handler 0 (the primary) and logs a warning.
+    Hardware sinks are stripped from the graph before it reaches the
+    cloud runner, so the runner only allocates output handlers for
+    webrtc sinks and remote record nodes. Orphan hardware sinks (no
+    buddy webrtc sink on the same pipeline) are dropped with a warning
+    rather than silently mis-routed.
     """
+    if frame_processor is None:
+        return []
+
     graph_data = initial_parameters.get("graph")
     if not isinstance(graph_data, dict):
         return []
@@ -173,29 +180,23 @@ def _compute_hardware_sink_routes(
         if isinstance(n, dict) and n.get("type") == "sink":
             sink_modes[n.get("id")] = n.get("sink_mode")
 
-    hardware_sink_ids = [
-        sid
-        for sid in all_sink_node_ids
-        if sink_modes.get(sid) in ("spout", "ndi", "syphon")
-    ]
-    if not hardware_sink_ids:
-        return []
-
     webrtc_sink_ids = [
         sid
         for sid in all_sink_node_ids
         if sink_modes.get(sid) not in ("spout", "ndi", "syphon")
     ]
+    hardware_sink_ids = [
+        sid
+        for sid in all_sink_node_ids
+        if sink_modes.get(sid) in ("spout", "ndi", "syphon")
+    ]
 
     def _upstream_of(sink_id: str) -> str | None:
         for e in edges:
-            if not isinstance(e, dict):
+            if not isinstance(e, dict) or e.get("kind") != "stream":
                 continue
-            if e.get("kind") != "stream":
-                continue
-            if e.get("to_node") != sink_id:
-                continue
-            return e.get("from_node") or e.get("from")
+            if e.get("to_node") == sink_id:
+                return e.get("from_node") or e.get("from")
         return None
 
     upstream_to_handler: dict[str, int] = {}
@@ -204,27 +205,51 @@ def _compute_hardware_sink_routes(
         if up and up not in upstream_to_handler:
             upstream_to_handler[up] = idx
 
-    routes: list[tuple[int, str]] = []
+    fp = frame_processor
+    taps: list[tuple[int, Callable]] = []
+
+    # Hardware sinks: handler N = buddy webrtc sink's index.
     for hw_id in hardware_sink_ids:
         up = _upstream_of(hw_id)
         handler_index = upstream_to_handler.get(up) if up else None
         if handler_index is None:
-            if webrtc_sink_ids:
-                logger.warning(
-                    f"Hardware sink {hw_id!r} has no webrtc sink sharing its "
-                    f"upstream pipeline {up!r}; falling back to primary "
-                    "cloud output (frames may not match expected pipeline)"
-                )
-                handler_index = 0
-            else:
-                logger.warning(
-                    f"Hardware sink {hw_id!r} cannot be wired: no webrtc sink "
-                    "exists in this graph to provide cloud frames"
-                )
-                continue
-        routes.append((handler_index, hw_id))
+            # Silently routing to handler 0 would deliver wrong-pipeline
+            # frames to Syphon — worse than no output. Skip and warn so
+            # the user notices.
+            logger.warning(
+                f"Hardware sink {hw_id!r} not wired: no webrtc sink shares "
+                f"its upstream pipeline {up!r}. The sink will receive no "
+                "frames; add a webrtc sink fed from the same pipeline to "
+                "enable it in cloud mode."
+            )
+            continue
+        taps.append((handler_index, _make_put_to_sink_cb(fp, hw_id)))
 
-    return routes
+    # Record nodes: placed after webrtc sinks in the cloud output mapping.
+    num_webrtc_sinks = len(webrtc_sink_ids)
+    for rec_pos, rec_id in enumerate(record_node_ids):
+        taps.append(
+            (
+                num_webrtc_sinks + rec_pos,
+                _make_put_to_record_cb(fp, rec_id),
+            )
+        )
+
+    return taps
+
+
+def _make_put_to_record_cb(frame_processor: "FrameProcessor", node_id: str) -> Callable:
+    def _cb(frame) -> None:
+        frame_processor.sink_manager.put_to_record(node_id, frame)
+
+    return _cb
+
+
+def _make_put_to_sink_cb(frame_processor: "FrameProcessor", node_id: str) -> Callable:
+    def _cb(frame) -> None:
+        frame_processor.sink_manager.put_to_sink(node_id, frame)
+
+    return _cb
 
 
 class Session:
@@ -1211,45 +1236,24 @@ class WebRTCManager:
                 # Tell CloudTrack to wire these after cloud connection starts
                 cloud_track.set_extra_sink_tracks(extra_sink_tracks)
 
-            # Set up record node callbacks so cloud record frames are
-            # received locally and fed into frame_processor record queues.
-            # Record tracks are NOT relayed to the browser — they stay
-            # server-side for local recording.
-            if record_node_ids and cloud_track is not None:
-                record_callbacks: list[tuple[str, Callable]] = []
-                for rec_id in record_node_ids:
-
-                    def _make_record_cb(node_id: str, fp: FrameProcessor) -> Callable:
-                        def _cb(frame) -> None:
-                            fp.sink_manager.put_to_record(node_id, frame)
-
-                        return _cb
-
-                    record_callbacks.append(
-                        (rec_id, _make_record_cb(rec_id, frame_processor))
-                    )
-                cloud_track.set_record_callbacks(record_callbacks)
-                logger.info(
-                    f"Cloud relay: registered {len(record_callbacks)} "
-                    f"record callback(s)"
-                )
-
-            # Set up hardware sink (Syphon/NDI/Spout) routes. Hardware sinks
-            # always run on the local machine; the cloud relay strips them
-            # from the graph before sending to the runner. Tee frames from
-            # the cloud output handler of a webrtc sink that shares the same
-            # upstream pipeline into the local sender's queue, so Syphon
-            # receives the same frames the browser sees.
+            # Build cloud-output-handler taps: extra fan-out callbacks the
+            # cloud relay should invoke when frames arrive on a given
+            # handler index. Two consumers today:
+            # - record nodes: handler N = num_extra_sinks + 1 + record_pos
+            #   (placed after primary + extra webrtc sinks)
+            # - hardware sinks (Syphon/NDI/Spout): handler N = the cloud
+            #   output handler of the webrtc sink that shares this sink's
+            #   upstream pipeline (so Syphon mirrors what the browser sees)
             if cloud_track is not None:
-                hardware_sink_routes = _compute_hardware_sink_routes(
-                    initial_parameters, sink_node_ids
+                taps = _build_cloud_output_taps(
+                    initial_parameters=initial_parameters,
+                    all_sink_node_ids=sink_node_ids,
+                    record_node_ids=record_node_ids,
+                    frame_processor=frame_processor,
                 )
-                if hardware_sink_routes:
-                    cloud_track.set_hardware_sink_routes(hardware_sink_routes)
-                    logger.info(
-                        f"Cloud relay: registered {len(hardware_sink_routes)} "
-                        f"hardware sink route(s)"
-                    )
+                if taps:
+                    cloud_track.set_output_taps(taps)
+                    logger.info(f"Cloud relay: registered {len(taps)} output tap(s)")
 
             # Create answer
             answer = await pc.createAnswer()

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -22,6 +22,7 @@ from aiortc.contrib.media import MediaRelay
 from aiortc.sdp import candidate_from_sdp
 
 from scope.core.nodes.registry import NodeRegistry
+from scope.core.outputs import HARDWARE_SINK_MODES
 
 from .audio_track import AudioProcessingTrack
 from .cloud_track import CloudTrack
@@ -121,7 +122,7 @@ def _parse_graph_node_ids(
             if node.get("type") == "sink":
                 all_sink_node_ids.append(node["id"])
                 sm = node.get("sink_mode")
-                if sm not in ("spout", "ndi", "syphon"):
+                if sm not in HARDWARE_SINK_MODES:
                     webrtc_sink_node_ids.append(node["id"])
             elif node.get("type") == "source":
                 all_source_node_ids.append(node["id"])
@@ -183,12 +184,10 @@ def _build_cloud_output_taps(
     webrtc_sink_ids = [
         sid
         for sid in all_sink_node_ids
-        if sink_modes.get(sid) not in ("spout", "ndi", "syphon")
+        if sink_modes.get(sid) not in HARDWARE_SINK_MODES
     ]
     hardware_sink_ids = [
-        sid
-        for sid in all_sink_node_ids
-        if sink_modes.get(sid) in ("spout", "ndi", "syphon")
+        sid for sid in all_sink_node_ids if sink_modes.get(sid) in HARDWARE_SINK_MODES
     ]
 
     def _upstream_of(sink_id: str) -> str | None:
@@ -1213,7 +1212,7 @@ class WebRTCManager:
                     f"transceivers for {len(sink_node_ids) - 1} extra sink(s)"
                 )
                 for i, sink_id in enumerate(sink_node_ids[1:]):
-                    if hw_sink_modes.get(sink_id) in ("spout", "ndi", "syphon"):
+                    if hw_sink_modes.get(sink_id) in HARDWARE_SINK_MODES:
                         logger.info(
                             f"Cloud relay: skipping browser delivery for "
                             f"hardware sink {sink_id!r} (handled locally)"

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -143,32 +143,26 @@ def _parse_graph_node_ids(
     )
 
 
-def _build_cloud_output_taps(
-    *,
+def _compute_hardware_sink_routes(
     initial_parameters: dict,
     all_sink_node_ids: list[str],
-    record_node_ids: list[str],
-    frame_processor: "FrameProcessor | None",
-) -> list[tuple[int, Callable]]:
-    """Build the list of ``(handler_index, callback)`` taps for cloud relay.
+) -> list[tuple[int, str]]:
+    """Map each hardware sink to the cloud output handler that should feed it.
 
-    Two consumers fan out off cloud output handlers:
+    Cloud-relay mode strips hardware sinks (Syphon/NDI/Spout) from the graph
+    before sending it to the cloud runner, so the runner produces output
+    tracks only for webrtc sinks. Each hardware sink is teed from the cloud
+    output handler of the webrtc sink that shares its upstream pipeline node,
+    so the local sender receives the same frames the browser sees.
 
-    1. Record nodes — handler indices come after the webrtc sinks
-       (primary + extras), so handler N = num_webrtc_sinks + record_pos.
-    2. Hardware sinks (Syphon/NDI/Spout) — handler N = the cloud output
-       handler of the webrtc sink that shares this sink's upstream
-       pipeline, so the local sender mirrors what the browser sees.
+    Returns a list of ``(handler_index, hardware_sink_node_id)`` pairs.
+    ``handler_index`` is the index into ``webrtc_client.output_handlers``:
+    0 is the primary CloudTrack output, 1+ are extra-sink tracks.
 
-    Hardware sinks are stripped from the graph before it reaches the
-    cloud runner, so the runner only allocates output handlers for
-    webrtc sinks and remote record nodes. Orphan hardware sinks (no
-    buddy webrtc sink on the same pipeline) are dropped with a warning
-    rather than silently mis-routed.
+    Orphan hardware sinks (no webrtc sink shares the upstream pipeline) are
+    dropped with a warning rather than silently mis-routed to handler 0 —
+    delivering some other pipeline's frames would be worse than no output.
     """
-    if frame_processor is None:
-        return []
-
     graph_data = initial_parameters.get("graph")
     if not isinstance(graph_data, dict):
         return []
@@ -189,6 +183,8 @@ def _build_cloud_output_taps(
     hardware_sink_ids = [
         sid for sid in all_sink_node_ids if sink_modes.get(sid) in HARDWARE_SINK_MODES
     ]
+    if not hardware_sink_ids:
+        return []
 
     def _upstream_of(sink_id: str) -> str | None:
         for e in edges:
@@ -204,17 +200,11 @@ def _build_cloud_output_taps(
         if up and up not in upstream_to_handler:
             upstream_to_handler[up] = idx
 
-    fp = frame_processor
-    taps: list[tuple[int, Callable]] = []
-
-    # Hardware sinks: handler N = buddy webrtc sink's index.
+    routes: list[tuple[int, str]] = []
     for hw_id in hardware_sink_ids:
         up = _upstream_of(hw_id)
         handler_index = upstream_to_handler.get(up) if up else None
         if handler_index is None:
-            # Silently routing to handler 0 would deliver wrong-pipeline
-            # frames to Syphon — worse than no output. Skip and warn so
-            # the user notices.
             logger.warning(
                 f"Hardware sink {hw_id!r} not wired: no webrtc sink shares "
                 f"its upstream pipeline {up!r}. The sink will receive no "
@@ -222,33 +212,9 @@ def _build_cloud_output_taps(
                 "enable it in cloud mode."
             )
             continue
-        taps.append((handler_index, _make_put_to_sink_cb(fp, hw_id)))
+        routes.append((handler_index, hw_id))
 
-    # Record nodes: placed after webrtc sinks in the cloud output mapping.
-    num_webrtc_sinks = len(webrtc_sink_ids)
-    for rec_pos, rec_id in enumerate(record_node_ids):
-        taps.append(
-            (
-                num_webrtc_sinks + rec_pos,
-                _make_put_to_record_cb(fp, rec_id),
-            )
-        )
-
-    return taps
-
-
-def _make_put_to_record_cb(frame_processor: "FrameProcessor", node_id: str) -> Callable:
-    def _cb(frame) -> None:
-        frame_processor.sink_manager.put_to_record(node_id, frame)
-
-    return _cb
-
-
-def _make_put_to_sink_cb(frame_processor: "FrameProcessor", node_id: str) -> Callable:
-    def _cb(frame) -> None:
-        frame_processor.sink_manager.put_to_sink(node_id, frame)
-
-    return _cb
+    return routes
 
 
 class Session:
@@ -1235,24 +1201,42 @@ class WebRTCManager:
                 # Tell CloudTrack to wire these after cloud connection starts
                 cloud_track.set_extra_sink_tracks(extra_sink_tracks)
 
-            # Build cloud-output-handler taps: extra fan-out callbacks the
-            # cloud relay should invoke when frames arrive on a given
-            # handler index. Two consumers today:
-            # - record nodes: handler N = num_extra_sinks + 1 + record_pos
-            #   (placed after primary + extra webrtc sinks)
-            # - hardware sinks (Syphon/NDI/Spout): handler N = the cloud
-            #   output handler of the webrtc sink that shares this sink's
-            #   upstream pipeline (so Syphon mirrors what the browser sees)
-            if cloud_track is not None:
-                taps = _build_cloud_output_taps(
-                    initial_parameters=initial_parameters,
-                    all_sink_node_ids=sink_node_ids,
-                    record_node_ids=record_node_ids,
-                    frame_processor=frame_processor,
+            # Set up record node callbacks so cloud record frames are
+            # received locally and fed into frame_processor record queues.
+            # Record tracks are NOT relayed to the browser — they stay
+            # server-side for local recording.
+            if record_node_ids and cloud_track is not None:
+                record_callbacks: list[tuple[str, Callable]] = []
+                for rec_id in record_node_ids:
+
+                    def _make_record_cb(node_id: str, fp: FrameProcessor) -> Callable:
+                        def _cb(frame) -> None:
+                            fp.sink_manager.put_to_record(node_id, frame)
+
+                        return _cb
+
+                    record_callbacks.append(
+                        (rec_id, _make_record_cb(rec_id, frame_processor))
+                    )
+                cloud_track.set_record_callbacks(record_callbacks)
+                logger.info(
+                    f"Cloud relay: registered {len(record_callbacks)} "
+                    f"record callback(s)"
                 )
-                if taps:
-                    cloud_track.set_output_taps(taps)
-                    logger.info(f"Cloud relay: registered {len(taps)} output tap(s)")
+
+            # Wire hardware sinks (Syphon/NDI/Spout) — always run locally,
+            # stripped from the cloud graph, fed by teeing the buddy webrtc
+            # sink's cloud output handler into the local sender.
+            if cloud_track is not None:
+                hardware_sink_routes = _compute_hardware_sink_routes(
+                    initial_parameters, sink_node_ids
+                )
+                if hardware_sink_routes:
+                    cloud_track.set_hardware_sink_routes(hardware_sink_routes)
+                    logger.info(
+                        f"Cloud relay: registered {len(hardware_sink_routes)} "
+                        f"hardware sink route(s)"
+                    )
 
             # Create answer
             answer = await pc.createAnswer()

--- a/src/scope/server/webrtc.py
+++ b/src/scope/server/webrtc.py
@@ -142,6 +142,91 @@ def _parse_graph_node_ids(
     )
 
 
+def _compute_hardware_sink_routes(
+    initial_parameters: dict,
+    all_sink_node_ids: list[str],
+) -> list[tuple[int, str]]:
+    """Map each hardware sink to the cloud output handler that should feed it.
+
+    Cloud-relay mode strips hardware sinks (Syphon/NDI/Spout) from the graph
+    before sending it to the cloud runner, so the runner produces output
+    tracks only for webrtc sinks. Each hardware sink is teed from the cloud
+    output handler of the webrtc sink that shares its upstream pipeline node,
+    so the local sender receives the same frames the browser sees.
+
+    Returns a list of ``(handler_index, hardware_sink_node_id)`` pairs.
+    ``handler_index`` is the index into ``webrtc_client.output_handlers``:
+    0 is the primary CloudTrack output, 1+ are extra-sink tracks.
+
+    If a hardware sink has no buddy webrtc sink with the same upstream, falls
+    back to handler 0 (the primary) and logs a warning.
+    """
+    graph_data = initial_parameters.get("graph")
+    if not isinstance(graph_data, dict):
+        return []
+
+    nodes = graph_data.get("nodes", []) or []
+    edges = graph_data.get("edges", []) or []
+
+    sink_modes: dict[str, str | None] = {}
+    for n in nodes:
+        if isinstance(n, dict) and n.get("type") == "sink":
+            sink_modes[n.get("id")] = n.get("sink_mode")
+
+    hardware_sink_ids = [
+        sid
+        for sid in all_sink_node_ids
+        if sink_modes.get(sid) in ("spout", "ndi", "syphon")
+    ]
+    if not hardware_sink_ids:
+        return []
+
+    webrtc_sink_ids = [
+        sid
+        for sid in all_sink_node_ids
+        if sink_modes.get(sid) not in ("spout", "ndi", "syphon")
+    ]
+
+    def _upstream_of(sink_id: str) -> str | None:
+        for e in edges:
+            if not isinstance(e, dict):
+                continue
+            if e.get("kind") != "stream":
+                continue
+            if e.get("to_node") != sink_id:
+                continue
+            return e.get("from_node") or e.get("from")
+        return None
+
+    upstream_to_handler: dict[str, int] = {}
+    for idx, sid in enumerate(webrtc_sink_ids):
+        up = _upstream_of(sid)
+        if up and up not in upstream_to_handler:
+            upstream_to_handler[up] = idx
+
+    routes: list[tuple[int, str]] = []
+    for hw_id in hardware_sink_ids:
+        up = _upstream_of(hw_id)
+        handler_index = upstream_to_handler.get(up) if up else None
+        if handler_index is None:
+            if webrtc_sink_ids:
+                logger.warning(
+                    f"Hardware sink {hw_id!r} has no webrtc sink sharing its "
+                    f"upstream pipeline {up!r}; falling back to primary "
+                    "cloud output (frames may not match expected pipeline)"
+                )
+                handler_index = 0
+            else:
+                logger.warning(
+                    f"Hardware sink {hw_id!r} cannot be wired: no webrtc sink "
+                    "exists in this graph to provide cloud frames"
+                )
+                continue
+        routes.append((handler_index, hw_id))
+
+    return routes
+
+
 class Session:
     """WebRTC Session containing peer connection and associated tracks."""
 
@@ -1073,8 +1158,22 @@ class WebRTCManager:
 
             # Attach extra sink video tracks to the browser's recvonly
             # transceivers (same pattern as the local-mode handler).
+            # Hardware sinks (Syphon/NDI/Spout) are skipped here: they are
+            # stripped from the graph sent to the cloud runner, so the cloud
+            # produces no output track for them. Their frames are teed from
+            # a webrtc sink's cloud output handler via hardware_sink_routes
+            # (see below), and the browser's recv-only transceiver for the
+            # hardware sink stays unattached (the browser never displays
+            # frames for a Syphon/NDI/Spout-only sink).
             if len(sink_node_ids) > 1 and cloud_track is not None and relay is not None:
                 from .cloud_track import CloudSinkOutputTrack
+
+                hw_sink_modes: dict[str, str | None] = {}
+                _graph = initial_parameters.get("graph")
+                if isinstance(_graph, dict):
+                    for _n in _graph.get("nodes", []) or []:
+                        if isinstance(_n, dict) and _n.get("type") == "sink":
+                            hw_sink_modes[_n.get("id")] = _n.get("sink_mode")
 
                 extra_sink_tracks: list[CloudSinkOutputTrack] = []
                 recv_only_video = [
@@ -1089,6 +1188,12 @@ class WebRTCManager:
                     f"transceivers for {len(sink_node_ids) - 1} extra sink(s)"
                 )
                 for i, sink_id in enumerate(sink_node_ids[1:]):
+                    if hw_sink_modes.get(sink_id) in ("spout", "ndi", "syphon"):
+                        logger.info(
+                            f"Cloud relay: skipping browser delivery for "
+                            f"hardware sink {sink_id!r} (handled locally)"
+                        )
+                        continue
                     extra_track = CloudSinkOutputTrack(frame_processor=frame_processor)
                     extra_sink_tracks.append(extra_track)
                     session.additional_tracks.append(extra_track)
@@ -1128,6 +1233,23 @@ class WebRTCManager:
                     f"Cloud relay: registered {len(record_callbacks)} "
                     f"record callback(s)"
                 )
+
+            # Set up hardware sink (Syphon/NDI/Spout) routes. Hardware sinks
+            # always run on the local machine; the cloud relay strips them
+            # from the graph before sending to the runner. Tee frames from
+            # the cloud output handler of a webrtc sink that shares the same
+            # upstream pipeline into the local sender's queue, so Syphon
+            # receives the same frames the browser sees.
+            if cloud_track is not None:
+                hardware_sink_routes = _compute_hardware_sink_routes(
+                    initial_parameters, sink_node_ids
+                )
+                if hardware_sink_routes:
+                    cloud_track.set_hardware_sink_routes(hardware_sink_routes)
+                    logger.info(
+                        f"Cloud relay: registered {len(hardware_sink_routes)} "
+                        f"hardware sink route(s)"
+                    )
 
             # Create answer
             answer = await pc.createAnswer()

--- a/tests/test_cloud_hardware_sinks.py
+++ b/tests/test_cloud_hardware_sinks.py
@@ -7,34 +7,8 @@ feed it — typically the handler of a webrtc sink that shares the same
 upstream pipeline.
 """
 
-from unittest.mock import MagicMock
-
 from scope.server.livepeer_client import LivepeerClient, _BrowserGraphInfo
-from scope.server.webrtc import _build_cloud_output_taps
-
-
-def _hw_routes(taps):
-    """Filter tap list down to the (handler_index, node_id) pairs we can
-    inspect for hardware sinks. We recover node_id by inspecting the
-    closure of each callback (set up via _make_put_to_sink_cb)."""
-    routes = []
-    for handler_index, callback in taps:
-        # Hardware-sink callbacks call sink_manager.put_to_sink(node_id, frame);
-        # record callbacks call put_to_record. We can't easily distinguish
-        # them from the outside, but in tests we register a MagicMock as the
-        # frame_processor so any captured node_id is in cell_contents.
-        cells = callback.__closure__ or ()
-        node_id = next(
-            (c.cell_contents for c in cells if isinstance(c.cell_contents, str)),
-            None,
-        )
-        routes.append((handler_index, node_id))
-    return routes
-
-
-def _fake_fp():
-    """A frame_processor stand-in whose sink_manager just records calls."""
-    return MagicMock()
+from scope.server.webrtc import _compute_hardware_sink_routes
 
 
 def test_single_pipeline_webrtc_plus_syphon():
@@ -59,13 +33,8 @@ def test_single_pipeline_webrtc_plus_syphon():
             ],
         }
     }
-    taps = _build_cloud_output_taps(
-        initial_parameters=params,
-        all_sink_node_ids=["output", "output_sink"],
-        record_node_ids=[],
-        frame_processor=_fake_fp(),
-    )
-    assert _hw_routes(taps) == [(0, "output_sink")]
+    routes = _compute_hardware_sink_routes(params, ["output", "output_sink"])
+    assert routes == [(0, "output_sink")]
 
 
 def test_no_hardware_sinks_returns_empty():
@@ -78,13 +47,7 @@ def test_no_hardware_sinks_returns_empty():
             "edges": [_edge("input", "output")],
         }
     }
-    taps = _build_cloud_output_taps(
-        initial_parameters=params,
-        all_sink_node_ids=["output"],
-        record_node_ids=[],
-        frame_processor=_fake_fp(),
-    )
-    assert taps == []
+    assert _compute_hardware_sink_routes(params, ["output"]) == []
 
 
 def test_multi_pipeline_hw_sink_routes_to_buddy_webrtc_sink():
@@ -125,15 +88,12 @@ def test_multi_pipeline_hw_sink_routes_to_buddy_webrtc_sink():
             ],
         }
     }
-    taps = _build_cloud_output_taps(
-        initial_parameters=params,
-        all_sink_node_ids=["out_a", "out_b", "syphon_a", "syphon_b"],
-        record_node_ids=[],
-        frame_processor=_fake_fp(),
+    routes = _compute_hardware_sink_routes(
+        params, ["out_a", "out_b", "syphon_a", "syphon_b"]
     )
     # syphon_a shares pipeline_a with out_a (handler 0).
     # syphon_b shares pipeline_b with out_b (handler 1).
-    assert sorted(_hw_routes(taps)) == [(0, "syphon_a"), (1, "syphon_b")]
+    assert sorted(routes) == [(0, "syphon_a"), (1, "syphon_b")]
 
 
 def test_spout_and_ndi_treated_as_hardware():
@@ -154,13 +114,8 @@ def test_spout_and_ndi_treated_as_hardware():
             ],
         }
     }
-    taps = _build_cloud_output_taps(
-        initial_parameters=params,
-        all_sink_node_ids=["browser", "spout", "ndi"],
-        record_node_ids=[],
-        frame_processor=_fake_fp(),
-    )
-    assert sorted(_hw_routes(taps)) == [(0, "ndi"), (0, "spout")]
+    routes = _compute_hardware_sink_routes(params, ["browser", "spout", "ndi"])
+    assert sorted(routes) == [(0, "ndi"), (0, "spout")]
 
 
 def test_orphan_hardware_sink_is_dropped_not_silently_mis_routed(caplog):
@@ -191,45 +146,10 @@ def test_orphan_hardware_sink_is_dropped_not_silently_mis_routed(caplog):
         }
     }
     with caplog.at_level("WARNING"):
-        taps = _build_cloud_output_taps(
-            initial_parameters=params,
-            all_sink_node_ids=["out_a", "syphon_orphan"],
-            record_node_ids=[],
-            frame_processor=_fake_fp(),
-        )
-    assert taps == []
+        routes = _compute_hardware_sink_routes(params, ["out_a", "syphon_orphan"])
+    assert routes == []
     assert "syphon_orphan" in caplog.text
     assert "no webrtc sink shares" in caplog.text
-
-
-def test_record_nodes_get_taps_after_webrtc_sinks():
-    """Record-node taps come after the webrtc sinks in the output handler
-    index space."""
-    params = {
-        "graph": {
-            "nodes": [
-                {"id": "input", "type": "source", "source_mode": "camera"},
-                {"id": "pipe", "type": "pipeline", "pipeline_id": "passthrough"},
-                {"id": "out_a", "type": "sink"},
-                {"id": "out_b", "type": "sink"},
-                {"id": "rec", "type": "record"},
-            ],
-            "edges": [
-                _edge("input", "pipe"),
-                _edge("pipe", "out_a"),
-                _edge("pipe", "out_b"),
-            ],
-        }
-    }
-    taps = _build_cloud_output_taps(
-        initial_parameters=params,
-        all_sink_node_ids=["out_a", "out_b"],
-        record_node_ids=["rec"],
-        frame_processor=_fake_fp(),
-    )
-    # 2 webrtc sinks → record tap should land at handler 2.
-    handler_indices = [t[0] for t in taps]
-    assert handler_indices == [2]
 
 
 def test_filter_runner_params_strips_hardware_sinks():

--- a/tests/test_cloud_hardware_sinks.py
+++ b/tests/test_cloud_hardware_sinks.py
@@ -7,8 +7,34 @@ feed it — typically the handler of a webrtc sink that shares the same
 upstream pipeline.
 """
 
+from unittest.mock import MagicMock
+
 from scope.server.livepeer_client import LivepeerClient, _BrowserGraphInfo
-from scope.server.webrtc import _compute_hardware_sink_routes
+from scope.server.webrtc import _build_cloud_output_taps
+
+
+def _hw_routes(taps):
+    """Filter tap list down to the (handler_index, node_id) pairs we can
+    inspect for hardware sinks. We recover node_id by inspecting the
+    closure of each callback (set up via _make_put_to_sink_cb)."""
+    routes = []
+    for handler_index, callback in taps:
+        # Hardware-sink callbacks call sink_manager.put_to_sink(node_id, frame);
+        # record callbacks call put_to_record. We can't easily distinguish
+        # them from the outside, but in tests we register a MagicMock as the
+        # frame_processor so any captured node_id is in cell_contents.
+        cells = callback.__closure__ or ()
+        node_id = next(
+            (c.cell_contents for c in cells if isinstance(c.cell_contents, str)),
+            None,
+        )
+        routes.append((handler_index, node_id))
+    return routes
+
+
+def _fake_fp():
+    """A frame_processor stand-in whose sink_manager just records calls."""
+    return MagicMock()
 
 
 def test_single_pipeline_webrtc_plus_syphon():
@@ -27,33 +53,19 @@ def test_single_pipeline_webrtc_plus_syphon():
                 },
             ],
             "edges": [
-                {
-                    "from_node": "input",
-                    "to_node": "longlive",
-                    "from_port": "video",
-                    "to_port": "video",
-                    "kind": "stream",
-                },
-                {
-                    "from_node": "longlive",
-                    "to_node": "output",
-                    "from_port": "video",
-                    "to_port": "video",
-                    "kind": "stream",
-                },
-                {
-                    "from_node": "longlive",
-                    "to_node": "output_sink",
-                    "from_port": "video",
-                    "to_port": "video",
-                    "kind": "stream",
-                },
+                _edge("input", "longlive"),
+                _edge("longlive", "output"),
+                _edge("longlive", "output_sink"),
             ],
         }
     }
-    all_sink_node_ids = ["output", "output_sink"]
-    routes = _compute_hardware_sink_routes(params, all_sink_node_ids)
-    assert routes == [(0, "output_sink")]
+    taps = _build_cloud_output_taps(
+        initial_parameters=params,
+        all_sink_node_ids=["output", "output_sink"],
+        record_node_ids=[],
+        frame_processor=_fake_fp(),
+    )
+    assert _hw_routes(taps) == [(0, "output_sink")]
 
 
 def test_no_hardware_sinks_returns_empty():
@@ -63,18 +75,16 @@ def test_no_hardware_sinks_returns_empty():
                 {"id": "input", "type": "source", "source_mode": "camera"},
                 {"id": "output", "type": "sink"},
             ],
-            "edges": [
-                {
-                    "from_node": "input",
-                    "to_node": "output",
-                    "from_port": "video",
-                    "to_port": "video",
-                    "kind": "stream",
-                },
-            ],
+            "edges": [_edge("input", "output")],
         }
     }
-    assert _compute_hardware_sink_routes(params, ["output"]) == []
+    taps = _build_cloud_output_taps(
+        initial_parameters=params,
+        all_sink_node_ids=["output"],
+        record_node_ids=[],
+        frame_processor=_fake_fp(),
+    )
+    assert taps == []
 
 
 def test_multi_pipeline_hw_sink_routes_to_buddy_webrtc_sink():
@@ -115,12 +125,15 @@ def test_multi_pipeline_hw_sink_routes_to_buddy_webrtc_sink():
             ],
         }
     }
-    routes = _compute_hardware_sink_routes(
-        params, ["out_a", "out_b", "syphon_a", "syphon_b"]
+    taps = _build_cloud_output_taps(
+        initial_parameters=params,
+        all_sink_node_ids=["out_a", "out_b", "syphon_a", "syphon_b"],
+        record_node_ids=[],
+        frame_processor=_fake_fp(),
     )
     # syphon_a shares pipeline_a with out_a (handler 0).
     # syphon_b shares pipeline_b with out_b (handler 1).
-    assert sorted(routes) == [(0, "syphon_a"), (1, "syphon_b")]
+    assert sorted(_hw_routes(taps)) == [(0, "syphon_a"), (1, "syphon_b")]
 
 
 def test_spout_and_ndi_treated_as_hardware():
@@ -141,8 +154,82 @@ def test_spout_and_ndi_treated_as_hardware():
             ],
         }
     }
-    routes = _compute_hardware_sink_routes(params, ["browser", "spout", "ndi"])
-    assert sorted(routes) == [(0, "ndi"), (0, "spout")]
+    taps = _build_cloud_output_taps(
+        initial_parameters=params,
+        all_sink_node_ids=["browser", "spout", "ndi"],
+        record_node_ids=[],
+        frame_processor=_fake_fp(),
+    )
+    assert sorted(_hw_routes(taps)) == [(0, "ndi"), (0, "spout")]
+
+
+def test_orphan_hardware_sink_is_dropped_not_silently_mis_routed(caplog):
+    """A hardware sink whose upstream pipeline has no webrtc-sink buddy is
+    dropped with a warning, not silently wired to handler 0 (which would
+    deliver some other pipeline's frames)."""
+    params = {
+        "graph": {
+            "nodes": [
+                {"id": "input_a", "type": "source", "source_mode": "camera"},
+                {"id": "input_b", "type": "source", "source_mode": "camera"},
+                {"id": "pipeline_a", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "pipeline_b", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "out_a", "type": "sink"},
+                {
+                    "id": "syphon_orphan",
+                    "type": "sink",
+                    "sink_mode": "syphon",
+                    "sink_name": "B",
+                },
+            ],
+            "edges": [
+                _edge("input_a", "pipeline_a"),
+                _edge("pipeline_a", "out_a"),
+                _edge("input_b", "pipeline_b"),
+                _edge("pipeline_b", "syphon_orphan"),
+            ],
+        }
+    }
+    with caplog.at_level("WARNING"):
+        taps = _build_cloud_output_taps(
+            initial_parameters=params,
+            all_sink_node_ids=["out_a", "syphon_orphan"],
+            record_node_ids=[],
+            frame_processor=_fake_fp(),
+        )
+    assert taps == []
+    assert "syphon_orphan" in caplog.text
+    assert "no webrtc sink shares" in caplog.text
+
+
+def test_record_nodes_get_taps_after_webrtc_sinks():
+    """Record-node taps come after the webrtc sinks in the output handler
+    index space."""
+    params = {
+        "graph": {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "camera"},
+                {"id": "pipe", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "out_a", "type": "sink"},
+                {"id": "out_b", "type": "sink"},
+                {"id": "rec", "type": "record"},
+            ],
+            "edges": [
+                _edge("input", "pipe"),
+                _edge("pipe", "out_a"),
+                _edge("pipe", "out_b"),
+            ],
+        }
+    }
+    taps = _build_cloud_output_taps(
+        initial_parameters=params,
+        all_sink_node_ids=["out_a", "out_b"],
+        record_node_ids=["rec"],
+        frame_processor=_fake_fp(),
+    )
+    # 2 webrtc sinks → record tap should land at handler 2.
+    handler_indices = [t[0] for t in taps]
+    assert handler_indices == [2]
 
 
 def test_filter_runner_params_strips_hardware_sinks():

--- a/tests/test_cloud_hardware_sinks.py
+++ b/tests/test_cloud_hardware_sinks.py
@@ -1,0 +1,257 @@
+"""Tests for hardware sink routing in cloud-relay mode.
+
+Hardware sinks (Syphon/NDI/Spout) always run on the local machine; the cloud
+runner only renders the pipeline. The webrtc relay code is responsible for
+mapping each hardware sink to the cloud output handler whose frames should
+feed it — typically the handler of a webrtc sink that shares the same
+upstream pipeline.
+"""
+
+from scope.server.livepeer_client import LivepeerClient, _BrowserGraphInfo
+from scope.server.webrtc import _compute_hardware_sink_routes
+
+
+def test_single_pipeline_webrtc_plus_syphon():
+    """User's case: one pipeline feeds both a webrtc sink and a Syphon sink."""
+    params = {
+        "graph": {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "camera"},
+                {"id": "output", "type": "sink"},
+                {"id": "longlive", "type": "pipeline", "pipeline_id": "longlive"},
+                {
+                    "id": "output_sink",
+                    "type": "sink",
+                    "sink_mode": "syphon",
+                    "sink_name": "Scope",
+                },
+            ],
+            "edges": [
+                {
+                    "from_node": "input",
+                    "to_node": "longlive",
+                    "from_port": "video",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from_node": "longlive",
+                    "to_node": "output",
+                    "from_port": "video",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                {
+                    "from_node": "longlive",
+                    "to_node": "output_sink",
+                    "from_port": "video",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+            ],
+        }
+    }
+    all_sink_node_ids = ["output", "output_sink"]
+    routes = _compute_hardware_sink_routes(params, all_sink_node_ids)
+    assert routes == [(0, "output_sink")]
+
+
+def test_no_hardware_sinks_returns_empty():
+    params = {
+        "graph": {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "camera"},
+                {"id": "output", "type": "sink"},
+            ],
+            "edges": [
+                {
+                    "from_node": "input",
+                    "to_node": "output",
+                    "from_port": "video",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+            ],
+        }
+    }
+    assert _compute_hardware_sink_routes(params, ["output"]) == []
+
+
+def test_multi_pipeline_hw_sink_routes_to_buddy_webrtc_sink():
+    """Two pipelines, each with a webrtc sink and a hardware sink.
+
+    Each hardware sink must wire to the cloud output handler of the webrtc
+    sink that shares its upstream pipeline, NOT just handler 0.
+    """
+    params = {
+        "graph": {
+            "nodes": [
+                {"id": "input_a", "type": "source", "source_mode": "camera"},
+                {"id": "input_b", "type": "source", "source_mode": "camera"},
+                {"id": "pipeline_a", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "pipeline_b", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "out_a", "type": "sink"},
+                {"id": "out_b", "type": "sink"},
+                {
+                    "id": "syphon_a",
+                    "type": "sink",
+                    "sink_mode": "syphon",
+                    "sink_name": "A",
+                },
+                {
+                    "id": "syphon_b",
+                    "type": "sink",
+                    "sink_mode": "syphon",
+                    "sink_name": "B",
+                },
+            ],
+            "edges": [
+                _edge("input_a", "pipeline_a"),
+                _edge("pipeline_a", "out_a"),
+                _edge("pipeline_a", "syphon_a"),
+                _edge("input_b", "pipeline_b"),
+                _edge("pipeline_b", "out_b"),
+                _edge("pipeline_b", "syphon_b"),
+            ],
+        }
+    }
+    routes = _compute_hardware_sink_routes(
+        params, ["out_a", "out_b", "syphon_a", "syphon_b"]
+    )
+    # syphon_a shares pipeline_a with out_a (handler 0).
+    # syphon_b shares pipeline_b with out_b (handler 1).
+    assert sorted(routes) == [(0, "syphon_a"), (1, "syphon_b")]
+
+
+def test_spout_and_ndi_treated_as_hardware():
+    params = {
+        "graph": {
+            "nodes": [
+                {"id": "src", "type": "source", "source_mode": "camera"},
+                {"id": "pipe", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "browser", "type": "sink"},
+                {"id": "spout", "type": "sink", "sink_mode": "spout"},
+                {"id": "ndi", "type": "sink", "sink_mode": "ndi"},
+            ],
+            "edges": [
+                _edge("src", "pipe"),
+                _edge("pipe", "browser"),
+                _edge("pipe", "spout"),
+                _edge("pipe", "ndi"),
+            ],
+        }
+    }
+    routes = _compute_hardware_sink_routes(params, ["browser", "spout", "ndi"])
+    assert sorted(routes) == [(0, "ndi"), (0, "spout")]
+
+
+def test_filter_runner_params_strips_hardware_sinks():
+    """The graph sent to the cloud runner must not contain hardware sinks."""
+    initial = {
+        "graph": {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "camera"},
+                {"id": "output", "type": "sink"},
+                {"id": "longlive", "type": "pipeline", "pipeline_id": "longlive"},
+                {
+                    "id": "output_sink",
+                    "type": "sink",
+                    "sink_mode": "syphon",
+                    "sink_name": "Scope",
+                },
+            ],
+            "edges": [
+                _edge("input", "longlive"),
+                _edge("longlive", "output"),
+                _edge("longlive", "output_sink"),
+            ],
+        }
+    }
+    parsed = LivepeerClient._parse_browser_graph(initial)
+    filtered = LivepeerClient._filter_runner_params(initial, parsed)
+    node_ids = [n["id"] for n in filtered["graph"]["nodes"]]
+    assert "output_sink" not in node_ids
+    assert "output" in node_ids
+    # The edge feeding the hardware sink should be gone.
+    edges = filtered["graph"]["edges"]
+    assert all(e.get("to_node") != "output_sink" for e in edges)
+
+
+def test_filter_runner_params_preserves_graph_when_no_hardware():
+    initial = {
+        "graph": {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "camera"},
+                {"id": "output", "type": "sink"},
+            ],
+            "edges": [_edge("input", "output")],
+        }
+    }
+    parsed = LivepeerClient._parse_browser_graph(initial)
+    filtered = LivepeerClient._filter_runner_params(initial, parsed)
+    assert filtered["graph"] == initial["graph"]
+
+
+def test_filter_runner_params_strips_both_hardware_and_sink_teed_records():
+    """Both transformations should compose.
+
+    Note: sink-teed-record detection in _parse_browser_graph uses
+    ``edge.get("from")`` (alias) rather than ``from_node``, so the
+    sink-teed edge here uses the alias form.
+    """
+    initial = {
+        "graph": {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "camera"},
+                {"id": "pipe", "type": "pipeline", "pipeline_id": "passthrough"},
+                {"id": "output", "type": "sink"},
+                {"id": "rec", "type": "record"},
+                {"id": "syphon", "type": "sink", "sink_mode": "syphon"},
+            ],
+            "edges": [
+                _edge("input", "pipe"),
+                _edge("pipe", "output"),
+                {
+                    "from": "output",
+                    "to_node": "rec",
+                    "from_port": "video",
+                    "to_port": "video",
+                    "kind": "stream",
+                },
+                _edge("pipe", "syphon"),
+            ],
+        }
+    }
+    parsed = LivepeerClient._parse_browser_graph(initial)
+    filtered = LivepeerClient._filter_runner_params(initial, parsed)
+    node_ids = {n["id"] for n in filtered["graph"]["nodes"]}
+    assert "syphon" not in node_ids
+    assert "rec" not in node_ids
+    assert {"input", "pipe", "output"} <= node_ids
+
+
+def test_browser_graph_info_keeps_hardware_sinks_out_of_sink_node_ids():
+    """Hardware sinks shouldn't appear in sink_node_ids; cloud doesn't know
+    about them after _filter_runner_params strips them."""
+    initial = {
+        "graph": {
+            "nodes": [
+                {"id": "input", "type": "source", "source_mode": "camera"},
+                {"id": "output", "type": "sink"},
+                {"id": "syphon", "type": "sink", "sink_mode": "syphon"},
+            ],
+            "edges": [],
+        }
+    }
+    parsed: _BrowserGraphInfo = LivepeerClient._parse_browser_graph(initial)
+    assert parsed.sink_node_ids == ["output"]
+
+
+def _edge(from_node: str, to_node: str) -> dict:
+    return {
+        "from_node": from_node,
+        "to_node": to_node,
+        "from_port": "video",
+        "to_port": "video",
+        "kind": "stream",
+    }


### PR DESCRIPTION
## Summary

Restores local Syphon / NDI / Spout output when Scope is connected to cloud. Currently the cloud Linux runner tries (and fails) to instantiate the hardware sender, while the local Mac creates nothing — so TouchDesigner / Resolume receivers stay black.

The original cloud-relay support for this was added in af49de02 and dropped together with the legacy Cloud Relay mode in 6fcc8ebf. This PR re-implements the same behavior on the Livepeer code path.

## Approach

1. `_filter_runner_params` strips hardware sink nodes (and their edges) from the graph forwarded to the runner — the cloud no longer sees them.
2. `FrameProcessor`'s cloud branch calls a new `sink_manager.setup_cloud_hardware_sinks()` that allocates per-node hardware-sink queues and starts the local sender threads (in local mode the graph executor does this; cloud mode has no executor).
3. `webrtc.py` computes `hardware_sink_routes` — for each hardware sink, the index of the cloud output handler whose webrtc sink shares the same upstream pipeline.
4. `CloudTrack._start` registers an extra callback on each mapped output handler that tees frames into `sink_manager.put_to_sink`, feeding the local SyphonSender.

End-to-end: cloud renders pipeline frames → `output_handlers[0]` callback fans out to **both** the browser (via CloudTrack) **and** the local SyphonSender → Syphon receivers see cloud-rendered frames.

## Test plan

- [ ] Build a graph: Camera → longlive → Sink + Syphon Output (Scope), connect to cloud, start session
- [ ] Verify the Syphon receiver (TouchDesigner / Resolume / Syphon Recorder) shows the cloud-rendered frames
- [ ] Verify cloud logs no longer contain `syphon-python not available` / `Failed to create SyphonSender`
- [ ] Verify local-only mode (no cloud) still works (regression check)
- [ ] Run `uv run pytest tests/test_cloud_hardware_sinks.py` — 8 new tests covering route computation, runner-graph stripping, and composition with sink-teed records

🤖 Generated with [Claude Code](https://claude.com/claude-code)
