### PR TITLE
chore(cloud): bump scope-ltx-2 to latest main

### DIFF
--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -47,8 +47,8 @@ COPY src/ /app/src/
 
 # Pre-install bundled plugins (cannot be removed by users)
 ENV DAYDREAM_SCOPE_BUNDLED_PLUGINS_FILE="/app/bundled-plugins.txt"
-RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git@d13b5f9d94130b975989cd820eedbef5b3a8f165" > /app/bundled-plugins.txt
-RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git@d13b5f9d94130b975989cd820eedbef5b3a8f165
+RUN echo "git+https://github.com/daydreamlive/scope-ltx-2.git@927f66f23e84b35aaed684fc8af171b1dd34ef63" > /app/bundled-plugins.txt
+RUN uv run daydream-scope install git+https://github.com/daydreamlive/scope-ltx-2.git@927f66f23e84b35aaed684fc8af171b1dd34ef63
 
 # Expose port 8000 for RunPod HTTP proxy
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- Bump pinned `scope-ltx-2` commit in `Dockerfile.cloud` from `d13b5f9` to `927f66f` (current HEAD of `daydreamlive/scope-ltx-2` main; latest change: "perf: skip CPU offload on high-VRAM GPUs").

## Test plan
- [ ] Cloud image builds successfully
- [ ] LTX pipeline loads and runs in cloud deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)