### PR TITLE
fix(cloud): raise trickle JSONL reader cap so workflow imports with e…

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -61,6 +61,11 @@ _connection_count = 0
 STREAM_TASK_SHUTDOWN_GRACE_S = 1.0
 STREAM_TASK_CANCEL_TIMEOUT_S = 1.0
 MEDIA_STATS_INTERVAL_S = 10.0
+# Trickle segments carry proxied API requests; workflow imports can pack
+# embedded assets (base64-encoded images/video) into a single request and
+# easily blow past the 1 MiB library default, which would tear down the
+# control-channel reader mid-import.
+MAX_CONTROL_EVENT_BYTES = 128 * 1024 * 1024
 REMOTE_VIDEO_CLOCK_RATE = 90_000
 REMOTE_VIDEO_TIME_BASE = fractions.Fraction(1, REMOTE_VIDEO_CLOCK_RATE)
 ASSETS_DIR_PATH = os.getenv("DAYDREAM_SCOPE_ASSETS_DIR", "/tmp/.daydream-scope/assets")
@@ -1279,7 +1284,9 @@ async def _subscribe_control(
                 "runner_job_id": os.getenv("FAL_JOB_ID") or os.getenv("FAL_RUNNER_ID"),
             }
         )
-        async for message in JSONLReader(control_url)():
+        async for message in JSONLReader(control_url)(
+            max_event_bytes=MAX_CONTROL_EVENT_BYTES
+        ):
             if stop_event.is_set():
                 break
             if not isinstance(message, dict):

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -59,6 +59,11 @@ SHUTDOWN_TIMEOUT_S = 5.0
 TASK_DRAIN_TIMEOUT_S = 0.25
 RUNNER_RESTART_TIMEOUT_S = 30.0
 PAYMENT_SEND_INTERVAL_S = 10.0
+# Trickle segments carry proxied API responses; workflow imports can pack
+# embedded assets (base64-encoded images/video) into a single response and
+# easily blow past the 1 MiB library default, which would tear down the
+# events loop mid-import.
+MAX_EVENT_BYTES = 128 * 1024 * 1024
 
 
 @dataclass(slots=True)
@@ -811,7 +816,9 @@ class LivepeerClient:
 
         unexpected_reason: str | None = None
         try:
-            async for event in JSONLReader(self._job.events_url)():
+            async for event in JSONLReader(self._job.events_url)(
+                max_event_bytes=MAX_EVENT_BYTES
+            ):
                 if not self._connected:
                     break
                 if not isinstance(event, dict):


### PR DESCRIPTION
…mbedded assets survive

Workflow exports embed referenced media as base64 in the JSON; a 1.07 MB workflow tripped the library-default 1 MiB per-segment limit on JSONLReader, causing the cloud's control-channel loop to abort ("Livepeer events loop stopped unexpectedly") and dropping the connection mid-import. Bump both readers to 128 MiB so practical embedded-asset workflows pass through without tearing down the relay.