### PR TITLE
fix(cloud): lower trickle JSONL reader cap to 5 MiB

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -65,7 +65,7 @@ MEDIA_STATS_INTERVAL_S = 10.0
 # embedded assets (base64-encoded images/video) into a single request and
 # easily blow past the 1 MiB library default, which would tear down the
 # control-channel reader mid-import.
-MAX_CONTROL_EVENT_BYTES = 128 * 1024 * 1024
+MAX_CONTROL_EVENT_BYTES = 5 * 1024 * 1024
 REMOTE_VIDEO_CLOCK_RATE = 90_000
 REMOTE_VIDEO_TIME_BASE = fractions.Fraction(1, REMOTE_VIDEO_CLOCK_RATE)
 ASSETS_DIR_PATH = os.getenv("DAYDREAM_SCOPE_ASSETS_DIR", "/tmp/.daydream-scope/assets")

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -63,7 +63,7 @@ PAYMENT_SEND_INTERVAL_S = 10.0
 # embedded assets (base64-encoded images/video) into a single response and
 # easily blow past the 1 MiB library default, which would tear down the
 # events loop mid-import.
-MAX_EVENT_BYTES = 128 * 1024 * 1024
+MAX_EVENT_BYTES = 5 * 1024 * 1024
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- Lowers `MAX_CONTROL_EVENT_BYTES` (cloud) and `MAX_EVENT_BYTES` (server) from 128 MiB to 5 MiB.
- Follow-up to #1035, which raised the cap from the 1 MiB library default. 128 MiB is much larger than any legitimate control-channel event needs; 5 MiB still accommodates workflow imports with embedded assets while bounding memory if a malformed or runaway producer streams unterminated JSONL.

## Test plan
- [ ] Verify a workflow import with embedded assets still succeeds end-to-end
- [ ] Confirm trickle control channel does not tear down mid-import under normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)