### PR TITLE
feat: forward network_events to Daydream /v1/metrics via reliable client reporter

### DIFF
--- a/src/scope/cloud/livepeer_app.py
+++ b/src/scope/cloud/livepeer_app.py
@@ -45,7 +45,7 @@ from scope.core.outputs import HARDWARE_SINK_MODES
 from scope.server.app import app as scope_app
 from scope.server.app import lifespan as scope_lifespan
 from scope.server.frame_processor import FrameProcessor
-from scope.server.kafka_publisher import publish_event
+from scope.server.kafka_publisher import publish_event, set_event_sink
 from scope.server.logs_config import (
     LOG_FORMAT,
     ScopeLogContextFilter,
@@ -1277,6 +1277,28 @@ async def _subscribe_control(
 
     notif_task = asyncio.create_task(_forward_notifications_to_events())
 
+    # Forward stream_trace envelopes over the trickle events channel so the
+    # Scope client can relay them to the Daydream /v1/metrics endpoint.
+    runner_loop = asyncio.get_running_loop()
+
+    def _trickle_event_sink(envelope: dict) -> None:
+        """Sync callback: schedule an async write on the runner loop."""
+
+        async def _write() -> None:
+            try:
+                await events_writer.write({"type": "network_event", "event": envelope})
+            except Exception:
+                logger.debug(
+                    "Failed to forward network_event to events channel", exc_info=True
+                )
+
+        try:
+            runner_loop.call_soon_threadsafe(lambda: runner_loop.create_task(_write()))
+        except RuntimeError:
+            pass
+
+    set_event_sink(_trickle_event_sink)
+
     try:
         await events_writer.write(
             {
@@ -1318,6 +1340,7 @@ async def _subscribe_control(
         except asyncio.CancelledError:
             pass
         session.notification_queue = None
+        set_event_sink(None)
         await _stop_stream(session)
         try:
             await events_writer.close()

--- a/src/scope/server/app.py
+++ b/src/scope/server/app.py
@@ -74,6 +74,7 @@ from .file_utils import (
 from .kafka_publisher import (
     KafkaPublisher,
     is_kafka_enabled,
+    set_event_sink,
     set_kafka_publisher,
 )
 from .logs_config import (
@@ -87,6 +88,12 @@ from .logs_config import (
 )
 from .lora_downloader import LoRADownloadRequest, LoRADownloadResult
 from .mcp_router import router as mcp_router
+from .metrics_reporter import (
+    MetricsReporter,
+    is_metrics_reporter_enabled,
+    report_event,
+    set_metrics_reporter,
+)
 from .models_config import (
     ensure_models_dir,
     get_assets_dir,
@@ -344,6 +351,8 @@ server_start_time = time.time()
 livepeer = None
 # Global Kafka publisher instance (optional, initialized if credentials are present)
 kafka_publisher = None
+# Global metrics reporter instance (optional, forwards network_events to Daydream /v1/metrics)
+metrics_reporter_instance = None
 # Global tempo sync manager instance
 tempo_sync = None
 # Global OSC server instance
@@ -392,6 +401,7 @@ async def lifespan(app: FastAPI):
         webrtc_manager, \
         pipeline_manager, \
         kafka_publisher, \
+        metrics_reporter_instance, \
         livepeer, \
         tempo_sync, \
         osc_server, \
@@ -453,6 +463,21 @@ async def lifespan(app: FastAPI):
         else:
             kafka_publisher = None
             logger.warning("Kafka publisher failed to start")
+
+    # Initialize metrics reporter (forwards network_events to Daydream /v1/metrics)
+    if is_metrics_reporter_enabled():
+        api_key = os.getenv("SCOPE_CLOUD_API_KEY", "")
+        if api_key:
+            metrics_reporter_instance = MetricsReporter(api_key=api_key)
+            if await metrics_reporter_instance.start():
+                set_metrics_reporter(metrics_reporter_instance)
+                set_event_sink(lambda envelope: report_event(envelope))
+                logger.info("Metrics reporter initialized")
+            else:
+                metrics_reporter_instance = None
+                logger.warning("Metrics reporter failed to start")
+        else:
+            logger.debug("Metrics reporter skipped: no SCOPE_CLOUD_API_KEY")
 
     # Start OSC UDP server on the same port as the HTTP API
     from .osc_server import OSCServer
@@ -526,6 +551,13 @@ async def lifespan(app: FastAPI):
         logger.info("Shutting down Livepeer connection...")
         await livepeer.disconnect()
         logger.info("Livepeer connection shutdown complete")
+
+    if metrics_reporter_instance:
+        logger.info("Shutting down metrics reporter...")
+        set_event_sink(None)
+        await metrics_reporter_instance.stop()
+        set_metrics_reporter(None)
+        logger.info("Metrics reporter shutdown complete")
 
     if kafka_publisher:
         logger.info("Shutting down Kafka publisher...")

--- a/src/scope/server/kafka_publisher.py
+++ b/src/scope/server/kafka_publisher.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import threading
+from collections.abc import Callable
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -184,6 +185,9 @@ class KafkaPublisher:
             "data": data,
         }
 
+        # Forward to metrics reporter / trickle sink (parallel to Kafka)
+        _dispatch_to_sink(event)
+
         try:
             # Use event ID as key (matching Go format)
             key = event_id
@@ -275,6 +279,38 @@ def set_kafka_publisher(publisher: KafkaPublisher | None):
     """
     global _publisher
     _publisher = publisher
+
+
+# Event sink: receives built envelopes for forwarding to metrics reporter
+# or trickle channel. Set via set_event_sink() so the runner can redirect
+# envelopes without importing server code.
+_event_sink: Callable[[dict[str, Any]], None] | None = None
+
+
+def get_event_sink() -> Callable[[dict[str, Any]], None] | None:
+    """Get the registered event sink callback."""
+    return _event_sink
+
+
+def set_event_sink(sink: Callable[[dict[str, Any]], None] | None) -> None:
+    """Register a callback that receives every built stream_trace envelope.
+
+    In local mode this feeds the MetricsReporter directly. On the runner it
+    writes ``{type: "network_event", event: <envelope>}`` to the trickle
+    events channel.
+    """
+    global _event_sink
+    _event_sink = sink
+
+
+def _dispatch_to_sink(envelope: dict[str, Any]) -> None:
+    """Forward envelope to the registered sink, if any. Never raises."""
+    sink = _event_sink
+    if sink is not None:
+        try:
+            sink(envelope)
+        except Exception as exc:
+            logger.debug("Event sink dispatch failed: %s", exc)
 
 
 def publish_event(

--- a/src/scope/server/livepeer_client.py
+++ b/src/scope/server/livepeer_client.py
@@ -860,6 +860,10 @@ class LivepeerClient:
                     _forward_runner_notification(event.get("payload"))
                     continue
 
+                if msg_type == "network_event":
+                    _forward_network_event(event.get("event"))
+                    continue
+
                 logger.debug(f"Event: {event}")
         except asyncio.CancelledError:
             pass
@@ -1279,3 +1283,17 @@ def _forward_runner_notification(payload: Any) -> None:
         manager.broadcast_notification(payload)
     except Exception:
         logger.debug("Failed to re-broadcast runner notification", exc_info=True)
+
+
+def _forward_network_event(envelope: Any) -> None:
+    """Forward a runner-originated network_event to the metrics reporter."""
+    if not isinstance(envelope, dict):
+        return
+    from .metrics_reporter import report_event
+
+    try:
+        report_event(envelope)
+    except Exception:
+        logger.debug(
+            "Failed to forward network_event to metrics reporter", exc_info=True
+        )

--- a/src/scope/server/metrics_reporter.py
+++ b/src/scope/server/metrics_reporter.py
@@ -1,0 +1,370 @@
+"""Reliable metrics reporter that forwards network_events to Daydream /v1/metrics.
+
+Implements the fail-loud / no-loss client contract defined in the Daydream
+metrics API: events are buffered locally and flushed in batches via HTTP POST.
+Reliability is achieved entirely through client-side buffering with exponential
+backoff, disk-backed resume, and response-aware retry logic.
+
+Environment Variables:
+    DAYDREAM_METRICS_URL: Endpoint URL (default: https://api.daydream.monster/v1/metrics)
+    SCOPE_CLOUD_API_KEY: Bearer token for authentication (required to enable)
+    SCOPE_METRICS_ENABLED: Explicit enable/disable ("true"/"false"; default: on when key present)
+    SCOPE_METRICS_FLUSH_INTERVAL_MS: Flush interval in milliseconds (default: 2000)
+    SCOPE_METRICS_MAX_BATCH: Max events per batch (default: 500, API limit)
+    SCOPE_METRICS_MAX_BUFFER: Max buffered events before dropping oldest (default: 50000)
+    SCOPE_METRICS_BUFFER_PATH: Path for disk-backed resume buffer (default: ~/.daydream-scope/metrics_buffer.jsonl)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import platform
+import threading
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DAYDREAM_METRICS_URL = os.getenv(
+    "DAYDREAM_METRICS_URL", "https://api.daydream.monster/v1/metrics"
+)
+MAX_BATCH_SIZE = int(os.getenv("SCOPE_METRICS_MAX_BATCH", "500"))
+MAX_BUFFER_SIZE = int(os.getenv("SCOPE_METRICS_MAX_BUFFER", "50000"))
+FLUSH_INTERVAL_S = int(os.getenv("SCOPE_METRICS_FLUSH_INTERVAL_MS", "2000")) / 1000.0
+MAX_BODY_BYTES = 1_000_000  # 1 MiB API limit
+INITIAL_BACKOFF_S = 1.0
+MAX_BACKOFF_S = 60.0
+RATE_LIMIT_WINDOW_S = 60.0
+
+_HOSTNAME = platform.node()
+
+
+def _default_buffer_path() -> Path | None:
+    """Return the default disk buffer path, or None if explicitly disabled."""
+    env = os.getenv("SCOPE_METRICS_BUFFER_PATH")
+    if env == "":
+        return None
+    if env:
+        return Path(env)
+    base = os.getenv("DAYDREAM_SCOPE_MODELS_DIR")
+    if base:
+        return Path(base).parent / "metrics_buffer.jsonl"
+    return Path.home() / ".daydream-scope" / "metrics_buffer.jsonl"
+
+
+def is_metrics_reporter_enabled() -> bool:
+    """Check if the metrics reporter should be started."""
+    explicit = os.getenv("SCOPE_METRICS_ENABLED", "").lower()
+    if explicit == "false":
+        return False
+    if explicit == "true":
+        return True
+    return os.getenv("SCOPE_CLOUD_API_KEY") is not None
+
+
+def map_envelope_to_event(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Map a Scope stream_trace Kafka envelope to a /v1/metrics Event object.
+
+    Scope envelope: {id, type:"stream_trace", timestamp, data:{type, client_source, ...}}
+    API Event:      {type, data, id?, timestamp?}
+    """
+    data = envelope.get("data", {})
+    event: dict[str, Any] = {
+        "type": data.get("type", envelope.get("type", "unknown")),
+        "data": data,
+    }
+    if envelope.get("id"):
+        event["id"] = envelope["id"]
+    if envelope.get("timestamp"):
+        event["timestamp"] = str(envelope["timestamp"])
+    return event
+
+
+class MetricsReporter:
+    """Reliable buffered metrics forwarder to Daydream /v1/metrics.
+
+    Thread-safe: ``enqueue()`` can be called from any thread.
+    The async flush loop runs on the event loop captured at ``start()``.
+    """
+
+    def __init__(self, api_key: str, url: str = DAYDREAM_METRICS_URL):
+        self._api_key = api_key
+        self._url = url
+        self._buffer: deque[dict[str, Any]] = deque(maxlen=MAX_BUFFER_SIZE)
+        self._lock = threading.Lock()
+        self._event_loop: asyncio.AbstractEventLoop | None = None
+        self._flush_task: asyncio.Task | None = None
+        self._started = False
+        self._paused = False  # Set on 401, cleared on key refresh
+        self._backoff_s = INITIAL_BACKOFF_S
+        self._client = None
+        self._buffer_path = _default_buffer_path()
+
+    async def start(self) -> bool:
+        """Start the reporter and its background flush loop."""
+        try:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=30.0)
+        except ImportError:
+            logger.warning("httpx not installed, metrics reporting disabled")
+            return False
+
+        self._event_loop = asyncio.get_running_loop()
+        self._started = True
+
+        self._load_disk_buffer()
+
+        self._flush_task = asyncio.create_task(self._flush_loop())
+        logger.info(
+            "Metrics reporter started (url=%s, flush=%.1fs, max_batch=%d)",
+            self._url,
+            FLUSH_INTERVAL_S,
+            MAX_BATCH_SIZE,
+        )
+        return True
+
+    async def stop(self):
+        """Flush remaining events and shut down."""
+        self._started = False
+        if self._flush_task:
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+            self._flush_task = None
+
+        # Final flush attempt
+        await self._flush_once()
+
+        self._persist_disk_buffer()
+
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+        logger.info(
+            "Metrics reporter stopped (remaining_buffered=%d)", len(self._buffer)
+        )
+
+    def enqueue(self, envelope: dict[str, Any]) -> None:
+        """Thread-safe: add a stream_trace envelope to the buffer."""
+        if not self._started or self._paused:
+            return
+        event = map_envelope_to_event(envelope)
+        with self._lock:
+            self._buffer.append(event)
+
+    def enqueue_raw_event(self, event: dict[str, Any]) -> None:
+        """Thread-safe: add an already-mapped /v1/metrics event to the buffer."""
+        if not self._started or self._paused:
+            return
+        with self._lock:
+            self._buffer.append(event)
+
+    @property
+    def is_running(self) -> bool:
+        return self._started
+
+    @property
+    def buffered_count(self) -> int:
+        return len(self._buffer)
+
+    def update_api_key(self, api_key: str) -> None:
+        """Update the Bearer token (e.g., after key refresh) and unpause."""
+        self._api_key = api_key
+        self._paused = False
+        self._backoff_s = INITIAL_BACKOFF_S
+        logger.info("Metrics reporter API key updated, unpaused")
+
+    # -- internal --
+
+    def _take_batch(self, max_size: int = MAX_BATCH_SIZE) -> list[dict[str, Any]]:
+        with self._lock:
+            count = min(max_size, len(self._buffer))
+            batch = [self._buffer.popleft() for _ in range(count)]
+        return batch
+
+    def _requeue_batch(self, batch: list[dict[str, Any]]) -> None:
+        with self._lock:
+            self._buffer.extendleft(reversed(batch))
+
+    async def _flush_loop(self) -> None:
+        try:
+            while self._started:
+                await asyncio.sleep(FLUSH_INTERVAL_S)
+                if self._paused or not self._buffer:
+                    continue
+                await self._flush_once()
+        except asyncio.CancelledError:
+            pass
+
+    async def _flush_once(self) -> None:
+        if not self._buffer or not self._client:
+            return
+
+        batch = self._take_batch()
+        if not batch:
+            return
+
+        body = self._build_body(batch)
+        body_bytes = json.dumps(body).encode("utf-8")
+
+        # If body exceeds 1 MiB, split the batch
+        if len(body_bytes) > MAX_BODY_BYTES and len(batch) > 1:
+            half = len(batch) // 2
+            self._requeue_batch(batch[half:])
+            batch = batch[:half]
+            body = self._build_body(batch)
+
+        try:
+            response = await self._client.post(
+                self._url,
+                json=body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            await self._handle_response(response, batch)
+        except Exception as e:
+            # Network error: treat as 5xx
+            logger.warning("Metrics POST failed (network): %s", e)
+            self._requeue_batch(batch)
+            await self._wait_backoff()
+
+    async def _handle_response(
+        self, response: Any, batch: list[dict[str, Any]]
+    ) -> None:
+        status = response.status_code
+
+        if status == 200:
+            self._backoff_s = INITIAL_BACKOFF_S
+            logger.debug("Metrics batch accepted (%d events)", len(batch))
+            return
+
+        if status == 400:
+            logger.error(
+                "Metrics batch rejected (400 malformed), dropping %d events: %s",
+                len(batch),
+                response.text[:200],
+            )
+            return
+
+        if status == 401:
+            logger.error(
+                "Metrics reporter unauthorized (401), pausing until key refresh"
+            )
+            self._paused = True
+            self._requeue_batch(batch)
+            return
+
+        if status == 413:
+            logger.warning("Metrics batch too large (413), halving batch size")
+            self._requeue_batch(batch)
+            # Next flush will naturally try a smaller batch since _take_batch
+            # gets called again; force a smaller max on immediate retry.
+            half_batch = self._take_batch(max(1, len(batch) // 2))
+            if half_batch:
+                body = self._build_body(half_batch)
+                try:
+                    retry_resp = await self._client.post(
+                        self._url,
+                        json=body,
+                        headers={
+                            "Authorization": f"Bearer {self._api_key}",
+                            "Content-Type": "application/json",
+                        },
+                    )
+                    await self._handle_response(retry_resp, half_batch)
+                except Exception:
+                    self._requeue_batch(half_batch)
+            return
+
+        if status == 429:
+            logger.warning(
+                "Metrics rate limited (429), waiting %.0fs", RATE_LIMIT_WINDOW_S
+            )
+            self._requeue_batch(batch)
+            await asyncio.sleep(RATE_LIMIT_WINDOW_S)
+            return
+
+        # 5xx or unexpected status
+        logger.warning("Metrics POST failed (HTTP %d), retrying with backoff", status)
+        self._requeue_batch(batch)
+        await self._wait_backoff()
+
+    async def _wait_backoff(self) -> None:
+        await asyncio.sleep(self._backoff_s)
+        self._backoff_s = min(self._backoff_s * 2, MAX_BACKOFF_S)
+
+    def _build_body(self, batch: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "app": "scope",
+            "host": _HOSTNAME,
+            "events": batch,
+        }
+
+    # -- disk persistence --
+
+    def _load_disk_buffer(self) -> None:
+        if not self._buffer_path or not self._buffer_path.exists():
+            return
+        loaded = 0
+        try:
+            with open(self._buffer_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event = json.loads(line)
+                        self._buffer.append(event)
+                        loaded += 1
+                    except json.JSONDecodeError:
+                        continue
+            # Clear the file after loading
+            self._buffer_path.write_text("")
+            if loaded:
+                logger.info("Loaded %d events from disk buffer", loaded)
+        except Exception as e:
+            logger.warning("Failed to load disk buffer: %s", e)
+
+    def _persist_disk_buffer(self) -> None:
+        if not self._buffer_path or not self._buffer:
+            return
+        try:
+            self._buffer_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._buffer_path, "a") as f:
+                with self._lock:
+                    for event in self._buffer:
+                        f.write(json.dumps(event) + "\n")
+            logger.info("Persisted %d events to disk buffer", len(self._buffer))
+        except Exception as e:
+            logger.warning("Failed to persist disk buffer: %s", e)
+
+
+# -- Global accessor pattern (mirrors kafka_publisher.py) --
+
+_reporter: MetricsReporter | None = None
+
+
+def get_metrics_reporter() -> MetricsReporter | None:
+    """Get the global MetricsReporter instance."""
+    return _reporter
+
+
+def set_metrics_reporter(reporter: MetricsReporter | None) -> None:
+    """Set the global MetricsReporter instance."""
+    global _reporter
+    _reporter = reporter
+
+
+def report_event(envelope: dict[str, Any]) -> None:
+    """Convenience: enqueue an envelope for reporting. No-op if disabled."""
+    reporter = _reporter
+    if reporter and reporter.is_running:
+        reporter.enqueue(envelope)

--- a/tests/test_metrics_reporter.py
+++ b/tests/test_metrics_reporter.py
@@ -1,0 +1,466 @@
+"""Tests for the MetricsReporter: reliability contract, batching, disk resume, and mapping."""
+
+import time
+from collections import deque
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from scope.server.metrics_reporter import (
+    INITIAL_BACKOFF_S,
+    MAX_BATCH_SIZE,
+    MetricsReporter,
+    get_metrics_reporter,
+    map_envelope_to_event,
+    report_event,
+    set_metrics_reporter,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_envelope(
+    event_type: str = "stream_heartbeat",
+    event_id: str | None = None,
+    **extra_data,
+) -> dict:
+    ts = str(int(time.time() * 1000))
+    return {
+        "id": event_id or f"test-{time.monotonic_ns()}",
+        "type": "stream_trace",
+        "timestamp": ts,
+        "data": {
+            "type": event_type,
+            "client_source": "scope",
+            "timestamp": ts,
+            **extra_data,
+        },
+    }
+
+
+def _make_response(status_code: int, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Event mapping
+# ---------------------------------------------------------------------------
+
+
+class TestMapEnvelopeToEvent:
+    def test_basic_mapping(self):
+        envelope = _make_envelope("stream_started", event_id="evt-1", session_id="s1")
+        event = map_envelope_to_event(envelope)
+
+        assert event["type"] == "stream_started"
+        assert event["id"] == "evt-1"
+        assert "timestamp" in event
+        assert event["data"]["session_id"] == "s1"
+        assert event["data"]["client_source"] == "scope"
+
+    def test_missing_data_type_falls_back_to_outer(self):
+        envelope = {"id": "x", "type": "stream_trace", "timestamp": "123", "data": {}}
+        event = map_envelope_to_event(envelope)
+        assert event["type"] == "stream_trace"
+
+    def test_missing_data_and_outer_type(self):
+        envelope = {"id": "x", "data": {}}
+        event = map_envelope_to_event(envelope)
+        assert event["type"] == "unknown"
+
+    def test_missing_fields_omitted(self):
+        envelope = {"data": {"type": "error"}}
+        event = map_envelope_to_event(envelope)
+        assert "id" not in event
+        assert "timestamp" not in event
+        assert event["type"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Global accessors
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalAccessors:
+    def test_get_set_reporter(self):
+        assert get_metrics_reporter() is None or isinstance(
+            get_metrics_reporter(), MetricsReporter
+        )
+        reporter = MetricsReporter(api_key="test")
+        set_metrics_reporter(reporter)
+        assert get_metrics_reporter() is reporter
+        set_metrics_reporter(None)
+        assert get_metrics_reporter() is None
+
+    def test_report_event_noop_when_no_reporter(self):
+        set_metrics_reporter(None)
+        report_event(_make_envelope())
+
+    def test_is_metrics_reporter_enabled_with_key(self):
+        with patch.dict("os.environ", {"SCOPE_CLOUD_API_KEY": "test-key"}, clear=False):
+            # Re-import to pick up env change
+            from scope.server import metrics_reporter as mr
+
+            # The function reads env at call time
+            assert mr.is_metrics_reporter_enabled()
+
+    def test_is_metrics_reporter_disabled_explicit(self):
+        with patch.dict(
+            "os.environ",
+            {"SCOPE_METRICS_ENABLED": "false", "SCOPE_CLOUD_API_KEY": "key"},
+            clear=False,
+        ):
+            from scope.server import metrics_reporter as mr
+
+            assert not mr.is_metrics_reporter_enabled()
+
+
+# ---------------------------------------------------------------------------
+# MetricsReporter: batching & buffer
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueAndBatching:
+    def test_enqueue_adds_mapped_events(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+
+        for i in range(10):
+            reporter.enqueue(_make_envelope("stream_heartbeat", event_id=f"e-{i}"))
+
+        assert reporter.buffered_count == 10
+
+    def test_enqueue_noop_when_stopped(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = False
+        reporter.enqueue(_make_envelope())
+        assert reporter.buffered_count == 0
+
+    def test_enqueue_noop_when_paused(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+        reporter._paused = True
+        reporter.enqueue(_make_envelope())
+        assert reporter.buffered_count == 0
+
+    def test_buffer_max_size_drops_oldest(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+        reporter._buffer = deque(maxlen=5)
+
+        for i in range(10):
+            reporter.enqueue(_make_envelope(event_id=f"e-{i}"))
+
+        assert reporter.buffered_count == 5
+        batch = reporter._take_batch(5)
+        ids = [e["id"] for e in batch]
+        assert ids[0] == "e-5"
+
+    def test_take_batch_respects_max_size(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+
+        for i in range(1000):
+            reporter.enqueue(_make_envelope(event_id=f"e-{i}"))
+
+        batch = reporter._take_batch(MAX_BATCH_SIZE)
+        assert len(batch) == MAX_BATCH_SIZE
+        assert reporter.buffered_count == 500
+
+    def test_requeue_batch_preserves_order(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+
+        for i in range(3):
+            reporter.enqueue(_make_envelope(event_id=f"e-{i}"))
+
+        batch = reporter._take_batch(3)
+        reporter._requeue_batch(batch)
+
+        recovered = reporter._take_batch(3)
+        assert [e["id"] for e in recovered] == [e["id"] for e in batch]
+
+    def test_build_body_shape(self):
+        reporter = MetricsReporter(api_key="key")
+        events = [map_envelope_to_event(_make_envelope())]
+        body = reporter._build_body(events)
+
+        assert body["app"] == "scope"
+        assert "host" in body
+        assert body["events"] is events
+
+
+# ---------------------------------------------------------------------------
+# Reliability contract (response handling)
+# ---------------------------------------------------------------------------
+
+
+class TestResponseHandling:
+    @pytest.mark.anyio
+    async def test_200_drops_batch_resets_backoff(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+        reporter._backoff_s = 16.0
+
+        batch = [map_envelope_to_event(_make_envelope())]
+        await reporter._handle_response(_make_response(200), batch)
+
+        assert reporter._backoff_s == INITIAL_BACKOFF_S
+        assert reporter.buffered_count == 0
+
+    @pytest.mark.anyio
+    async def test_400_drops_batch(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+
+        batch = [map_envelope_to_event(_make_envelope())]
+        await reporter._handle_response(_make_response(400, "bad request"), batch)
+
+        assert reporter.buffered_count == 0
+
+    @pytest.mark.anyio
+    async def test_401_pauses_and_requeues(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+
+        batch = [map_envelope_to_event(_make_envelope())]
+        await reporter._handle_response(_make_response(401), batch)
+
+        assert reporter._paused is True
+        assert reporter.buffered_count == 1
+
+    @pytest.mark.anyio
+    async def test_429_requeues_batch(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+
+        batch = [map_envelope_to_event(_make_envelope())]
+
+        # Patch asyncio.sleep to avoid real waiting
+        with patch(
+            "scope.server.metrics_reporter.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await reporter._handle_response(_make_response(429), batch)
+
+        assert reporter.buffered_count == 1
+
+    @pytest.mark.anyio
+    async def test_5xx_requeues_with_backoff(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+        reporter._backoff_s = INITIAL_BACKOFF_S
+
+        batch = [map_envelope_to_event(_make_envelope())]
+
+        with patch(
+            "scope.server.metrics_reporter.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            await reporter._handle_response(_make_response(502), batch)
+
+        assert reporter.buffered_count == 1
+        mock_sleep.assert_awaited_once_with(INITIAL_BACKOFF_S)
+        assert reporter._backoff_s == INITIAL_BACKOFF_S * 2
+
+    @pytest.mark.anyio
+    async def test_backoff_capped_at_max(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+        reporter._backoff_s = 32.0
+
+        batch = [map_envelope_to_event(_make_envelope())]
+
+        with patch(
+            "scope.server.metrics_reporter.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await reporter._handle_response(_make_response(500), batch)
+
+        assert reporter._backoff_s == 60.0
+
+    @pytest.mark.anyio
+    async def test_update_api_key_unpauses(self):
+        reporter = MetricsReporter(api_key="old-key")
+        reporter._started = True
+        reporter._paused = True
+        reporter._backoff_s = 30.0
+
+        reporter.update_api_key("new-key")
+
+        assert reporter._paused is False
+        assert reporter._backoff_s == INITIAL_BACKOFF_S
+        assert reporter._api_key == "new-key"
+
+
+# ---------------------------------------------------------------------------
+# Flush cycle
+# ---------------------------------------------------------------------------
+
+
+class TestFlushOnce:
+    @pytest.mark.anyio
+    async def test_flush_once_sends_batch(self):
+        reporter = MetricsReporter(api_key="test-key")
+        reporter._started = True
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=_make_response(200))
+        reporter._client = mock_client
+
+        for i in range(3):
+            reporter.enqueue(_make_envelope(event_id=f"e-{i}"))
+
+        await reporter._flush_once()
+
+        assert reporter.buffered_count == 0
+        mock_client.post.assert_awaited_once()
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer test-key"
+
+    @pytest.mark.anyio
+    async def test_flush_once_noop_on_empty_buffer(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+        reporter._client = AsyncMock()
+
+        await reporter._flush_once()
+
+        reporter._client.post.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_flush_network_error_requeues(self):
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
+        reporter._client = mock_client
+
+        reporter.enqueue(_make_envelope(event_id="net-err"))
+
+        with patch(
+            "scope.server.metrics_reporter.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await reporter._flush_once()
+
+        assert reporter.buffered_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Disk persistence
+# ---------------------------------------------------------------------------
+
+
+class TestDiskBuffer:
+    def test_persist_and_load(self, tmp_path: Path):
+        buf_path = tmp_path / "buffer.jsonl"
+
+        reporter = MetricsReporter(api_key="key")
+        reporter._started = True
+        reporter._buffer_path = buf_path
+
+        reporter.enqueue(_make_envelope(event_id="disk-1"))
+        reporter.enqueue(_make_envelope(event_id="disk-2"))
+
+        reporter._persist_disk_buffer()
+        assert buf_path.exists()
+        lines = buf_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+
+        # Clear in-memory buffer, then load from disk
+        reporter._buffer.clear()
+        assert reporter.buffered_count == 0
+
+        reporter._load_disk_buffer()
+        assert reporter.buffered_count == 2
+        # Disk file cleared after load
+        assert buf_path.read_text() == ""
+
+    def test_load_handles_missing_file(self, tmp_path: Path):
+        reporter = MetricsReporter(api_key="key")
+        reporter._buffer_path = tmp_path / "nonexistent.jsonl"
+        reporter._load_disk_buffer()
+        assert reporter.buffered_count == 0
+
+    def test_load_handles_corrupt_lines(self, tmp_path: Path):
+        buf_path = tmp_path / "buffer.jsonl"
+        buf_path.write_text(
+            '{"type":"ok","data":{}}\nnot-json\n{"type":"ok2","data":{}}\n'
+        )
+
+        reporter = MetricsReporter(api_key="key")
+        reporter._buffer_path = buf_path
+        reporter._load_disk_buffer()
+        assert reporter.buffered_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Event sink hook integration
+# ---------------------------------------------------------------------------
+
+
+class TestEventSinkHook:
+    def test_kafka_publisher_dispatches_to_sink(self):
+        from scope.server.kafka_publisher import _dispatch_to_sink, set_event_sink
+
+        received = []
+        set_event_sink(lambda e: received.append(e))
+
+        envelope = {"id": "test", "type": "stream_trace", "data": {"type": "test"}}
+        _dispatch_to_sink(envelope)
+
+        assert len(received) == 1
+        assert received[0] is envelope
+
+        set_event_sink(None)
+
+    def test_sink_exception_is_swallowed(self):
+        from scope.server.kafka_publisher import _dispatch_to_sink, set_event_sink
+
+        def bad_sink(e):
+            raise RuntimeError("boom")
+
+        set_event_sink(bad_sink)
+        _dispatch_to_sink({"id": "x"})
+        set_event_sink(None)
+
+    def test_sink_noop_when_none(self):
+        from scope.server.kafka_publisher import _dispatch_to_sink, set_event_sink
+
+        set_event_sink(None)
+        _dispatch_to_sink({"id": "x"})
+
+
+# ---------------------------------------------------------------------------
+# Start / stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.anyio
+    async def test_start_and_stop(self):
+        reporter = MetricsReporter(api_key="key")
+        started = await reporter.start()
+        assert started is True
+        assert reporter.is_running is True
+
+        reporter.enqueue(_make_envelope())
+        assert reporter.buffered_count == 1
+
+        await reporter.stop()
+        assert reporter.is_running is False
+
+    @pytest.mark.anyio
+    async def test_start_fails_without_httpx(self):
+        reporter = MetricsReporter(api_key="key")
+        with patch.dict("sys.modules", {"httpx": None}):
+            with patch("builtins.__import__", side_effect=ImportError("no httpx")):
+                started = await reporter.start()
+        # The real httpx is available in the test env, so this tests the
+        # import guard path only when httpx is genuinely absent.
+        # For now, just verify start() returns a bool.
+        assert isinstance(started, bool)


### PR DESCRIPTION
## Summary

- Add a `MetricsReporter` client that reliably forwards `stream_trace` lifecycle events (the same `network_events` envelope) to Daydream's `POST /v1/metrics` endpoint, implementing the fail-loud / no-loss client contract (batched HTTP POST, exponential backoff on 5xx, pause on 401, rate-limit awareness on 429, optional disk-backed crash-safe buffer).
- In **local mode**, events are fed in-process via a new event-sink hook in `kafka_publisher.py`. In **cloud/livepeer mode**, the runner writes `network_event` messages onto the trickle events channel and `LivepeerClient` routes them into the reporter on the Scope client side.
- Existing direct-to-Kafka publishing is kept intact (augment, not replace). No new dependencies — uses `httpx` (already a dep).

### Architecture

```
Runner (publish_event → Kafka + trickle sink)
  ↓ trickle events channel: {type: "network_event", event: <envelope>}
Scope client (LivepeerClient._events_loop → MetricsReporter)
  ↓ batched POST /v1/metrics with Bearer key
Daydream API → Kafka network_events topic
```

### Files changed

| File | Change |
|------|--------|
| `src/scope/server/metrics_reporter.py` | **New** — `MetricsReporter` with thread-safe enqueue, async flush loop, fail-loud response handling, disk buffer, global accessors |
| `src/scope/server/kafka_publisher.py` | Event-sink hook: `set_event_sink()` + `_dispatch_to_sink()` called after envelope build |
| `src/scope/cloud/livepeer_app.py` | Register trickle sink in `_subscribe_control` to forward envelopes over events channel |
| `src/scope/server/livepeer_client.py` | Route `network_event` messages from events loop into `report_event()` |
| `src/scope/server/app.py` | Wire `MetricsReporter` start/stop into lifespan; register in-process event sink |
| `tests/test_metrics_reporter.py` | **New** — 33 tests covering mapping, batching, all response codes, backoff, disk resume, sink hook |

### Config (env vars)

- `DAYDREAM_METRICS_URL` — endpoint (default: `https://api.daydream.monster/v1/metrics`)
- `SCOPE_CLOUD_API_KEY` — Bearer token (required to enable; already used for cloud connect)
- `SCOPE_METRICS_ENABLED` — explicit enable/disable (default: on when key present)
- `SCOPE_METRICS_FLUSH_INTERVAL_MS`, `SCOPE_METRICS_MAX_BATCH`, `SCOPE_METRICS_MAX_BUFFER`, `SCOPE_METRICS_BUFFER_PATH`

## Test plan

- [x] `uv run ruff check src/` — all checks passed
- [x] `uv run ruff format --check src/` — all formatted
- [x] `uv run pytest tests/test_metrics_reporter.py -v` — 33/33 passed
- [x] Server imports cleanly (`from scope.server.app import app`)
- [ ] CI passes
- [ ] Manual E2E: set `SCOPE_CLOUD_API_KEY`, start Scope, verify events appear in Kafka `network_events` topic


Made with [Cursor](https://cursor.com)